### PR TITLE
feat(shims): suppress SHIM001 for consumer-bridged types (#69 follow-up)

### DIFF
--- a/src/Fallout.SourceGenerators/TransitionShimGenerator.cs
+++ b/src/Fallout.SourceGenerators/TransitionShimGenerator.cs
@@ -129,6 +129,14 @@ public sealed class TransitionShimGenerator : IIncrementalGenerator
             fqnCounts.Where(kv => kv.Value > 1).Select(kv => kv.Key),
             StringComparer.Ordinal);
 
+        // Pre-pass: collect FQNs of every top-level public type the consuming
+        // compilation already declares under the target shim prefix. A hand-
+        // written bridge at the target FQN is the consumer's authoritative
+        // answer — the generator skips that canonical type silently (no
+        // emission, no SHIM001).
+        var handBridged = new HashSet<string>(StringComparer.Ordinal);
+        CollectHandBridgedFqns(compilation.SourceModule.GlobalNamespace, marker.ToPrefix, handBridged);
+
         // The same logical type can be reached via multiple referenced assemblies.
         // Dedupe hint names so AddSource doesn't throw.
         var emittedHints = new HashSet<string>(StringComparer.Ordinal);
@@ -140,8 +148,28 @@ public sealed class TransitionShimGenerator : IIncrementalGenerator
             if (!assemblyRef.Name.StartsWith("Fallout.", StringComparison.Ordinal))
                 continue;
 
-            VisitNamespace(ctx, assemblyRef.GlobalNamespace, marker, emittedHints, ambiguous);
+            VisitNamespace(ctx, assemblyRef.GlobalNamespace, marker, emittedHints, ambiguous, handBridged);
         }
+    }
+
+    private static void CollectHandBridgedFqns(INamespaceSymbol ns, string toPrefix, HashSet<string> sink)
+    {
+        var fullNs = ns.ToDisplayString();
+        var inScope = !string.IsNullOrEmpty(fullNs)
+            && (fullNs == toPrefix || fullNs.StartsWith(toPrefix + ".", StringComparison.Ordinal));
+        if (inScope)
+        {
+            foreach (var type in ns.GetTypeMembers())
+            {
+                if (type.DeclaredAccessibility != Accessibility.Public) continue;
+                // Compose the metadata-style FQN: namespace + "." + MetadataName.
+                // MetadataName encodes arity (e.g. `Foo`1` for `Foo<T>`), so this
+                // matches arity correctly when we look it up later.
+                sink.Add(fullNs + "." + type.MetadataName);
+            }
+        }
+        foreach (var child in ns.GetNamespaceMembers())
+            CollectHandBridgedFqns(child, toPrefix, sink);
     }
 
     private static void CountFqnsInNamespace(INamespaceSymbol ns, ShimMarker marker, Dictionary<string, int> counts)
@@ -161,7 +189,7 @@ public sealed class TransitionShimGenerator : IIncrementalGenerator
             CountFqnsInNamespace(child, marker, counts);
     }
 
-    private static void VisitNamespace(SourceProductionContext ctx, INamespaceSymbol ns, ShimMarker marker, HashSet<string> emittedHints, HashSet<string> ambiguousFqns)
+    private static void VisitNamespace(SourceProductionContext ctx, INamespaceSymbol ns, ShimMarker marker, HashSet<string> emittedHints, HashSet<string> ambiguousFqns, HashSet<string> handBridgedFqns)
     {
         foreach (var type in ns.GetTypeMembers())
         {
@@ -176,17 +204,25 @@ public sealed class TransitionShimGenerator : IIncrementalGenerator
                 || fullNamespace.StartsWith(marker.FromPrefix + ".", StringComparison.Ordinal);
             if (!matches) continue;
 
-            EmitOrSkipType(ctx, type, marker, emittedHints, ambiguousFqns);
+            EmitOrSkipType(ctx, type, marker, emittedHints, ambiguousFqns, handBridgedFqns);
         }
         foreach (var child in ns.GetNamespaceMembers())
-            VisitNamespace(ctx, child, marker, emittedHints, ambiguousFqns);
+            VisitNamespace(ctx, child, marker, emittedHints, ambiguousFqns, handBridgedFqns);
     }
 
-    private static void EmitOrSkipType(SourceProductionContext ctx, INamedTypeSymbol type, ShimMarker marker, HashSet<string> emittedHints, HashSet<string> ambiguousFqns)
+    private static void EmitOrSkipType(SourceProductionContext ctx, INamedTypeSymbol type, ShimMarker marker, HashSet<string> emittedHints, HashSet<string> ambiguousFqns, HashSet<string> handBridgedFqns)
     {
         // Skip nested types at top level — they get emitted inside their
         // declaring shim's source.
         if (type.ContainingType is not null)
+            return;
+
+        // If the consumer hand-wrote a shim at the target FQN, treat that as the
+        // authoritative bridge. Skip both emission and the SHIM001 diagnostic —
+        // the canonical type is covered, just not by us.
+        var targetNs = SwapNamespace(type.ContainingNamespace.ToDisplayString(), marker);
+        var targetMetadataFqn = targetNs + "." + type.MetadataName;
+        if (handBridgedFqns.Contains(targetMetadataFqn))
             return;
 
         var fqn = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);

--- a/tests/Fallout.SourceGenerators.Tests/TransitionShimGeneratorTest.cs
+++ b/tests/Fallout.SourceGenerators.Tests/TransitionShimGeneratorTest.cs
@@ -72,6 +72,52 @@ public class TransitionShimGeneratorTest
         return Verifier.Verify(result);
     }
 
+    // Hand-bridge suppression: when the consuming compilation declares a type at
+    // the target shim FQN, the generator treats that as the authoritative bridge —
+    // no emission, no SHIM001 (even for canonical kinds that would otherwise be
+    // skipped as Hard tier). Mirrors the session-4 CI host pattern in Nuke.Common.
+    [Fact]
+    public void SkipsCanonicalTypesAlreadyHandBridgedByConsumer()
+    {
+        var canonical = CompileCanonicalAssembly("""
+            namespace Fallout.Common
+            {
+                public sealed class HandBridgedSealed { public HandBridgedSealed() {} }
+                public class HandBridgedRegular { public HandBridgedRegular() {} }
+            }
+            """);
+
+        var shimCompilation = CSharpCompilation.Create("Nuke.HandBridged",
+            new[]
+            {
+                CSharpSyntaxTree.ParseText("""
+                    [assembly: Fallout.Migrate.Shims.ShimAllPublicTypesUnder("Fallout.Common", "Nuke.Common")]
+                    """),
+                CSharpSyntaxTree.ParseText("""
+                    namespace Nuke.Common
+                    {
+                        public static class HandBridgedSealed { }
+                        public static class HandBridgedRegular { }
+                    }
+                    """),
+            },
+            Basic.Reference.Assemblies.NetStandard20.References.All
+                .Concat(new[] { canonical }),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var driver = CSharpGeneratorDriver.Create(new TransitionShimGenerator());
+        var result = driver.RunGenerators(shimCompilation).GetRunResult();
+
+        // No source emitted for the hand-bridged canonical types.
+        result.GeneratedTrees
+            .Where(t => !t.FilePath.EndsWith("ShimAllPublicTypesUnderAttribute.g.cs", System.StringComparison.Ordinal))
+            .Should().BeEmpty();
+
+        // And no SHIM001 diagnostic for either hand-bridged type — the sealed
+        // one would normally warn, the regular one would normally emit.
+        result.Diagnostics.Should().BeEmpty();
+    }
+
     [Fact]
     public void EmitsNothingWhenNoMarkerAttributePresent()
     {


### PR DESCRIPTION
## Summary

Cleans up the 20 SHIM001 warnings left over from session 4 (the 10 CI host singleton hand-bridges × 2 referenced-assembly paths).

The `TransitionShimGenerator` now pre-walks the consuming compilation's own namespaces under the target shim prefix and collects FQNs of every top-level public type the consumer has hand-written. When the canonical-side walk would emit a shim for a type whose target FQN already exists in that set, the generator silently defers to the hand-bridge — no source emitted, no SHIM001 diagnostic.

## Why no annotation?

Considered an explicit `[assembly: SkipShimForCanonical(typeof(...))]` marker. Rejected because:
- The generator already auto-discovers everything from the canonical assembly walk; symmetry says consumer-side hand-writes should be auto-discovered too.
- The hand-bridge file itself is the source of truth — adding a parallel attribute would risk drift.
- Implicit detection works for the CI hosts (session 4) AND the existing `NukeBuild` hand-bridge in `Nuke.Common.NukeBuild.cs` and any future hand-bridges with zero ceremony.

A canonical name + arity match via `INamedTypeSymbol.MetadataName` keeps arity-correctness for generics.

## Live impact

Before this PR (the Nuke.Common shim build):

| Kind | Count |
|---|---|
| enum | 76 |
| **no-accessible-ctor** | **28** |
| delegate | 14 |
| struct | 4 |
| ambiguous-across-assemblies | 4 |
| sealed-class | 2 |

After:

| Kind | Count | Change |
|---|---|---|
| enum | 76 | — |
| **no-accessible-ctor** | **8** | **−20** (the 10 CI hosts × 2 paths) |
| delegate | 14 | — |
| struct | 4 | — |
| ambiguous-across-assemblies | 4 | — |
| sealed-class | 2 | — |

The 4 remaining unique `no-accessible-ctor` types — `AbsolutePath`, `AzureKeyVault`, `MSBuildProject`, `DelegateDisposable` — are the natural session-5 candidates.

## Verification

- New generator test `SkipsCanonicalTypesAlreadyHandBridgedByConsumer` covers both the sealed-class case (would otherwise warn) and the regular-class case (would otherwise emit). Both should be silent when a hand-bridge exists.
- 6/6 `Fallout.SourceGenerators.Tests` pass — no snapshot regression on the existing 5.
- `Nuke.Common` shim builds clean (0 errors) with the 20 CI host SHIM001 warnings now silent.
- `tests/Nuke.Common.Shim.Tests` still builds clean.

## Test plan
- [ ] CI green
- [ ] Live shim build: confirm the 10 CI host SHIM001 warnings are gone
- [ ] Existing `NukeBuild` hand-bridge is also auto-discovered (no behavior change there since the canonical name is `FalloutBuild`, not `NukeBuild` — different name, no collision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)