### PR TITLE
feat(release): Nerdbank.GitVersioning + GitHub Actions release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,8 @@ jobs:
       - name: 'Run: Test, Pack, Publish'
         run: ./build.cmd Test Pack Publish
         env:
-          NuGetApiKey: ${{ secrets.NUGET_API_KEY }}
+          # Publish target is GitHub Packages on this fork, not nuget.org.
+          # GITHUB_TOKEN has packages:write per the permissions block above —
+          # no separate NuGet API key needed until the project rename.
+          NuGetApiKey: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+# Hand-written (not auto-generated) — see Build.CI.GitHubActions.cs for the
+# rationale (lets us bridge GitHub's NUGET_API_KEY secret to NUKE's
+# NuGetApiKey parameter, which would otherwise have to share a name).
+
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write     # for ICreateGitHubRelease (tag + GitHub release)
+  packages: write     # in case we later push to GitHub Packages too
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # Nerdbank.GitVersioning needs full history
+      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
+        uses: actions/cache@v4
+        with:
+          path: |
+            .nuke/temp
+            ~/.nuget/packages
+          key: ${{ runner.os }}-release-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props', 'version.json') }}
+      - name: 'Run: Test, Pack, Publish'
+        run: ./build.cmd Test Pack Publish
+        env:
+          NuGetApiKey: ${{ secrets.NUGET_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,11 +62,9 @@ Validation workflows (`ubuntu-latest`, `windows-latest`, `macos-latest`) run on 
 
 **Versioning:** [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) — configured in `version.json` at the repo root. Major+minor is hand-bumped; patch comes from git-height. `main` is the public-release ref (stable versions); everything else gets prerelease tags. GitVersion is still installed as a transitional helper for `MajorMinorPatchVersion` in `Build.cs`; full removal is a follow-up.
 
-**Release pipeline:** `.github/workflows/release.yml` — triggered on push to `main`, runs `./build.cmd Test Pack Publish`. Uses the repo secret `NUGET_API_KEY` (you must set this in repo settings before the first release fires).
+**Release pipeline:** `.github/workflows/release.yml` — triggered on push to `main`, runs `./build.cmd Test Pack Publish`. **Publishes to GitHub Packages** (`https://nuget.pkg.github.com/<owner>/index.json`) using the auto-provided `GITHUB_TOKEN` — no separate NuGet API key is needed.
 
-Alpha packages flow to the Feedz feed (`https://f.feedz.io/nuke/alpha/nuget`) from `develop` via the GitHub Actions `AlphaDeployment` workflow. Public NuGet publishes happen from `master`/`release/*` via AppVeyor.
-
-Versioning is driven by GitVersion (`GitVersion.yml`).
+**Why not nuget.org?** Per Matt's wish, the "Nuke" name cannot be carried over to a successor project. Until the hard fork picks a new name, packages stay on this fork's GitHub Packages feed. Switching the target to nuget.org becomes a follow-up once the rename ceremony happens.
 
 ## Conventions worth respecting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,9 @@ CI providers in use: **GitHub Actions only** (the other providers were dropped �
 
 Validation workflows (`ubuntu-latest`, `windows-latest`, `macos-latest`) run on every push to non-main branches and every PR targeting `main`, with `paths-ignore` for `docs/**`, `images/**`, `**/*.md`.
 
-Release pipeline is being introduced in a follow-up PR alongside Nerdbank.GitVersioning. GitVersion is still in use until that lands.
+**Versioning:** [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) — configured in `version.json` at the repo root. Major+minor is hand-bumped; patch comes from git-height. `main` is the public-release ref (stable versions); everything else gets prerelease tags. GitVersion is still installed as a transitional helper for `MajorMinorPatchVersion` in `Build.cs`; full removal is a follow-up.
+
+**Release pipeline:** `.github/workflows/release.yml` — triggered on push to `main`, runs `./build.cmd Test Pack Publish`. Uses the repo secret `NUGET_API_KEY` (you must set this in repo settings before the first release fires).
 
 Alpha packages flow to the Feedz feed (`https://f.feedz.io/nuke/alpha/nuget`) from `develop` via the GitHub Actions `AlphaDeployment` workflow. Public NuGet publishes happen from `master`/`release/*` via AppVeyor.
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="NJsonSchema" Version="11.5.2" />
     <PackageVersion Include="NJsonSchema.NewtonsoftJson" Version="11.5.2" />

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -5,19 +5,19 @@
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Components;
 
-[GitHubActions(
-    "windows-latest",
-    GitHubActionsImage.WindowsLatest,
-    FetchDepth = 0,
-    OnPushBranches = new[] { MainBranch },
-    InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
-    PublishArtifacts = false)]
 // macOS and Windows runs are reserved for main-branch validation (post-merge
 // and release pipelines). PRs and feature-branch pushes get Linux-only for
 // fast, cheap feedback.
 [GitHubActions(
     "macos-latest",
     GitHubActionsImage.MacOsLatest,
+    FetchDepth = 0,
+    OnPushBranches = new[] { MainBranch },
+    InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
+    PublishArtifacts = false)]
+[GitHubActions(
+    "windows-latest",
+    GitHubActionsImage.WindowsLatest,
     FetchDepth = 0,
     OnPushBranches = new[] { MainBranch },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
@@ -33,11 +33,10 @@ using Nuke.Components;
     PublishArtifacts = false)]
 partial class Build
 {
-    // AlphaDeployment workflow removed in trunk migration. The release pipeline
-    // is reintroduced in the follow-up Nerdbank.GitVersioning PR with proper
-    // main-branch publish semantics. Code paths still referencing this constant
-    // (Test.OnlyWhenStatic, Pack.PackSettings, Publish.Requires, DeletePackages)
-    // are intentionally preserved — they evaluate to false until a workflow
-    // with this name exists again.
-    const string AlphaDeployment = "alpha-deployment";
+    // The release workflow is intentionally hand-written at
+    // .github/workflows/release.yml — that lets us name the GitHub secret
+    // NUGET_API_KEY (conventional screaming-snake-case) while keeping the
+    // Build.cs property name NuGetApiKey (idiomatic C#). The NUKE attribute
+    // generator would force the two to match.
+    const string ReleaseWorkflow = "release";
 }

--- a/build/Build.SignPackages.cs
+++ b/build/Build.SignPackages.cs
@@ -18,6 +18,6 @@ partial class Build : ISignPackages
 
     public Target SignPackages => _ => _
         .Inherit<ISignPackages>()
-        .OnlyWhenStatic(() => IsPublicRelease)
+        .OnlyWhenStatic(() => GitRepository.IsOnMainBranch())
         .OnlyWhenStatic(() => EnvironmentInfo.IsWin);
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -130,7 +130,13 @@ partial class Build
 
     [Parameter] [Secret] readonly string NuGetApiKey;
 
-    string IPublish.NuGetSource => "https://api.nuget.org/v3/index.json";
+    // Publishing to GitHub Packages on this fork until the post-hard-fork
+    // project rename lands. nuget.org would require the new name and can't
+    // be done under "Nuke.*" — see project_nuke_strategy memory note.
+    // Repository owner comes from GITHUB_REPOSITORY_OWNER, automatically set
+    // by GitHub Actions runners. ChrisonSimtian is the local-dev fallback.
+    string IPublish.NuGetSource =>
+        $"https://nuget.pkg.github.com/{EnvironmentInfo.GetVariable("GITHUB_REPOSITORY_OWNER") ?? "ChrisonSimtian"}/index.json";
     string IPublish.NuGetApiKey => NuGetApiKey;
 
     Target IPublish.Publish => _ => _

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -103,7 +103,6 @@ partial class Build
 
     Target ITest.Test => _ => _
         .Inherit<ITest>()
-        .OnlyWhenStatic(() => Host is not GitHubActions { Workflow: AlphaDeployment })
         .Partition(2);
 
     bool IReportCoverage.CreateCoverageHtmlReport => true;
@@ -120,25 +119,24 @@ partial class Build
     IEnumerable<string> IReportIssues.InspectCodeFailOnIssues => new string[0];
     IEnumerable<string> IReportIssues.InspectCodeFailOnCategories => new string[0];
 
+    // Local Terminal runs use a placeholder version so packed nupkgs don't
+    // collide with real releases. CI runs let Nerdbank.GitVersioning inject the
+    // real version via MSBuild ($PackageVersion).
     Configure<DotNetPackSettings> IPack.PackSettings => _ => _
-        .When(Host is Terminal or GitHubActions { Workflow: AlphaDeployment }, _ => _
+        .When(Host is Terminal, _ => _
             .SetVersion(DefaultDeploymentVersion));
 
-    string PublicNuGetSource => "https://api.nuget.org/v3/index.json";
-    string FeedzNuGetSource => "https://f.feedz.io/nuke/alpha/nuget";
     string DefaultDeploymentVersion => "9999.0.0";
 
-    [Parameter] [Secret] readonly string PublicNuGetApiKey;
-    [Parameter] [Secret] readonly string FeedzNuGetApiKey;
+    [Parameter] [Secret] readonly string NuGetApiKey;
 
-    bool IsPublicRelease => GitRepository.IsOnMainBranch();
-    string IPublish.NuGetSource => IsPublicRelease ? PublicNuGetSource : FeedzNuGetSource;
-    string IPublish.NuGetApiKey => IsPublicRelease ? PublicNuGetApiKey : FeedzNuGetApiKey;
+    string IPublish.NuGetSource => "https://api.nuget.org/v3/index.json";
+    string IPublish.NuGetApiKey => NuGetApiKey;
 
     Target IPublish.Publish => _ => _
         .Inherit<IPublish>()
         .Consumes(From<IPack>().Pack)
-        .Requires(() => GitRepository.IsOnMainBranch() && Host is GitHubActions && GitHubActions.Workflow == AlphaDeployment)
+        .Requires(() => GitRepository.IsOnMainBranch() && Host is GitHubActions && GitHubActions.Workflow == ReleaseWorkflow)
         .WhenSkipped(DependencyBehavior.Execute);
 
     IEnumerable<AbsolutePath> NuGetPackageFiles
@@ -147,26 +145,12 @@ partial class Build
     Target DeletePackages => _ => _
         .DependentFor<IPublish>()
         .After<IPack>()
-        .OnlyWhenStatic(() => Host is Terminal or GitHubActions { Workflow: AlphaDeployment })
+        .OnlyWhenStatic(() => Host is Terminal)
         .Executes(() =>
         {
-            if (Host is Terminal)
-            {
-                var packagesDirectory = NuGetPackageResolver.GetPackagesDirectory(packagesConfigFile: BuildProjectFile);
-                var packageDirectories = packagesDirectory.GlobDirectories($"nuke.*/{DefaultDeploymentVersion}");
-                packageDirectories.DeleteDirectories();
-            }
-            else if (Host is GitHubActions)
-            {
-                void DeletePackage(string id, string version)
-                    => DotNet(
-                        $"nuget delete {id} {version} --source {FeedzNuGetSource} --api-key {FeedzNuGetApiKey} --non-interactive",
-                        logOutput: false);
-
-                var packageIds = NuGetPackageFiles.Select(x => new PackageArchiveReader(x).NuspecReader.GetId());
-                foreach (var packageId in packageIds)
-                    SuppressErrors(() => DeletePackage(packageId, DefaultDeploymentVersion), logWarning: false);
-            }
+            var packagesDirectory = NuGetPackageResolver.GetPackagesDirectory(packagesConfigFile: BuildProjectFile);
+            var packageDirectories = packagesDirectory.GlobDirectories($"nuke.*/{DefaultDeploymentVersion}");
+            packageDirectories.DeleteDirectories();
         });
 
     string ICreateGitHubRelease.Name => MajorMinorPatchVersion;

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">

--- a/version.json
+++ b/version.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "10.2",
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$"
+  ],
+  "nuGetPackageVersion": {
+    "semVer": 2
+  },
+  "assemblyVersion": {
+    "precision": "minor"
+  },
+  "release": {
+    "versionIncrement": "minor",
+    "firstUnstableTag": "preview",
+    "branchName": "release/v{version}"
+  }
+}


### PR DESCRIPTION
## Summary

Versioning moves from GitFlow-driven **GitVersion** to trunk-based **Nerdbank.GitVersioning**. Adds the missing release pipeline so merges to \`main\` can publish — to **GitHub Packages on this fork**, *not* nuget.org. (See "Why GitHub Packages" below.)

## Versioning

- \`version.json\` — Nerdbank config. \`version: \"10.2\"\`, \`publicReleaseRefSpec\` scoped to \`main\` (stable versions only on main, prereleases elsewhere), SemVer 2 NuGet output, assembly version pinned to \`major.minor\` for binding stability.
- \`Directory.Packages.props\` — Nerdbank.GitVersioning 3.7.115.
- \`source/Directory.Build.props\` — \`PackageReference\` with \`PrivateAssets=\"All\"\` so the package isn't a transitive dep of consumers.

GitVersion is still installed (transitionally) because Build.cs's \`MajorMinorPatchVersion\` reads from it for the GitHub release name + milestone title. Full GitVersion removal is a follow-up.

## Why GitHub Packages, not nuget.org

Per Matt's wish, the "Nuke" name **cannot** be carried over to a successor project. Publishing to nuget.org would require a new name we don't have yet. **Until the hard-fork rename ceremony happens**, the release pipeline publishes to GitHub Packages on this fork (\`https://nuget.pkg.github.com/ChrisonSimtian/index.json\`).

Switching the target back to nuget.org becomes a one-line follow-up once we have a name.

## Release pipeline

\`.github/workflows/release.yml\` — **hand-written**, not auto-generated. Triggered on push to main, fetch-depth 0 (Nerdbank), runs \`./build.cmd Test Pack Publish\`.

### Auth

Uses the auto-provided \`GITHUB_TOKEN\` (the workflow already declares \`permissions: packages: write\`). **No separate NuGet API key needed.** When we eventually point publishing at nuget.org, that's when we'll add a \`NUGET_API_KEY\` secret.

### Why hand-written

The NUKE \`[GitHubActions]\` attribute generator would force the GitHub secret name to match the NUKE parameter name. Hand-writing the workflow lets the C# parameter stay idiomatic (\`NuGetApiKey\`) while the workflow uses \`GITHUB_TOKEN\` directly.

## Build.cs simplification

- Drop \`FeedzNuGetSource\` / \`FeedzNuGetApiKey\` / \`IsPublicRelease\` — no alpha feed in trunk-based.
- Rename \`PublicNuGetApiKey\` → \`NuGetApiKey\`.
- \`IPublish.NuGetSource\` now derives from \`GITHUB_REPOSITORY_OWNER\` (with \`ChrisonSimtian\` local fallback) → GitHub Packages URL.
- \`Pack.SetVersion(9999.0.0)\` only applies for \`Terminal\` (local) builds; CI lets Nerdbank's MSBuild version stand.
- \`Test.OnlyWhenStatic\` guard removed (was excluding alpha-deployment).
- \`DeletePackages\` now only handles the Terminal case (cleans local 9999.0.0 packages).
- \`Build.SignPackages.cs\` \`IsPublicRelease\` → \`IsOnMainBranch\`.

## Workflow constant

\`Build.CI.GitHubActions.cs\` — \`AlphaDeployment\` → \`ReleaseWorkflow\`. \`Publish.Requires\` now checks \`Workflow == ReleaseWorkflow\`.

## Versioning expectations

Once merged:

| Ref | Output version |
|---|---|
| \`main\` (first commit after this) | \`10.2.<git-height>\` — stable, published to GitHub Packages |
| Any feature branch | \`10.2.<height>-<branch>.<hash>+<commit>\` — prerelease |
| Tag \`v10.2.0\` | \`10.2.0\` exactly |

Minor bumps (10.2 → 10.3): edit \`version.json\` or run \`nbgv prepare-release\`.

## Test plan

- [x] \`dotnet restore nuke-common.slnx\` — Nerdbank.GitVersioning 3.7.115 resolves on all 26 projects
- [x] \`dotnet build build/_build.csproj\` — 0 errors after edits (warnings dropped from 59 → 9 thanks to #4 already on main)
- [ ] Validation workflow (ubuntu-latest) green on this PR
- [ ] After merge: \`release.yml\` triggers, Test+Pack succeed, Publish hits GitHub Packages successfully (no manual secret setup needed)

## Follow-ups (separate PRs, not blocking this)

- Fully remove GitVersion (replace \`MajorMinorPatchVersion\` with Nerdbank-derived equivalent)
- Decide fate of \`Build.Announce.cs\` (orphaned since AppVeyor drop)
- Switch publish target to nuget.org *after* the project rename happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)