### PR TITLE
feat(shims): hand-bridge DelegateDisposable, document non-bridgeable types (#69 session 5)

### DIFF
--- a/src/Shims/Nuke.Common/README.md
+++ b/src/Shims/Nuke.Common/README.md
@@ -13,19 +13,27 @@ This package is a **partial transition shim** for projects mid-migration from NU
 | `[Solution]` | `Fallout.Common.ProjectModel.SolutionAttribute` | Subclass |
 | `[GitRepository]` | `Fallout.Common.Git.GitRepositoryAttribute` | Subclass |
 | `CI host singletons` (`GitHubActions`, `AzurePipelines`, `TeamCity`, `AppVeyor`, `GitLab`, `Jenkins`, `Bamboo`, `Bitbucket`, `Bitrise`, `TravisCI`) | `Fallout.Common.CI.<Vendor>.<Vendor>` | Hand-written static class re-exposing `.Instance` (returns canonical type) |
+| `DelegateDisposable` | `Fallout.Common.Utilities.DelegateDisposable` | Hand-written static class re-exposing `CreateBracket` / `SetAndRestore` |
 
 The MVP unblocks a `class Build : NukeBuild` declaration with parameter/secret/solution/git injection — the entry-point surface of most consumer Build.cs files. CI host shims cover the `GitHubActions.Instance.Workflow`-style access path.
 
-### CI host shim limitation
+### Hand-bridge limitation (CI hosts, `DelegateDisposable`)
 
-Because CI hosts are framework-injected, `[CI] readonly GitHubActions GitHubActions;` field declarations and `Host is GitHubActions` type checks need consumers to use the canonical (`Fallout.Common.CI.GitHubActions.GitHubActions`) type directly — the shim's `Instance` accessor returns a canonical instance, but the shim type itself is `static class` so it can't be used as a field type. Use `fallout-migrate` to rewrite those references.
+These types are framework-injected or use private/internal constructors. The shim is `static class`, so consumers receiving canonical-typed instances (e.g. `[CI] readonly GitHubActions GitHubActions;`, `Host is GitHubActions`, methods returning `DelegateDisposable`) need to switch the type reference to canonical. Use `fallout-migrate` for those rewrites; the shim covers static factory / `.Instance` access paths only.
+
+## What's NOT covered (and won't be)
+
+These types have private/internal ctors and no public static factories, **and** are mainly used as value types — meaning the hand-bridge would be empty (no public statics to re-expose) and a subclass shim can't carry implicit operators or be assignment-compatible with framework-returned canonical instances:
+
+- **`Fallout.Common.IO.AbsolutePath`** — used via `AbsolutePath path = "/foo"` (implicit `string`/`AbsolutePath` conversion), `parent / "child"` (`operator/`), and field-injection. None of those work through a static-class shim. Use `fallout-migrate` to rewrite `Nuke.Common.IO.AbsolutePath` → `Fallout.Common.IO.AbsolutePath`.
+- **`Fallout.Common.Tools.AzureKeyVault.AzureKeyVault`** — zero public statics, framework-constructed only. `fallout-migrate` rename.
+- **`Fallout.Common.Tools.MSBuild.MSBuildProject`** — zero public statics, framework-returned only. `fallout-migrate` rename.
 
 ## What's NOT covered (yet)
 
 - **CI attributes** (`[GitHubActions]`, `[AzurePipelines]`, `[TeamCity]`, `[AppVeyor]`, ...) — these take enum parameters (`GitHubActionsImage`, etc.) that the shim doesn't re-export. C# can't subclass enums; bridging them needs a source generator. Tracked in the follow-up issue.
 - **The `Target` delegate** — delegates can't be implicitly converted across types in C#, so the shim can't bridge `Nuke.Common.Target Compile => _ => _` cleanly. Use `fallout-migrate` for the source-level rename.
 - **Static helper classes** — `DotNetTasks`, `MSBuildTasks`, etc. require method-by-method delegation. Tracked for the source-generator follow-up.
-- **IO types** — `AbsolutePath`, file globbing helpers — also need wrapper classes with mirrored members.
 
 ## Packaging
 

--- a/src/Shims/Nuke.Common/Utilities/DelegateDisposable.cs
+++ b/src/Shims/Nuke.Common/Utilities/DelegateDisposable.cs
@@ -1,0 +1,27 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+// Hand-written transition shim. The canonical DelegateDisposable has a private
+// ctor and exposes itself only via static factories; the generator skips it as
+// no-accessible-ctor, and a subclass wouldn't compile anyway. This static-class
+// shim re-exposes the three factories so consumers keep compiling on
+// `using Nuke.Common.Utilities;`.
+
+using System;
+using System.Linq.Expressions;
+
+namespace Nuke.Common.Utilities;
+
+public static class DelegateDisposable
+{
+    public static IDisposable CreateBracket(Action setup = null, Action cleanup = null)
+        => global::Fallout.Common.Utilities.DelegateDisposable.CreateBracket(setup, cleanup);
+
+    public static IDisposable CreateBracket<T>(Func<T> setup, Action<T> cleanup)
+        => global::Fallout.Common.Utilities.DelegateDisposable.CreateBracket(setup, cleanup);
+
+    public static IDisposable SetAndRestore<T>(Expression<Func<T>> memberProvider, T value)
+        => global::Fallout.Common.Utilities.DelegateDisposable.SetAndRestore(memberProvider, value);
+}

--- a/tests/Nuke.Common.Shim.Tests/SampleConsumerBuild.cs
+++ b/tests/Nuke.Common.Shim.Tests/SampleConsumerBuild.cs
@@ -17,6 +17,7 @@ using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.CI.TeamCity;
 using Nuke.Common.Git;
 using Nuke.Common.ProjectModel;
+using Nuke.Common.Utilities;
 
 namespace Nuke.Common.Shim.Tests;
 
@@ -44,5 +45,18 @@ public abstract class SampleConsumerBuild : NukeBuild, INukeBuild
         _ = TeamCity.Instance?.BuildNumber;
         _ = AppVeyor.Instance?.AccountName;
         _ = AppVeyor.MessageLimit;
+    }
+
+    // DelegateDisposable shim re-exposes the static factories. Consumer
+    // usage stays canonical-typed at runtime (the factories return
+    // canonical IDisposable instances).
+    void TouchDelegateDisposableShim()
+    {
+        using var bracket = DelegateDisposable.CreateBracket(
+            setup: () => { },
+            cleanup: () => { });
+        using var typed = DelegateDisposable.CreateBracket(
+            setup: () => 42,
+            cleanup: _ => { });
     }
 }


### PR DESCRIPTION
## Summary

Closes out the remaining `no-accessible-ctor` SHIM001 bucket honestly.

**What ships as a bridge:**
- `Nuke.Common.Utilities.DelegateDisposable` — `static class` re-exposing `CreateBracket(Action, Action)`, `CreateBracket<T>(Func<T>, Action<T>)`, and `SetAndRestore<T>`. All three return canonical `IDisposable`, so consumer calls flow through naturally.

**What ships as docs (not bridge):**
- `Fallout.Common.IO.AbsolutePath`
- `Fallout.Common.Tools.AzureKeyVault.AzureKeyVault`
- `Fallout.Common.Tools.MSBuild.MSBuildProject`

These three are documented as `fallout-migrate` rename targets in a new "What's NOT covered (and won't be)" README section.

## Why those three aren't bridged

| Type | Public statics | Why a hand-bridge wouldn't help |
|---|---|---|
| `AbsolutePath` | `Create()` + 5 const strings | Dominant consumer syntax is `AbsolutePath path = "/foo"` (implicit conversion) and `parent / "child"` (operator/). A `static class` shim can't carry implicit operators, and a subclass shim can't be assignment-compatible with the framework-returned canonical instances. The bridge would be decorative — `AbsolutePath.Create(...)` is rarely how consumers write it. |
| `AzureKeyVault` | none | Internal ctor, framework-constructed only. Zero surface to re-expose. |
| `MSBuildProject` | none | Internal ctor, framework-returned only. Zero surface to re-expose. |

The `fallout-migrate` rewrite (`Nuke.Common.X.Y` → `Fallout.Common.X.Y`) is the right tool for these — same conclusion as enums, delegates, and structs.

## Live impact

| Kind | Before (#141) | After |
|---|---|---|
| enum | 76 | 76 |
| **no-accessible-ctor** | **8** | **6** (DelegateDisposable × 2 paths removed) |
| delegate | 14 | 14 |
| struct | 4 | 4 |
| ambiguous-across-assemblies | 4 | 4 |
| sealed-class | 2 | 2 |

The 3 remaining unique `no-accessible-ctor` types match the 3 documented fallout-migrate targets exactly.

## Verification

- `src/Shims/Nuke.Common` builds clean (0 errors)
- `tests/Nuke.Common.Shim.Tests` builds clean — `SampleConsumerBuild.TouchDelegateDisposableShim()` exercises both `CreateBracket` overloads
- The hand-bridge-suppression mechanism from #141 automatically picks up `DelegateDisposable`, so no SHIM001 fires for it

## #69 roadmap status after this

- session 1: ✅ Easy-tier generator + `Nuke.Common` shim
- session 2: ✅ Static-class method delegation
- session 2b: ⏸️ Sealed-class wrappers — deferred (1 unique attribute, low ROI)
- session 3: ✅ `Nuke.Build` + `Nuke.Components` shims
- session 4: ✅ CI host singletons (10 vendors)
- session 4b: ✅ SHIM001 suppression for consumer-bridged types (#141)
- **session 5 (this PR)**: ✅ DelegateDisposable bridge + non-bridgeable docs

The `no-accessible-ctor` line of attack is now closed — what remains (`AbsolutePath`, `AzureKeyVault`, `MSBuildProject`) is documented `fallout-migrate` territory.

## Test plan
- [ ] CI green
- [ ] Live shim build: `kind: no-accessible-ctor` count is 6 (down from 8)
- [ ] Consumer trial: `using Nuke.Common.Utilities;` + `DelegateDisposable.CreateBracket(...)` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)