### PR TITLE
docs(readme): add proper badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,16 @@
 
 > Build automation for C#/.NET — the hard-fork successor to NUKE.
 
-[![Build](https://img.shields.io/github/actions/workflow/status/ChrisonSimtian/nuke/ubuntu-latest.yml?branch=main&label=build&style=for-the-badge&logo=github&logoColor=white)](https://github.com/ChrisonSimtian/nuke/actions)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge)](LICENSE)
+[![CI](https://github.com/ChrisonSimtian/Fallout/actions/workflows/ubuntu-latest.yml/badge.svg)](https://github.com/ChrisonSimtian/Fallout/actions/workflows/ubuntu-latest.yml)
+[![NuGet](https://img.shields.io/nuget/v/Fallout.Common?label=Fallout.Common)](https://www.nuget.org/packages/Fallout.Common)
+[![NuGet downloads](https://img.shields.io/nuget/dt/Fallout.Common?label=downloads)](https://www.nuget.org/packages/Fallout.Common)
+[![Latest release](https://img.shields.io/github/v/release/ChrisonSimtian/Fallout?label=release)](https://github.com/ChrisonSimtian/Fallout/releases/latest)
+[![GitHub last commit](https://img.shields.io/github/last-commit/ChrisonSimtian/Fallout)](https://github.com/ChrisonSimtian/Fallout/commits/main)
+[![.NET 10](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)](https://dot.net)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Open issues](https://img.shields.io/github/issues/ChrisonSimtian/Fallout)](https://github.com/ChrisonSimtian/Fallout/issues)
+[![Open PRs](https://img.shields.io/github/issues-pr/ChrisonSimtian/Fallout)](https://github.com/ChrisonSimtian/Fallout/pulls)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/ChrisonSimtian?label=sponsor&logo=githubsponsors&color=EA4AAA)](https://github.com/sponsors/ChrisonSimtian)
 
 > [!IMPORTANT]
 > **Rebrand in progress.** This repository is in the middle of being renamed from **NUKE** to **Fallout** as part of a hard fork. URLs, package names, and namespaces are migrating in stages — see the [Fallout rebrand milestone](https://github.com/ChrisonSimtian/nuke/milestone/1) for status. The legacy `Nuke.*` namespaces are still in use; the `Fallout.*` rename is tracked in issue [#32](https://github.com/ChrisonSimtian/nuke/issues/32).


### PR DESCRIPTION
## Summary

Replaces the two `for-the-badge` style badges at the top of README with a richer row matching the convention from `ChrisonSimtian/ErpForFactoryGames`.

## Badges added

| Badge | Why |
|---|---|
| CI status (ubuntu-latest) | Live build state |
| NuGet version (Fallout.Common) | Latest published version |
| NuGet downloads (Fallout.Common) | Adoption signal |
| Latest GitHub release | Tag-aware release cadence |
| Last commit on main | Activity / liveness |
| .NET 10 | Stack signal |
| MIT license | Compliance |
| Open issues | Backlog visibility |
| Open PRs | Throughput signal |
| GitHub Sponsors | Funding entry point (pairs with `costs.md`) |

`Fallout.Common` was picked as the representative package — it's the canonical entry point of the `Fallout.*` family.

## Other cleanup

Also fixed the stale `ChrisonSimtian/nuke` URLs **on the badge anchors** — repo is `ChrisonSimtian/Fallout` now (the `/nuke` URLs only worked via GitHub redirect).

The rest of the file still has stale `/nuke` URLs in body text. **Deliberately out of scope** for this PR — that's a wider cleanup pass worth doing in one focused sweep.

## Test plan

- [ ] Badges render on GitHub
- [ ] CI badge tracks ubuntu-latest workflow
- [ ] NuGet badges show current version (currently `10.2.14`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)