### PR TITLE
chore: replace matkoch.* NuGet dep with vendored fork of vs-solutionpersistence

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          submodules: recursive
           fetch-depth: 0
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # Nerdbank.GitVersioning needs full history
+          submodules: recursive   # vendor/vs-solutionpersistence
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -32,6 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          submodules: recursive
           fetch-depth: 0
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          submodules: recursive
           fetch-depth: 0
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vendor/vs-solutionpersistence"]
+	path = vendor/vs-solutionpersistence
+	url = https://github.com/ChrisonSimtian/vs-solutionpersistence
+	branch = main

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,9 +55,14 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.12.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.12.0" />
   </ItemGroup>
-  <!-- Solution Model -->
+  <!-- Solution Model — netstandard2.0 polyfills for the vendored SolutionPersistence
+       source. The library itself isn't a NuGet dep; it's compiled from
+       vendor/vs-solutionpersistence/ into Fallout.VisualStudio.SolutionPersistence. -->
   <ItemGroup>
-    <PackageVersion Include="matkoch.Microsoft.VisualStudio.SolutionPersistence" Version="1.0.61" />
+    <PackageVersion Include="IsExternalInit" Version="1.0.3" />
+    <PackageVersion Include="PolySharp" Version="1.15.0" />
+    <PackageVersion Include="System.Memory" Version="4.6.3" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
     <PackageVersion Include="Scriban" Version="7.1.0" />
   </ItemGroup>
   <!-- MSBuild (Fallout.ProjectModel + Fallout.MSBuildTasks) -->

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -13,6 +13,7 @@ using Fallout.Components;
     "macos-latest",
     GitHubActionsImage.MacOsLatest,
     FetchDepth = 0,
+    Submodules = GitHubActionsSubmodules.Recursive,
     OnPushBranches = new[] { MainBranch },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
     PublishArtifacts = false)]
@@ -20,6 +21,7 @@ using Fallout.Components;
     "windows-latest",
     GitHubActionsImage.WindowsLatest,
     FetchDepth = 0,
+    Submodules = GitHubActionsSubmodules.Recursive,
     OnPushBranches = new[] { MainBranch },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
     PublishArtifacts = false)]
@@ -29,6 +31,7 @@ using Fallout.Components;
     "ubuntu-latest",
     GitHubActionsImage.UbuntuLatest,
     FetchDepth = 0,
+    Submodules = GitHubActionsSubmodules.Recursive,
     OnPullRequestBranches = new[] { MainBranch },
     OnPullRequestExcludePaths = new[] { "docs/**", ".assets/**", "**/*.md" },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },

--- a/fallout.slnx
+++ b/fallout.slnx
@@ -20,6 +20,7 @@
   <Project Path="src\Fallout.MSBuildTasks\Fallout.MSBuildTasks.csproj" />
   <Project Path="src\Fallout.ProjectModel\Fallout.ProjectModel.csproj" />
   <Project Path="src\Fallout.SolutionModel\Fallout.SolutionModel.csproj" />
+  <Project Path="src\Fallout.VisualStudio.SolutionPersistence\Fallout.VisualStudio.SolutionPersistence.csproj" />
   <Project Path="src\Fallout.SourceGenerators\Fallout.SourceGenerators.csproj" />
   <Project Path="src\Fallout.Tooling.Generator\Fallout.Tooling.Generator.csproj" />
   <Project Path="src\Fallout.Tooling\Fallout.Tooling.csproj" />

--- a/src/Fallout.SolutionModel/Fallout.SolutionModel.csproj
+++ b/src/Fallout.SolutionModel/Fallout.SolutionModel.csproj
@@ -6,10 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Fallout.Utilities\Fallout.Utilities.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="matkoch.Microsoft.VisualStudio.SolutionPersistence" />
+    <ProjectReference Include="..\Fallout.VisualStudio.SolutionPersistence\Fallout.VisualStudio.SolutionPersistence.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Fallout.SourceGenerators/Fallout.SourceGenerators.csproj
+++ b/src/Fallout.SourceGenerators/Fallout.SourceGenerators.csproj
@@ -16,10 +16,12 @@
     <ProjectReference Include="..\Fallout.SolutionModel\Fallout.SolutionModel.csproj" />
     <ProjectReference Include="..\Fallout.Utilities\Fallout.Utilities.csproj" />
     <ProjectReference Include="..\Fallout.Utilities.IO.Globbing\Fallout.Utilities.IO.Globbing.csproj" />
+    <!-- SolutionPersistence is vendored — source compiled into Fallout.VisualStudio.SolutionPersistence.
+         The generator runs inside Roslyn, so its dependency DLLs need to land in this project's output dir. -->
+    <ProjectReference Include="..\Fallout.VisualStudio.SolutionPersistence\Fallout.VisualStudio.SolutionPersistence.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="matkoch.Microsoft.VisualStudio.SolutionPersistence" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.7.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" PrivateAssets="all" GeneratePathProperty="true" />
@@ -27,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(Pkgmatkoch_Microsoft_VisualStudio_SolutionPersistence)\lib\netstandard2.0\*.*" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    <None Include="$(MSBuildProjectDirectory)\..\Fallout.VisualStudio.SolutionPersistence\bin\$(Configuration)\netstandard2.0\Microsoft.VisualStudio.SolutionPersistence.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" />
     <None Include="$(PkgNewtonsoft_Json)\lib\netstandard2.0\*.*" CopyToOutputDirectory="PreserveNewest" Visible="false" />
     <None Include="$(PkgScriban)\lib\netstandard2.0\*.*" CopyToOutputDirectory="PreserveNewest" Visible="false" />
   </ItemGroup>
@@ -44,7 +46,7 @@
       <TargetPathWithTargetPlatformMoniker Include="$(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetFramework)\Fallout.Utilities.dll" IncludeRuntimeDependency="false" />
       <TargetPathWithTargetPlatformMoniker Include="$(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetFramework)\Fallout.Utilities.IO.Globbing.dll" IncludeRuntimeDependency="false" />
 
-      <TargetPathWithTargetPlatformMoniker Include="$(Pkgmatkoch_Microsoft_VisualStudio_SolutionPersistence)\lib\$(TargetFramework)\*.dll" IncludeRuntimeDependency="false" />
+      <TargetPathWithTargetPlatformMoniker Include="$(MSBuildProjectDirectory)\..\Fallout.VisualStudio.SolutionPersistence\bin\$(Configuration)\netstandard2.0\Microsoft.VisualStudio.SolutionPersistence.dll" IncludeRuntimeDependency="false" />
       <TargetPathWithTargetPlatformMoniker Include="$(PkgNewtonsoft_Json)\lib\$(TargetFramework)\*.dll" IncludeRuntimeDependency="false" />
       <TargetPathWithTargetPlatformMoniker Include="$(PkgScriban)\lib\$(TargetFramework)\*.dll" IncludeRuntimeDependency="false" />
     </ItemGroup>

--- a/src/Fallout.VisualStudio.SolutionPersistence/Fallout.VisualStudio.SolutionPersistence.csproj
+++ b/src/Fallout.VisualStudio.SolutionPersistence/Fallout.VisualStudio.SolutionPersistence.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Vendored fork of Microsoft.VisualStudio.SolutionPersistence with netstandard2.0
+    support. Sources live under vendor/vs-solutionpersistence/, tracked as a submodule
+    against ChrisonSimtian/vs-solutionpersistence — which is in turn a fork of
+    matkoch/vs-solutionpersistence (preserving his netstandard2.0 patches with full
+    attribution; the MIT license + upstream Microsoft history are intact).
+
+    Why a wrapper csproj instead of the submodule's own:
+    - The submodule's csproj has dev-time infrastructure (PublicApiAnalyzers, etc.)
+      that doesn't fit our build. We just need a clean library output.
+    - This wrapper compiles the same source files, multi-targets the TFMs we need
+      (netstandard2.0 for our source generator, net8.0/net10.0 for runtime consumers),
+      and stays out of the submodule's way so we can rebase on upstream without conflict.
+
+    AssemblyName matches upstream so type identity is preserved — anything looking
+    for `Microsoft.VisualStudio.SolutionPersistence` types just works.
+  -->
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <AssemblyName>Microsoft.VisualStudio.SolutionPersistence</AssemblyName>
+    <RootNamespace>Microsoft.VisualStudio.SolutionPersistence</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CS1591;CS1573;CS8632;RS0016</NoWarn>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <UpstreamSourceDir>$(MSBuildThisFileDirectory)..\..\vendor\vs-solutionpersistence\src\Microsoft.VisualStudio.SolutionPersistence</UpstreamSourceDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(UpstreamSourceDir)\**\*.cs" Exclude="$(UpstreamSourceDir)\bin\**;$(UpstreamSourceDir)\obj\**" />
+    <EmbeddedResource Include="$(UpstreamSourceDir)\Errors.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Errors.Designer.cs</LastGenOutput>
+      <LogicalName>Microsoft.VisualStudio.SolutionPersistence.Errors.resources</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <!-- Polyfills for netstandard2.0: records (IsExternalInit), Span<T>/Memory<T>,
+       IAsyncEnumerable, and System.Diagnostics.CodeAnalysis nullable attributes via PolySharp. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="IsExternalInit" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" PrivateAssets="all" />
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Fallout.SourceGenerators.Tests/StronglyTypedSolutionGeneratorTest.Test#Solution.g.verified.cs
+++ b/tests/Fallout.SourceGenerators.Tests/StronglyTypedSolutionGeneratorTest.Test#Solution.g.verified.cs
@@ -36,6 +36,7 @@ internal class Solution(SolutionModel model, AbsolutePath path) : Fallout.Common
     public Fallout.Common.ProjectModel.Project Fallout_Utilities_Tests => this.GetProject("Fallout.Utilities.Tests");
     public Fallout.Common.ProjectModel.Project Fallout_Utilities_Text_Json => this.GetProject("Fallout.Utilities.Text.Json");
     public Fallout.Common.ProjectModel.Project Fallout_Utilities_Text_Yaml => this.GetProject("Fallout.Utilities.Text.Yaml");
+    public Fallout.Common.ProjectModel.Project Fallout_VisualStudio_SolutionPersistence => this.GetProject("Fallout.VisualStudio.SolutionPersistence");
     public Fallout.Common.ProjectModel.Project Nuke_Common => this.GetProject("Nuke.Common");
     public Fallout.Common.ProjectModel.Project Nuke_Common_Shim_Tests => this.GetProject("Nuke.Common.Shim.Tests");
 


### PR DESCRIPTION
## Summary

Drops the `matkoch.Microsoft.VisualStudio.SolutionPersistence` NuGet dependency and brings the source in-tree as a git submodule of our own fork. Closes **#77**.

Sovereignty story:

- Upstream `Microsoft.VisualStudio.SolutionPersistence` only ships net472 + net8.0 — no netstandard2.0, which the source generator needs.
- Matt's fork (`matkoch/vs-solutionpersistence`) already adds netstandard2.0 (Span<char> conversions, HashSet.TryGetValue, PolySharp polyfills, etc.).
- We forked **his fork** → `ChrisonSimtian/vs-solutionpersistence`. License + history intact (MIT, attribution: Microsoft + Matthias Koch).

## Mechanics

- Submodule at `vendor/vs-solutionpersistence/`.
- New project `src/Fallout.VisualStudio.SolutionPersistence/` — a wrapper csproj that compiles the vendored source into a multi-target library (`netstandard2.0;net8.0;net10.0`). `AssemblyName=Microsoft.VisualStudio.SolutionPersistence` — drop-in.
- Wrapper bypasses the submodule's own csproj (dev-time analyzers locked to MS internal feeds; not what we need). Keeping our build separate lets us rebase the submodule on upstream without conflict.

## Consumer rewires

| File | Change |
|---|---|
| `Fallout.SolutionModel.csproj` | Drops matkoch PackageReference, adds ProjectReference to wrapper |
| `Fallout.SourceGenerators.csproj` | Same swap; the source-generator DLL bundling block now copies from the wrapper's output dir |
| `Directory.Packages.props` | Removed matkoch entry; added the 4 polyfill PackageVersions the wrapper consumes |
| `fallout.slnx` | New project added |
| `Solution.g.verified.cs` | Regenerated — picks up one extra line for the new project |

## Verification

- `dotnet build fallout.slnx -c Debug`: 0 errors, 15 pre-existing warnings
- `dotnet test fallout.slnx`: 408 passed, 7 skipped, 0 failed
- `grep matkoch.Microsoft` repo-wide: 0 matches

## Follow-up

`docs/dependencies.md` to be updated separately (matkoch row → vendored fork row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)