### PR TITLE
feat(shims): hand-written CI host singletons in Nuke.Common (#69 session 4)

### DIFF
--- a/src/Shims/Nuke.Common/CI/AppVeyor/AppVeyor.cs
+++ b/src/Shims/Nuke.Common/CI/AppVeyor/AppVeyor.cs
@@ -1,0 +1,26 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+// Hand-written transition shim for the framework-injected CI host singleton.
+// The TransitionShimGenerator can't bridge these because consumers receive
+// canonical-typed instances from Host.Instance (which can't be cast to a shim
+// subclass) and field-injection via [CI] is canonical-typed at runtime. This
+// shim re-exposes the static Instance accessor so the common idiom
+// `AppVeyor.Instance.AccountName` keeps compiling under
+// `using Nuke.Common.CI.AppVeyor;`.
+
+namespace Nuke.Common.CI.AppVeyor;
+
+public static class AppVeyor
+{
+    public static global::Fallout.Common.CI.AppVeyor.AppVeyor Instance
+        => global::Fallout.Common.CI.AppVeyor.AppVeyor.Instance;
+
+    public static int MessageLimit
+    {
+        get => global::Fallout.Common.CI.AppVeyor.AppVeyor.MessageLimit;
+        set => global::Fallout.Common.CI.AppVeyor.AppVeyor.MessageLimit = value;
+    }
+}

--- a/src/Shims/Nuke.Common/CI/AzurePipelines/AzurePipelines.cs
+++ b/src/Shims/Nuke.Common/CI/AzurePipelines/AzurePipelines.cs
@@ -1,0 +1,16 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+// Hand-written transition shim for the framework-injected CI host singleton.
+// See src/Shims/Nuke.Common/CI/AppVeyor/AppVeyor.cs for the rationale shared
+// across all CI host shims.
+
+namespace Nuke.Common.CI.AzurePipelines;
+
+public static class AzurePipelines
+{
+    public static global::Fallout.Common.CI.AzurePipelines.AzurePipelines Instance
+        => global::Fallout.Common.CI.AzurePipelines.AzurePipelines.Instance;
+}

--- a/src/Shims/Nuke.Common/CI/Bamboo/Bamboo.cs
+++ b/src/Shims/Nuke.Common/CI/Bamboo/Bamboo.cs
@@ -1,0 +1,16 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+// Hand-written transition shim for the framework-injected CI host singleton.
+// See src/Shims/Nuke.Common/CI/AppVeyor/AppVeyor.cs for the rationale shared
+// across all CI host shims.
+
+namespace Nuke.Common.CI.Bamboo;
+
+public static class Bamboo
+{
+    public static global::Fallout.Common.CI.Bamboo.Bamboo Instance
+        => global::Fallout.Common.CI.Bamboo.Bamboo.Instance;
+}

--- a/src/Shims/Nuke.Common/CI/Bitbucket/Bitbucket.cs
+++ b/src/Shims/Nuke.Common/CI/Bitbucket/Bitbucket.cs
@@ -1,0 +1,16 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+// Hand-written transition shim for the framework-injected CI host singleton.
+// See src/Shims/Nuke.Common/CI/AppVeyor/AppVeyor.cs for the rationale shared
+// across all CI host shims.
+
+namespace Nuke.Common.CI.Bitbucket;
+
+public static class Bitbucket
+{
+    public static global::Fallout.Common.CI.Bitbucket.Bitbucket Instance
+        => global::Fallout.Common.CI.Bitbucket.Bitbucket.Instance;
+}

--- a/src/Shims/Nuke.Common/CI/Bitrise/Bitrise.cs
+++ b/src/Shims/Nuke.Common/CI/Bitrise/Bitrise.cs
@@ -1,0 +1,16 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+// Hand-written transition shim for the framework-injected CI host singleton.
+// See src/Shims/Nuke.Common/CI/AppVeyor/AppVeyor.cs for the rationale shared
+// across all CI host shims.
+
+namespace Nuke.Common.CI.Bitrise;
+
+public static class Bitrise
+{
+    public static global::Fallout.Common.CI.Bitrise.Bitrise Instance
+        => global::Fallout.Common.CI.Bitrise.Bitrise.Instance;
+}

--- a/src/Shims/Nuke.Common/CI/GitHubActions/GitHubActions.cs
+++ b/src/Shims/Nuke.Common/CI/GitHubActions/GitHubActions.cs
@@ -1,0 +1,16 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+// Hand-written transition shim for the framework-injected CI host singleton.
+// See src/Shims/Nuke.Common/CI/AppVeyor/AppVeyor.cs for the rationale shared
+// across all CI host shims.
+
+namespace Nuke.Common.CI.GitHubActions;
+
+public static class GitHubActions
+{
+    public static global::Fallout.Common.CI.GitHubActions.GitHubActions Instance
+        => global::Fallout.Common.CI.GitHubActions.GitHubActions.Instance;
+}

--- a/src/Shims/Nuke.Common/CI/GitLab/GitLab.cs
+++ b/src/Shims/Nuke.Common/CI/GitLab/GitLab.cs
@@ -1,0 +1,16 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+// Hand-written transition shim for the framework-injected CI host singleton.
+// See src/Shims/Nuke.Common/CI/AppVeyor/AppVeyor.cs for the rationale shared
+// across all CI host shims.
+
+namespace Nuke.Common.CI.GitLab;
+
+public static class GitLab
+{
+    public static global::Fallout.Common.CI.GitLab.GitLab Instance
+        => global::Fallout.Common.CI.GitLab.GitLab.Instance;
+}

--- a/src/Shims/Nuke.Common/CI/Jenkins/Jenkins.cs
+++ b/src/Shims/Nuke.Common/CI/Jenkins/Jenkins.cs
@@ -1,0 +1,16 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+// Hand-written transition shim for the framework-injected CI host singleton.
+// See src/Shims/Nuke.Common/CI/AppVeyor/AppVeyor.cs for the rationale shared
+// across all CI host shims.
+
+namespace Nuke.Common.CI.Jenkins;
+
+public static class Jenkins
+{
+    public static global::Fallout.Common.CI.Jenkins.Jenkins Instance
+        => global::Fallout.Common.CI.Jenkins.Jenkins.Instance;
+}

--- a/src/Shims/Nuke.Common/CI/TeamCity/TeamCity.cs
+++ b/src/Shims/Nuke.Common/CI/TeamCity/TeamCity.cs
@@ -1,0 +1,16 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+// Hand-written transition shim for the framework-injected CI host singleton.
+// See src/Shims/Nuke.Common/CI/AppVeyor/AppVeyor.cs for the rationale shared
+// across all CI host shims.
+
+namespace Nuke.Common.CI.TeamCity;
+
+public static class TeamCity
+{
+    public static global::Fallout.Common.CI.TeamCity.TeamCity Instance
+        => global::Fallout.Common.CI.TeamCity.TeamCity.Instance;
+}

--- a/src/Shims/Nuke.Common/CI/TravisCI/TravisCI.cs
+++ b/src/Shims/Nuke.Common/CI/TravisCI/TravisCI.cs
@@ -1,0 +1,16 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+// Hand-written transition shim for the framework-injected CI host singleton.
+// See src/Shims/Nuke.Common/CI/AppVeyor/AppVeyor.cs for the rationale shared
+// across all CI host shims.
+
+namespace Nuke.Common.CI.TravisCI;
+
+public static class TravisCI
+{
+    public static global::Fallout.Common.CI.TravisCI.TravisCI Instance
+        => global::Fallout.Common.CI.TravisCI.TravisCI.Instance;
+}

--- a/src/Shims/Nuke.Common/README.md
+++ b/src/Shims/Nuke.Common/README.md
@@ -12,8 +12,13 @@ This package is a **partial transition shim** for projects mid-migration from NU
 | `[Secret]` | `Fallout.Common.SecretAttribute` | Subclass |
 | `[Solution]` | `Fallout.Common.ProjectModel.SolutionAttribute` | Subclass |
 | `[GitRepository]` | `Fallout.Common.Git.GitRepositoryAttribute` | Subclass |
+| `CI host singletons` (`GitHubActions`, `AzurePipelines`, `TeamCity`, `AppVeyor`, `GitLab`, `Jenkins`, `Bamboo`, `Bitbucket`, `Bitrise`, `TravisCI`) | `Fallout.Common.CI.<Vendor>.<Vendor>` | Hand-written static class re-exposing `.Instance` (returns canonical type) |
 
-The MVP unblocks a `class Build : NukeBuild` declaration with parameter/secret/solution/git injection — the entry-point surface of most consumer Build.cs files.
+The MVP unblocks a `class Build : NukeBuild` declaration with parameter/secret/solution/git injection — the entry-point surface of most consumer Build.cs files. CI host shims cover the `GitHubActions.Instance.Workflow`-style access path.
+
+### CI host shim limitation
+
+Because CI hosts are framework-injected, `[CI] readonly GitHubActions GitHubActions;` field declarations and `Host is GitHubActions` type checks need consumers to use the canonical (`Fallout.Common.CI.GitHubActions.GitHubActions`) type directly — the shim's `Instance` accessor returns a canonical instance, but the shim type itself is `static class` so it can't be used as a field type. Use `fallout-migrate` to rewrite those references.
 
 ## What's NOT covered (yet)
 

--- a/tests/Nuke.Common.Shim.Tests/SampleConsumerBuild.cs
+++ b/tests/Nuke.Common.Shim.Tests/SampleConsumerBuild.cs
@@ -11,6 +11,10 @@
 #pragma warning disable CS0169  // unused fields — same reason
 
 using Nuke.Common;
+using Nuke.Common.CI.AppVeyor;
+using Nuke.Common.CI.AzurePipelines;
+using Nuke.Common.CI.GitHubActions;
+using Nuke.Common.CI.TeamCity;
 using Nuke.Common.Git;
 using Nuke.Common.ProjectModel;
 
@@ -27,4 +31,18 @@ public abstract class SampleConsumerBuild : NukeBuild, INukeBuild
     [Solution] readonly Fallout.Common.ProjectModel.Solution Solution;
     [Solution("path/to/explicit.slnx")] readonly Fallout.Common.ProjectModel.Solution ExplicitSolution;
     [GitRepository] readonly Fallout.Common.Git.GitRepository GitRepository;
+
+    // CI-host shims expose only the static `Instance` accessor. Consumers can
+    // still chain into instance members because the returned type is canonical.
+    // Field-injection patterns like `[CI] readonly GitHubActions GitHubActions`
+    // are intentionally NOT supported — those need `fallout-migrate` to flip
+    // the type reference to canonical.
+    void TouchCiHostShims()
+    {
+        _ = GitHubActions.Instance?.Workflow;
+        _ = AzurePipelines.Instance?.AgentName;
+        _ = TeamCity.Instance?.BuildNumber;
+        _ = AppVeyor.Instance?.AccountName;
+        _ = AppVeyor.MessageLimit;
+    }
 }


### PR DESCRIPTION
## Summary

Adds hand-written transition shims for the 10 historical NUKE CI host singleton types under `Nuke.Common.CI.<Vendor>`:

- `GitHubActions`, `AzurePipelines`, `TeamCity`, `AppVeyor`, `GitLab`, `Jenkins`, `Bamboo`, `Bitbucket`, `Bitrise`, `TravisCI`

Each shim is a `public static class` that re-exposes the canonical `.Instance` accessor (returning the canonical type). `AppVeyor` additionally re-exposes `MessageLimit`.

## Why hand-written instead of generator-driven?

These hit two structural walls that the `TransitionShimGenerator` can't bridge:

1. **No accessible ctor.** All 10 host ctors are `internal`. The generator's `HasAnyAccessibleInstanceCtor` check skips them with SHIM001 (`no-accessible-ctor`).
2. **Subclassing wouldn't help anyway.** Consumers don't `new` these — `Host.Instance` returns a canonical-typed instance. A shim subclass type can't receive a canonical instance via `[CI] readonly GitHubActions GitHubActions;` (cast fails) or via `Host is GitHubActions` (returns false). Subclassing only helps when the consumer constructs/extends, which is the Easy tier's actual win.

Static pass-through is the honest fix: under `using Nuke.Common.CI.GitHubActions;`, consumers write `GitHubActions.Instance.Workflow` — `Instance` returns the canonical type, so instance member access flows through naturally. Zero member-by-member duplication.

## Limitation (documented)

Field-injection patterns and `Host is GitHubActions` checks **still need** `fallout-migrate` to flip the type reference to canonical. The `Nuke.Common.CI.<Vendor>.<Vendor>` shim is a `static class` — it can't be a field type. This is captured in a new "CI host shim limitation" section in `src/Shims/Nuke.Common/README.md`.

## Verification

- `src/Shims/Nuke.Common` builds clean (0 errors). The 10 SHIM001 warnings for these hosts still fire — we hand-bridge alongside the generator's diagnostic rather than suppress it. Diagnostic-suppression is a small follow-up if desired.
- `tests/Nuke.Common.Shim.Tests` builds clean. `SampleConsumerBuild.TouchCiHostShims()` exercises `GitHubActions.Instance.Workflow`, `AzurePipelines.Instance.AgentName`, `TeamCity.Instance.BuildNumber`, `AppVeyor.Instance.AccountName`, `AppVeyor.MessageLimit` — compiling that file is the contract.
- `Fallout.SourceGenerators.Tests` — 5/5 pass, no snapshot regression.

## #69 roadmap status after this

- session 1: ✅ Easy-tier generator + `Nuke.Common` shim
- session 2: ✅ Static-class method delegation
- session 2b: ⏸️ Sealed-class wrappers (deferred — live ROI is 1 attribute type; revisit later)
- session 3: ✅ `Nuke.Build` + `Nuke.Components` shims
- **session 4 (this PR)**: ✅ CI host singletons (10 vendors, hand-written)

## Test plan
- [ ] CI green (ubuntu-latest validation workflow)
- [ ] `dotnet build src/Shims/Nuke.Common/Nuke.Common.csproj` locally → 0 errors
- [ ] `dotnet build tests/Nuke.Common.Shim.Tests/Nuke.Common.Shim.Tests.csproj` locally → 0 errors
- [ ] (Manual) consumer trial: `var w = GitHubActions.Instance?.Workflow;` resolves and chains into canonical members

🤖 Generated with [Claude Code](https://claude.com/claude-code)