### PR TITLE
chore(release): publish to nuget.org as primary feed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # Hand-written (not auto-generated) — see Build.CI.GitHubActions.cs for the
-# rationale (lets us bridge GitHub's NUGET_API_KEY secret to NUKE's
+# rationale (lets us bridge GitHub's NUGET_API_KEY secret to Fallout's
 # NuGetApiKey parameter, which would otherwise have to share a name).
 
 name: release
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: write     # for ICreateGitHubRelease (tag + GitHub release)
-  packages: write     # in case we later push to GitHub Packages too
 
 jobs:
   release:
@@ -31,8 +30,8 @@ jobs:
       - name: 'Run: Test, Pack, Publish'
         run: ./build.cmd Test Pack Publish
         env:
-          # Publish target is GitHub Packages on this fork, not nuget.org.
-          # GITHUB_TOKEN has packages:write per the permissions block above —
-          # no separate NuGet API key needed until the project rename.
-          NuGetApiKey: ${{ secrets.GITHUB_TOKEN }}
+          # Publish target is nuget.org now that Fallout.* rename has landed (#54).
+          # NUGET_API_KEY is an API key scoped to push Fallout.* packages, set in
+          # repo Settings → Secrets and variables → Actions.
+          NuGetApiKey: ${{ secrets.NUGET_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,7 @@ Validation workflows: **`ubuntu-latest`** runs on every PR targeting `main` (wit
 
 **Versioning:** [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) — configured in `version.json` at the repo root. Major+minor is hand-bumped; patch comes from git-height. `main` is the public-release ref (stable versions); everything else gets prerelease tags. GitVersion is still installed as a transitional helper for `MajorMinorPatchVersion` in `Build.cs`; full removal is a follow-up.
 
-**Release pipeline:** `.github/workflows/release.yml` — triggered on push to `main`, runs `./build.cmd Test Pack Publish`. **Publishes to GitHub Packages** (`https://nuget.pkg.github.com/<owner>/index.json`) using the auto-provided `GITHUB_TOKEN` — no separate NuGet API key is needed.
-
-**Why not nuget.org?** Per Matt's wish, the "Nuke" name cannot be carried over to a successor project. The successor brand is Fallout. Until the breaking-rename phases land (#32, #34), packages stay on this fork's GitHub Packages feed.
+**Release pipeline:** `.github/workflows/release.yml` — triggered on push to `main`, runs `./build.cmd Test Pack Publish`. **Publishes to nuget.org** (`https://api.nuget.org/v3/index.json`) under the `Fallout.*` package ID prefix, using the `NUGET_API_KEY` repo secret (a nuget.org API key scoped to push `Fallout.*`). Prefix reservation tracked in [#33](https://github.com/ChrisonSimtian/Fallout/issues/33).
 
 ## Conventions worth respecting
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -123,13 +123,9 @@ partial class Build
 
     [Parameter] [Secret] readonly string NuGetApiKey;
 
-    // Publishing to GitHub Packages on this fork until the post-hard-fork
-    // project rename lands. nuget.org would require the new name and can't
-    // be done under "Fallout.*" — see project_nuke_strategy memory note.
-    // Repository owner comes from GITHUB_REPOSITORY_OWNER, automatically set
-    // by GitHub Actions runners. ChrisonSimtian is the local-dev fallback.
-    string IPublish.NuGetSource =>
-        $"https://nuget.pkg.github.com/{EnvironmentInfo.GetVariable("GITHUB_REPOSITORY_OWNER") ?? "ChrisonSimtian"}/index.json";
+    // Publishing to nuget.org now that the Fallout.* rename has landed (#54).
+    // Requires NUGET_API_KEY in repo secrets — see release.yml.
+    string IPublish.NuGetSource => "https://api.nuget.org/v3/index.json";
     string IPublish.NuGetApiKey => NuGetApiKey;
 
     Target IPublish.Publish => _ => _
@@ -148,7 +144,7 @@ partial class Build
         .Executes(() =>
         {
             var packagesDirectory = NuGetPackageResolver.GetPackagesDirectory(packagesConfigFile: BuildProjectFile);
-            var packageDirectories = packagesDirectory.GlobDirectories($"nuke.*/{DefaultDeploymentVersion}");
+            var packageDirectories = packagesDirectory.GlobDirectories($"fallout.*/{DefaultDeploymentVersion}");
             packageDirectories.DeleteDirectories();
         });
 


### PR DESCRIPTION
## Summary

- Switches the release pipeline from publishing to GitHub Packages (the pre-rename stopgap) to **publishing `Fallout.*` packages to nuget.org**.
- Enables the prefix reservation flow tracked in #33.
- Fixes a latent bug: `DeletePackages` glob in `Build.cs` was still `nuke.*` (the #52 string-reference audit's `\bNuke\.` regex didn't catch lowercase literals).

Refs #33 — issue stays open until Microsoft approves the prefix reservation (manual form after first publish).

## ⚠️ Manual steps required BEFORE merging

This PR will fail at the `Publish` step on the next push to `main` if these aren't done first:

1. **nuget.org** → API keys → create a key scoped to **Push** with glob pattern `Fallout.*` (against your existing org account).
2. **Repo Settings → Secrets and variables → Actions** → add a repository secret named `NUGET_API_KEY` with that value.

That's it for pre-merge. The CI will then attempt the first nuget.org publish on the next push to `main`.

## After merge

Next push to `main` publishes all `Fallout.*` packages to nuget.org. Once at least one is up, submit the prefix reservation:

- [NuGet ID prefix reservation docs](https://learn.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation)
- Reservation review is manual; typically 1–7 days.

Once approved, you can close #33.

## What's NOT in this PR

- Removing the `Nuke.*` packages already published to GitHub Packages on the fork. Those stay as historical artifacts of the pre-rename period. No churn until a consumer asks.
- Prefix reservation submission — that's an out-of-band action with Microsoft.
- The first actual nuget.org publish (happens automatically on the next `main` push after this lands).

## Test plan

- [ ] `dotnet build build/_build.csproj -c Debug` passes locally (verified — 0 errors, 14 pre-existing warnings)
- [ ] `NUGET_API_KEY` secret added to repo settings before merging
- [ ] After merge, watch `.github/workflows/release.yml` run and confirm packages appear under https://www.nuget.org/profiles/<your-org>
- [ ] File the prefix reservation form

🤖 Generated with [Claude Code](https://claude.com/claude-code)