### PR TITLE
docs: add costs.md transparency doc + README sponsorship section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The original NUKE code is preserved here under the MIT License with attribution.
 
 - [Elevator Pitch](#elevator-pitch)
 - [Build Status](#build-status)
+- [Sponsorship](#sponsorship)
 
 ## Elevator Pitch
 
@@ -40,6 +41,10 @@ CI runs on every push to non-`main` branches and every PR targeting `main`, acro
 | GitHub Actions | [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/ChrisonSimtian/nuke/ubuntu-latest.yml?branch=main&label=build&style=flat-square&logo=github&logoColor=white)](https://github.com/ChrisonSimtian/nuke/actions)        | Win / Ubuntu / macOS | [`.github/workflows/`](https://github.com/ChrisonSimtian/nuke/tree/main/.github/workflows)     |
 
 Multi-provider CI support (Azure Pipelines, GitLab, TeamCity, AppVeyor) was removed during the takeover and is being revived demand-driven — see [#8](https://github.com/ChrisonSimtian/nuke/issues/8).
+
+## Sponsorship
+
+Fallout is volunteer-run. There's no donation channel yet, but we want to be transparent about what running the project costs — see [`costs.md`](costs.md) for the full list. If you or your organisation would like to help offset those costs, open an issue and we'll work out the details.
 
 ## Credits
 

--- a/costs.md
+++ b/costs.md
@@ -4,9 +4,9 @@ This file lists the running costs of the Fallout project for transparency.
 
 If you'd like to help offset any of these, see the [Sponsorship](README.md#sponsorship) section in the README.
 
-| Position | Cost (NZD) | Frequency | Notes |
+| Position | Cost (USD) | Frequency | Notes |
 |---|---|---|---|
-| Domain `fallout.build` (Cloudflare Registrar) | _TBD — see Cloudflare invoice_ | Yearly | Cloudflare bills at-cost in USD; the NZD figure is the converted amount on the day the invoice was charged. |
+| Domain `fallout.build` (Cloudflare Registrar) | _TBD — see Cloudflare invoice_ | Yearly | Cloudflare Registrar charges at-cost. |
 
 Everything else the project relies on is currently free at our usage tier:
 

--- a/costs.md
+++ b/costs.md
@@ -6,7 +6,7 @@ If you'd like to help offset any of these, see the [Sponsorship](README.md#spons
 
 | Position | Cost (USD) | Frequency | Notes |
 |---|---|---|---|
-| Domain `fallout.build` (Cloudflare Registrar) | _TBD — see Cloudflare invoice_ | Yearly | Cloudflare Registrar charges at-cost. |
+| Domain `fallout.build` (Cloudflare Registrar) | $25.20 | Yearly | Cloudflare Registrar charges at-cost. |
 
 Everything else the project relies on is currently free at our usage tier:
 

--- a/costs.md
+++ b/costs.md
@@ -1,0 +1,21 @@
+# Project Costs
+
+This file lists the running costs of the Fallout project for transparency.
+
+If you'd like to help offset any of these, see the [Sponsorship](README.md#sponsorship) section in the README.
+
+| Position | Cost (NZD) | Frequency | Notes |
+|---|---|---|---|
+| Domain `fallout.build` (Cloudflare Registrar) | _TBD — see Cloudflare invoice_ | Yearly | Cloudflare bills at-cost in USD; the NZD figure is the converted amount on the day the invoice was charged. |
+
+Everything else the project relies on is currently free at our usage tier:
+
+- **GitHub** (repo, issues, Actions, Packages) — free for public repositories.
+- **NuGet.org** — free for OSS publishers (used once the rebrand reserves `Fallout.*` package IDs; see [#33](https://github.com/ChrisonSimtian/Fallout/issues/33)).
+- **Documentation hosting** — planned on GitHub Pages, included with the repo.
+
+This list will grow if we ever add paid services (an organization seat tier, paid CI minutes, a dedicated docs host, etc.). Each addition will land in a PR that updates this file.
+
+---
+
+_Last updated: 2026-05-21_


### PR DESCRIPTION
## Summary

- Adds `costs.md` at the repo root listing the project's running costs — currently just the `fallout.build` domain via Cloudflare Registrar at **\$25.20/yr**.
- Adds a new **Sponsorship** section in the README that links to `costs.md` and explains the project is volunteer-run with no donation channel yet.
- Adds the section to the README Table of Contents.

Closes #55.

## Test plan

- [ ] `costs.md` renders cleanly on GitHub
- [ ] README ToC link to Sponsorship works
- [ ] Sponsorship section link to `costs.md` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)