### PR TITLE
chore(rebrand): rename global tool command nuke → fallout

### DIFF
--- a/docs/01-getting-started/01-installation.md
+++ b/docs/01-getting-started/01-installation.md
@@ -20,7 +20,7 @@ From now on, you can use the global tool to:
 - [Manage secrets in parameter files](../06-global-tool/02-secrets.md)
 
 :::note
-If you're running on Linux-based systems, it's worth checking if the `nuke` global tool is available. This can be verified with `where nuke`. If the global tool is not found, you have to manually add `$HOME/.dotnet/tools` to your terminal configuration:
+If you're running on Linux-based systems, it's worth checking if the `fallout` global tool is available. This can be verified with `where fallout`. If the global tool is not found, you have to manually add `$HOME/.dotnet/tools` to your terminal configuration:
 
 <Tabs>
   <TabItem value="zsh" label="Zsh" default>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,13 +58,13 @@ Images, icons, logos, and other non-code binary content live under `.assets/`. T
 
 | Area | Projects | Purpose |
 |---|---|---|
-| Core framework | `Nuke.Common`, `Nuke.Build`, `Nuke.Build.Shared`, `Nuke.Components`, `Nuke.Tooling` | The API consumers reference and the host runtime that executes targets. |
-| Code generation | `Nuke.SourceGenerators`, `Nuke.Tooling.Generator` | Roslyn source generators that produce per-target code at compile time, plus the `.cs`-from-`.json` tool-wrapper generator. |
-| Models | `Nuke.ProjectModel`, `Nuke.SolutionModel` | Strongly-typed wrappers over `.csproj` / `.sln` / `.slnx`. |
-| Tooling | `Nuke.GlobalTool`, `Nuke.MSBuildTasks` | The `dotnet nuke` global tool and the MSBuild tasks layer it builds on. |
-| Utilities | `Nuke.Utilities` + sub-packages (`IO.Compression`, `IO.Globbing`, `Net`, `Text.Json`, `Text.Yaml`) | Standalone helpers reusable outside the build context. |
+| Core framework | `Fallout.Common`, `Fallout.Build`, `Fallout.Build.Shared`, `Fallout.Components`, `Fallout.Tooling` | The API consumers reference and the host runtime that executes targets. |
+| Code generation | `Fallout.SourceGenerators`, `Fallout.Tooling.Generator` | Roslyn source generators that produce per-target code at compile time, plus the `.cs`-from-`.json` tool-wrapper generator. |
+| Models | `Fallout.ProjectModel`, `Fallout.SolutionModel` | Strongly-typed wrappers over `.csproj` / `.sln` / `.slnx`. |
+| Tooling | `Fallout.GlobalTool`, `Fallout.MSBuildTasks` | The `dotnet fallout` global tool and the MSBuild tasks layer it builds on. |
+| Utilities | `Fallout.Utilities` + sub-packages (`IO.Compression`, `IO.Globbing`, `Net`, `Text.Json`, `Text.Yaml`) | Standalone helpers reusable outside the build context. |
 
-Every project under `src/` has a sibling under `tests/` (e.g. `src/Nuke.Common/` → `tests/Nuke.Common.Tests/`).
+Every project under `src/` has a sibling under `tests/` (e.g. `src/Fallout.Common/` → `tests/Fallout.Common.Tests/`).
 
 ## Build conventions
 

--- a/src/Fallout.GlobalTool/Fallout.GlobalTool.csproj
+++ b/src/Fallout.GlobalTool/Fallout.GlobalTool.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <PackAsTool>true</PackAsTool>
-    <ToolCommandName>nuke</ToolCommandName>
+    <ToolCommandName>fallout</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Fallout.GlobalTool/Program.Complete.cs
+++ b/src/Fallout.GlobalTool/Program.Complete.cs
@@ -17,7 +17,7 @@ namespace Fallout.GlobalTool;
 
 partial class Program
 {
-    private const string CommandName = "nuke";
+    private const string CommandName = "fallout";
 
     [UsedImplicitly]
     public static int Complete(string[] args, [CanBeNull] AbsolutePath rootDirectory, [CanBeNull] AbsolutePath buildScript)


### PR DESCRIPTION
## Summary

Renames the global tool's user-visible command from `dotnet nuke` to `dotnet fallout`.

Closes #38.

## Changes

| File | What |
|---|---|
| `Fallout.GlobalTool.csproj` | `<ToolCommandName>nuke</ToolCommandName>` → `fallout` |
| `Program.Complete.cs` | `CommandName = "nuke"` → `"fallout"` — shell completion parses `fallout <args>` now |
| `docs/01-getting-started/01-installation.md` | `where nuke` → `where fallout` |
| `docs/architecture.md` | One stale table row missed in #54 — `Nuke.*` → `Fallout.*` package names + `dotnet nuke` → `dotnet fallout` |

## Migration impact

- Users on `Nuke.GlobalTool` keep `dotnet nuke` — different package, untouched
- Users who already installed `Fallout.GlobalTool` from nuget.org (~hours old) see `dotnet nuke` → `dotnet fallout` on next update. The migration guide (#37) will call this out.

## Verification

- `dotnet build fallout.slnx -c Debug`: 0 errors, 15 pre-existing warnings
- `dotnet test fallout.slnx`: 391 passed, 7 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)