### PR TITLE
chore(rebrand): rename Constants.cs internals (NukeFileName, NukeDirectoryName, etc.)

### DIFF
--- a/src/Fallout.Build.Shared/Constants.cs
+++ b/src/Fallout.Build.Shared/Constants.cs
@@ -20,13 +20,13 @@ namespace Fallout.Common;
 [UsedImplicitly]
 internal static class Constants
 {
-    internal const string NukeFileName = NukeDirectoryName;
-    internal const string NukeDirectoryName = ".fallout";
+    internal const string FalloutFileName = FalloutDirectoryName;
+    internal const string FalloutDirectoryName = ".fallout";
     // Legacy directory name from the pre-Fallout era. Read-only: lets existing
     // consumer projects keep building until they migrate (manually or via the
     // forthcoming Fallout.Migrate CLI). New setups always use .fallout/.
     internal const string LegacyNukeDirectoryName = ".nuke";
-    internal const string NukeCommonPackageId = "Fallout.Common";
+    internal const string FalloutCommonPackageId = "Fallout.Common";
     internal const string BuildSchemaFileName = "build.schema.json";
     internal const string VisualStudioDebugFileName = $"{VisualStudioDebugParameterName}.log";
 
@@ -62,28 +62,28 @@ internal static class Constants
     internal const string UpstreamNukeRepositoryGit = UpstreamNukeRepository + ".git";
 
     internal static AbsolutePath GlobalTemporaryDirectory => Path.GetTempPath();
-    internal static AbsolutePath GlobalNukeDirectory =>  EnvironmentInfo.SpecialFolder(SpecialFolders.UserProfile) / ".fallout";
+    internal static AbsolutePath GlobalFalloutDirectory =>  EnvironmentInfo.SpecialFolder(SpecialFolders.UserProfile) / ".fallout";
 
     [CanBeNull]
     internal static AbsolutePath TryGetRootDirectoryFrom(AbsolutePath startDirectory, bool includeLegacy = true)
     {
         var rootDirectory = new DirectoryInfo(startDirectory)
             .DescendantsAndSelf(x => x.Parent)
-            .FirstOrDefault(x => x.GetDirectories(NukeDirectoryName).Any() ||
+            .FirstOrDefault(x => x.GetDirectories(FalloutDirectoryName).Any() ||
                                  x.GetDirectories(LegacyNukeDirectoryName).Any() ||
-                                 includeLegacy && x.GetFiles(NukeFileName).Any())
+                                 includeLegacy && x.GetFiles(FalloutFileName).Any())
             ?.FullName;
-        return rootDirectory != GlobalNukeDirectory.Parent ? (AbsolutePath) rootDirectory : null;
+        return rootDirectory != GlobalFalloutDirectory.Parent ? (AbsolutePath) rootDirectory : null;
     }
 
     internal static bool IsLegacy(AbsolutePath rootDirectory)
     {
-        return File.Exists(rootDirectory / NukeFileName);
+        return File.Exists(rootDirectory / FalloutFileName);
     }
 
-    internal static AbsolutePath GetNukeDirectory(AbsolutePath rootDirectory)
+    internal static AbsolutePath GetFalloutDirectory(AbsolutePath rootDirectory)
     {
-        var newDir = rootDirectory / NukeDirectoryName;
+        var newDir = rootDirectory / FalloutDirectoryName;
         if (Directory.Exists(newDir))
             return newDir;
         var legacyDir = rootDirectory / LegacyNukeDirectoryName;
@@ -93,7 +93,7 @@ internal static class Constants
     internal static AbsolutePath GetTemporaryDirectory(AbsolutePath rootDirectory)
     {
         return !IsLegacy(rootDirectory)
-            ? GetNukeDirectory(rootDirectory) / "temp"
+            ? GetFalloutDirectory(rootDirectory) / "temp"
             : rootDirectory / ".tmp";
     }
 
@@ -122,23 +122,23 @@ internal static class Constants
 
     internal static AbsolutePath GetBuildSchemaFile(AbsolutePath rootDirectory)
     {
-        return GetNukeDirectory(rootDirectory) / BuildSchemaFileName;
+        return GetFalloutDirectory(rootDirectory) / BuildSchemaFileName;
     }
 
     internal static AbsolutePath GetDefaultParametersFile(AbsolutePath rootDirectory)
     {
-        return GetNukeDirectory(rootDirectory) / GetParametersFileName(DefaultProfileName);
+        return GetFalloutDirectory(rootDirectory) / GetParametersFileName(DefaultProfileName);
     }
 
     internal static IEnumerable<AbsolutePath> GetParametersProfileFiles(AbsolutePath rootDirectory)
     {
-        return new DirectoryInfo(GetNukeDirectory(rootDirectory)).GetFiles($"{ParametersFilePrefix}.*.json", SearchOption.TopDirectoryOnly)
+        return new DirectoryInfo(GetFalloutDirectory(rootDirectory)).GetFiles($"{ParametersFilePrefix}.*.json", SearchOption.TopDirectoryOnly)
             .Select(x => (AbsolutePath)x.FullName);
     }
 
     internal static AbsolutePath GetParametersProfileFile(AbsolutePath rootDirectory, string profile)
     {
-        return GetNukeDirectory(rootDirectory) / GetParametersFileName(profile);
+        return GetFalloutDirectory(rootDirectory) / GetParametersFileName(profile);
     }
 
     internal static string GetParametersFileName(string profile)

--- a/src/Fallout.Build.Shared/Notifications.cs
+++ b/src/Fallout.Build.Shared/Notifications.cs
@@ -37,7 +37,7 @@ internal class NotificationFetcher
     private const string NotificationEndpoint = Constants.FalloutNotificationsUrl;
     private const string UtmMedium = "development";
 
-    private readonly AbsolutePath _notificationDirectory = Constants.GlobalNukeDirectory / "received-notifications";
+    private readonly AbsolutePath _notificationDirectory = Constants.GlobalFalloutDirectory / "received-notifications";
     private readonly string _utmSource;
 
     public NotificationFetcher(string utmSource)

--- a/src/Fallout.Build/Execution/Extensions/ArgumentsFromParametersFileAttribute.cs
+++ b/src/Fallout.Build/Execution/Extensions/ArgumentsFromParametersFileAttribute.cs
@@ -23,7 +23,7 @@ public class ArgumentsFromParametersFileAttribute : BuildExtensionAttributeBase,
     public void OnBuildCreated(IReadOnlyCollection<ExecutableTarget> executableTargets)
     {
         // TODO: probably remove
-        if (!Constants.GetNukeDirectory(FalloutBuild.RootDirectory).DirectoryExists())
+        if (!Constants.GetFalloutDirectory(FalloutBuild.RootDirectory).DirectoryExists())
             return;
 
 

--- a/src/Fallout.Build/Execution/Extensions/UpdateNotificationAttribute.cs
+++ b/src/Fallout.Build/Execution/Extensions/UpdateNotificationAttribute.cs
@@ -30,7 +30,7 @@ internal class UpdateNotificationAttribute : BuildExtensionAttributeBase, IOnBui
             Notify();
     }
 
-    private bool ShouldNotify => !Directory.Exists(GetNukeDirectory(Build.RootDirectory)) &&
+    private bool ShouldNotify => !Directory.Exists(GetFalloutDirectory(Build.RootDirectory)) &&
                                  !Build.IsInterceptorExecution;
 
     private static void Notify()

--- a/src/Fallout.Build/FalloutBuild.Statics.cs
+++ b/src/Fallout.Build/FalloutBuild.Statics.cs
@@ -104,7 +104,7 @@ public abstract partial class FalloutBuild
         return TryGetRootDirectoryFrom(EnvironmentInfo.WorkingDirectory)
             .NotNull(new[]
                      {
-                         $"Could not locate '{NukeDirectoryName}' directory/file while walking up from '{EnvironmentInfo.WorkingDirectory}'.",
+                         $"Could not locate '{FalloutDirectoryName}' directory/file while walking up from '{EnvironmentInfo.WorkingDirectory}'.",
                          "Either create a directory/file to mark the root directory, or add '--root [path]' to the invocation."
                      }.JoinNewLine());
     }

--- a/src/Fallout.Build/FalloutBuild.cs
+++ b/src/Fallout.Build/FalloutBuild.cs
@@ -179,7 +179,7 @@ public abstract partial class FalloutBuild : IFalloutBuild
         BuildProjectFile == null
             ? Assembly.GetEntryAssembly().NotNull().Location != string.Empty
                 ? BuildAssemblyDirectory
-                : GlobalNukeDirectory / "packages"
+                : GlobalFalloutDirectory / "packages"
             : null;
 
     internal IEnumerable<string> TargetNames => ExecutableTargetFactory.GetTargetProperties(GetType()).Select(x => x.GetDisplayShortName());

--- a/src/Fallout.Build/Telemetry/Telemetry.cs
+++ b/src/Fallout.Build/Telemetry/Telemetry.cs
@@ -63,7 +63,7 @@ internal static partial class Telemetry
     private static int? CheckAwareness()
     {
         AbsolutePath GetCookieFile(string name, int version)
-            => Constants.GlobalNukeDirectory / "telemetry-awareness" / $"v{version}" / name;
+            => Constants.GlobalFalloutDirectory / "telemetry-awareness" / $"v{version}" / name;
 
         // Check for calls from Fallout.GlobalTool and custom global tools
         if (SuppressErrors(() => FalloutBuild.BuildProjectFile, logWarning: false) == null)

--- a/src/Fallout.Common/Attributes/HandleSingleFileExecutionAttribute.cs
+++ b/src/Fallout.Common/Attributes/HandleSingleFileExecutionAttribute.cs
@@ -40,7 +40,7 @@ public class HandleSingleFileExecutionAttribute : BuildExtensionAttributeBase, I
         if (!packageResourceNames.Any())
             return;
 
-        var globalPackagesDirectory = Constants.GlobalNukeDirectory / "packages";
+        var globalPackagesDirectory = Constants.GlobalFalloutDirectory / "packages";
         Log.Information("Extracting packages to {PackagesDirectory}", globalPackagesDirectory);
 
         foreach (var packageResourceName in packageResourceNames)
@@ -76,7 +76,7 @@ public class HandleSingleFileExecutionAttribute : BuildExtensionAttributeBase, I
         HttpTasks.HttpDownloadFile(ScriptUrl, ScriptFile);
 
         var version = GetDotNetRuntimeVersion();
-        var installLocation = Constants.GlobalNukeDirectory / "dotnet-runtime" / (version ?? "current");
+        var installLocation = Constants.GlobalFalloutDirectory / "dotnet-runtime" / (version ?? "current");
         var dotnetExecutable = installLocation / (EnvironmentInfo.IsWin ? "dotnet.exe" : "dotnet");
 
         if (version == null || !dotnetExecutable.Exists())
@@ -104,7 +104,7 @@ public class HandleSingleFileExecutionAttribute : BuildExtensionAttributeBase, I
     private bool IsSingleFileExecution => Assembly.GetEntryAssembly().NotNull().Location == string.Empty;
 
     private string ScriptFileName => EnvironmentInfo.IsWin ? "dotnet-install.ps1" : "dotnet-install.sh";
-    private AbsolutePath ScriptFile => Constants.GlobalNukeDirectory / ScriptFileName;
+    private AbsolutePath ScriptFile => Constants.GlobalFalloutDirectory / ScriptFileName;
 
     [CanBeNull]
     private string GetDotNetRuntimeVersion()

--- a/src/Fallout.Common/Attributes/SolutionAttribute.cs
+++ b/src/Fallout.Common/Attributes/SolutionAttribute.cs
@@ -67,16 +67,16 @@ public class SolutionAttribute(string relativePath)
 
     private AbsolutePath TryGetSolutionFileFromNukeFile()
     {
-        var nukeFile = Build.RootDirectory / Constants.NukeFileName;
+        var nukeFile = Build.RootDirectory / Constants.FalloutFileName;
         if (!nukeFile.Exists())
             return null;
 
         var solutionFileRelative = nukeFile.ReadAllLines().ElementAtOrDefault(0);
         Assert.True(solutionFileRelative != null && !solutionFileRelative.Contains(value: '\\'),
-            $"First line of {Constants.NukeFileName} must provide solution path using UNIX separators");
+            $"First line of {Constants.FalloutFileName} must provide solution path using UNIX separators");
 
         var solutionFile = Build.RootDirectory / solutionFileRelative;
-        Assert.FileExists(solutionFile, $"Solution file '{solutionFile}' provided via {Constants.NukeFileName} does not exist");
+        Assert.FileExists(solutionFile, $"Solution file '{solutionFile}' provided via {Constants.FalloutFileName} does not exist");
 
         return solutionFile;
     }

--- a/src/Fallout.GlobalTool/Program.Navigation.cs
+++ b/src/Fallout.GlobalTool/Program.Navigation.cs
@@ -82,8 +82,8 @@ partial class Program
     {
         return PushAndSetNext(() =>
         {
-            var directories = EnvironmentInfo.WorkingDirectory.GlobDirectories($"**/{NukeDirectoryName}")
-                .Concat(EnvironmentInfo.WorkingDirectory.GlobFiles($"**/{NukeDirectoryName}"))
+            var directories = EnvironmentInfo.WorkingDirectory.GlobDirectories($"**/{FalloutDirectoryName}")
+                .Concat(EnvironmentInfo.WorkingDirectory.GlobFiles($"**/{FalloutDirectoryName}"))
                 .Where(x => !x.Equals(EnvironmentInfo.WorkingDirectory))
                 .Select(x => x.Parent)
                 .Select(x => (x, EnvironmentInfo.WorkingDirectory.GetRelativePathTo(x).ToString()))

--- a/src/Fallout.GlobalTool/Program.Setup.cs
+++ b/src/Fallout.GlobalTool/Program.Setup.cs
@@ -45,9 +45,9 @@ partial class Program
 
         #region Basic
 
-        var nukeLatestReleaseVersion = NuGetVersionResolver.GetLatestVersion(NukeCommonPackageId, includePrereleases: false);
-        var nukeLatestPrereleaseVersion = NuGetVersionResolver.GetLatestVersion(NukeCommonPackageId, includePrereleases: true);
-        var nukeLatestLocalVersion = NuGetPackageResolver.GetGlobalInstalledPackage(NukeCommonPackageId, version: null, packagesConfigFile: null)
+        var nukeLatestReleaseVersion = NuGetVersionResolver.GetLatestVersion(FalloutCommonPackageId, includePrereleases: false);
+        var nukeLatestPrereleaseVersion = NuGetVersionResolver.GetLatestVersion(FalloutCommonPackageId, includePrereleases: true);
+        var nukeLatestLocalVersion = NuGetPackageResolver.GetGlobalInstalledPackage(FalloutCommonPackageId, version: null, packagesConfigFile: null)
             ?.Version.ToString();
 
         if (rootDirectory == null)
@@ -99,7 +99,7 @@ partial class Program
         var buildProjectFile = rootDirectory / buildProjectRelativeDirectory / buildProjectName + ".csproj";
         var buildProjectGuid = Guid.NewGuid().ToString().ToUpper();
 
-        (rootDirectory / NukeDirectoryName).CreateDirectory();
+        (rootDirectory / FalloutDirectoryName).CreateDirectory();
 
         WriteBuildScripts(
             scriptDirectory: WorkingDirectory,

--- a/src/Fallout.GlobalTool/Program.Update.cs
+++ b/src/Fallout.GlobalTool/Program.Update.cs
@@ -64,7 +64,7 @@ partial class Program
 
     private static void UpdateConfigurationFile(AbsolutePath rootDirectory)
     {
-        var configurationFile = rootDirectory / NukeDirectoryName;
+        var configurationFile = rootDirectory / FalloutDirectoryName;
         if (!configurationFile.Exists())
             return;
 
@@ -72,8 +72,8 @@ partial class Program
         configurationFile.DeleteFile();
 
         WriteConfigurationFile(rootDirectory, solutionFile);
-        Host.Warning($"The previous {NukeFileName} file was transformed to a {NukeDirectoryName} directory.");
-        Host.Warning($"The .tmp directory can be cleared, as it is moved to {NukeDirectoryName}/temp as well.");
+        Host.Warning($"The previous {FalloutFileName} file was transformed to a {FalloutDirectoryName} directory.");
+        Host.Warning($"The .tmp directory can be cleared, as it is moved to {FalloutDirectoryName}/temp as well.");
         if (solutionFile != null)
             Host.Warning($"Verify the property referencing the solution has the same name as the member with the {nameof(SolutionAttribute)}.");
     }

--- a/src/Fallout.GlobalTool/Program.cs
+++ b/src/Fallout.GlobalTool/Program.cs
@@ -86,7 +86,7 @@ public partial class Program
         if (rootDirectory == null || buildScript == null)
         {
             var missingItem = rootDirectory == null
-                ? $"{Constants.NukeDirectoryName} directory/file"
+                ? $"{Constants.FalloutDirectoryName} directory/file"
                 : "build.ps1/sh files";
 
             return PromptForConfirmation($"Could not find {missingItem}. Do you want to setup a build?")

--- a/src/Fallout.GlobalTool/ProjectUpdater.cs
+++ b/src/Fallout.GlobalTool/ProjectUpdater.cs
@@ -35,10 +35,10 @@ public static class ProjectUpdater
 
     private static void UpdateNukeCommonPackage(Microsoft.Build.Evaluation.Project buildProject, out FloatRange previousPackageVersion)
     {
-        var packageItem = buildProject.Items.SingleOrDefault(x => x.EvaluatedInclude == Constants.NukeCommonPackageId).NotNull();
+        var packageItem = buildProject.Items.SingleOrDefault(x => x.EvaluatedInclude == Constants.FalloutCommonPackageId).NotNull();
         previousPackageVersion = FloatRange.Parse(packageItem.GetMetadataValue("Version"));
 
-        var latestPackageVersion = NuGetVersionResolver.GetLatestVersion(Constants.NukeCommonPackageId, includePrereleases: false).GetAwaiter().GetResult();
+        var latestPackageVersion = NuGetVersionResolver.GetLatestVersion(Constants.FalloutCommonPackageId, includePrereleases: false).GetAwaiter().GetResult();
         if (previousPackageVersion.Satisfies(NuGetVersion.Parse(latestPackageVersion)))
             return;
 


### PR DESCRIPTION
## Summary

Mechanical rename of five internal-only constants in `Fallout.Build.Shared.Constants` plus their call sites:

| Old | New |
|---|---|
| `NukeFileName` | `FalloutFileName` |
| `NukeDirectoryName` | `FalloutDirectoryName` |
| `NukeCommonPackageId` | `FalloutCommonPackageId` |
| `GetNukeDirectory(...)` | `GetFalloutDirectory(...)` |
| `GlobalNukeDirectory` | `GlobalFalloutDirectory` |

All five symbols are `internal` — **zero consumer-visible impact**. Just leftover legacy naming.

14 files changed, 39 lines on each side. Refs #57.

## Carve-outs preserved (deliberate)

- `LegacyNukeDirectoryName` — back-compat constant whose **value** is the literal `.nuke`; renaming the symbol would be misleading.
- `UpstreamNukeRepository` / `UpstreamNukeRepositoryGit` — pointers to `nuke-build/nuke` for legacy URL recognition.
- `NukeTelemetryVersion` — MSBuild property in user-facing templates; deferred to the MSBuild-prop deprecation PR with the rest of that family.

## Verification

- `dotnet build fallout.slnx -c Debug`: 0 errors, 15 pre-existing warnings
- `dotnet test fallout.slnx`: 391 passed, 7 skipped, 0 failed

## Test plan

- [ ] `ubuntu-latest` CI green
- [ ] After merge, release run publishes 10.2.x with no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)