### PR TITLE
fix(publish): --skip-duplicate so nuget push is idempotent

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -142,6 +142,12 @@ partial class Build
         => From<IPack>().PackagesDirectory.GlobFiles("*.nupkg")
             .Where(x => !x.NameWithoutExtension.StartsWith("Nuke.", StringComparison.OrdinalIgnoreCase));
 
+    // `--skip-duplicate` makes nuget push idempotent: if a version is already on the feed,
+    // skip it instead of erroring. Lets us rerun release.yml safely when a single package
+    // fails mid-batch without nuking the whole pipeline on retry.
+    Configure<DotNetNuGetPushSettings> IPublish.PushSettings => _ => _
+        .EnableSkipDuplicate();
+
     IEnumerable<AbsolutePath> NuGetPackageFiles
         => From<IPack>().PackagesDirectory.GlobFiles("*.nupkg");
 


### PR DESCRIPTION
## Summary

Without \`--skip-duplicate\`, one failed push during \`IPublish.Publish\` aborts the whole batch, and any retry fails with HTTP 409 on every package that did succeed the first time. We hit this twice today (#107 SolutionPersistence prefix-reservation, then again during key-permission debugging), and it's painful: the release pipeline becomes non-recoverable from any partial-failure state.

Adds an \`IPublish.PushSettings\` override that calls \`.EnableSkipDuplicate()\`. Composes on top of the existing \`PushSettingsBase\` in \`Fallout.Components\`, so \`--source\` and \`--api-key\` still flow through.

## Test plan

- [x] \`dotnet build build/_build.csproj -c Release\` clean (0 errors)
- [ ] Next release.yml run pushes successfully, including any in-flight 10.3.x recovery
- [ ] Rerunning a release with already-published versions no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)