### PR TITLE
fix(nuget): repo nuget.config breaks corporate packageSourceMapping setups

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -5,6 +5,12 @@
   </solution>
   <packageSources>
     <clear />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
+  <packageSourceMapping>
+    <clear />
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
## Summary

Closes #2.

The repo's `nuget.config` registered nuget.org under the source name `nuget` and provided no `packageSourceMapping` block. Any contributor or CI agent with a user-level `NuGet.Config` containing a `packageSourceMapping` block keyed to `nuget.org` (extremely common in enterprise setups) gets a fully broken restore with cryptic NU1100 errors — because source mapping is keyed by source *name*, not URL.

Two changes:

1. Rename source key `nuget` → `nuget.org` (de-facto standard).
2. Add explicit `<packageSourceMapping>` with `<clear/>` + wildcard → `nuget.org`. This wins over any inherited user-level mapping, so the repo is now immune to corporate config drift.

Tiny diff (+7/-1). Belt-and-braces — either change alone would help, both together are bulletproof.

## Test plan
- [x] `dotnet restore nuke-common.slnx` against a real corporate `NuGet.Config` with active `packageSourceMapping` — succeeds where previously every project failed with NU1100
- [x] Vulnerability warnings (NU1901/NU1902/NU1903) now correctly surface — confirms NuGetAudit is working, which itself is the point of #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)