### PR TITLE
chore(ci): drop push trigger from ubuntu-latest (deduplicate runs)

### DIFF
--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -17,9 +17,6 @@
 name: ubuntu-latest
 
 on:
-  push:
-    branches-ignore:
-      - main
   pull_request:
     branches:
       - main

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -22,11 +22,12 @@ using Nuke.Components;
     OnPushBranches = new[] { MainBranch },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
     PublishArtifacts = false)]
+// pull_request only — same-repo branches would otherwise fire both push and
+// pull_request events on every push, double-running the validation.
 [GitHubActions(
     "ubuntu-latest",
     GitHubActionsImage.UbuntuLatest,
     FetchDepth = 0,
-    OnPushBranchesIgnore = new[] { MainBranch },
     OnPullRequestBranches = new[] { MainBranch },
     OnPullRequestExcludePaths = new[] { "docs/**", "images/**", "**/*.md" },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },


### PR DESCRIPTION
## Summary

Every PR was firing \`ubuntu-latest\` **twice** — once for the \`push\` event, once for the \`pull_request\` event — because GitHub fires both for same-repo branch pushes with an open PR. Doubling CI runtime and credits for no extra signal.

**Stacked on #22.** Re-base to main once that lands.

### Keeping pull_request only

- ✅ Fork PRs continue to trigger (\`pull_request\` fires from forks; \`push\` doesn't go to the parent repo).
- ✅ \`paths-ignore\` semantics work naturally on \`pull_request\` (they were already a no-op for \`push\`).
- ⚠️ Pushes to a feature branch without an open PR no longer trigger CI. In trunk-based that's fine — the PR is the work unit.

## Test plan

- [ ] This PR fires exactly one \`ubuntu-latest\` run (not two)
- [ ] Push a follow-up commit to the same branch → still one run, not two

🤖 Generated with [Claude Code](https://claude.com/claude-code)