### PR TITLE
chore(ci): Linux-only validation on PRs; full matrix only on main

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -18,15 +18,8 @@ name: macos-latest
 
 on:
   push:
-    branches-ignore:
-      - main
-  pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'docs/**'
-      - 'images/**'
-      - '**/*.md'
 
 jobs:
   macos-latest:

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -18,15 +18,8 @@ name: windows-latest
 
 on:
   push:
-    branches-ignore:
-      - main
-  pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'docs/**'
-      - 'images/**'
-      - '**/*.md'
 
 jobs:
   windows-latest:

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -9,18 +9,17 @@ using Nuke.Components;
     "windows-latest",
     GitHubActionsImage.WindowsLatest,
     FetchDepth = 0,
-    OnPushBranchesIgnore = new[] { MainBranch },
-    OnPullRequestBranches = new[] { MainBranch },
-    OnPullRequestExcludePaths = new[] { "docs/**", "images/**", "**/*.md" },
+    OnPushBranches = new[] { MainBranch },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
     PublishArtifacts = false)]
+// macOS and Windows runs are reserved for main-branch validation (post-merge
+// and release pipelines). PRs and feature-branch pushes get Linux-only for
+// fast, cheap feedback.
 [GitHubActions(
     "macos-latest",
     GitHubActionsImage.MacOsLatest,
     FetchDepth = 0,
-    OnPushBranchesIgnore = new[] { MainBranch },
-    OnPullRequestBranches = new[] { MainBranch },
-    OnPullRequestExcludePaths = new[] { "docs/**", "images/**", "**/*.md" },
+    OnPushBranches = new[] { MainBranch },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
     PublishArtifacts = false)]
 [GitHubActions(


### PR DESCRIPTION
## Summary

Previously every push to a non-main branch and every PR triggered Test+Pack on Ubuntu **and** Windows **and** macOS in parallel — 3× the runtime and credits per change. Cross-OS coverage matters more on what's actually shipping, less on every in-flight branch.

**Stacked on #11.** Update base after that merges.

### New behavior

- \`ubuntu-latest.yml\` — unchanged (push to non-main, PRs to main, paths-ignore for docs/images/markdown). Fast Linux feedback loop.
- \`windows-latest.yml\`, \`macos-latest.yml\` — trigger **only on push to main** (post-merge + the release pipeline coming in the Nerdbank PR).

### Trade-off

A cross-OS regression now lands on main before it's caught, and gets fixed on a follow-up branch instead of being blocked at PR time. Acceptable for an enterprise-CI/CD platform that needs cheap, fast pre-merge signal; the post-merge check still catches it before any release ships.

If a particular PR touches OS-sensitive code (path handling, process invocation, ANSI), the author can manually push a temp branch named \`*-windows\` / \`*-macos\` and add a one-off workflow_dispatch — or just open the PR and rely on Linux + reviewer judgment.

## Test plan
- [x] \`dotnet build build/_build.csproj\` — 0 errors
- [ ] Verify on this PR that **only** \`ubuntu-latest\` triggers
- [ ] After merge to main, verify windows-latest and macos-latest run post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)