### PR TITLE
feat(shims): split SHIM001 to quiet language-limit skips (#69 follow-up)

### DIFF
--- a/src/Fallout.SourceGenerators/TransitionShimGenerator.cs
+++ b/src/Fallout.SourceGenerators/TransitionShimGenerator.cs
@@ -32,14 +32,30 @@ public sealed class TransitionShimGenerator : IIncrementalGenerator
     private const string AttributeName = "ShimAllPublicTypesUnderAttribute";
     private const string AttributeFullName = AttributeNamespace + "." + AttributeName;
 
-    private static readonly DiagnosticDescriptor SkippedTypeRule = new(
+    // SHIM001: actionable skips. Something COULD still bridge these — un-seal
+    // the canonical, promote a ctor's visibility, dedup across assemblies, or
+    // hand-write a shim. Warning by default.
+    private static readonly DiagnosticDescriptor ActionableSkipRule = new(
         id: "SHIM001",
-        title: "Transition-shim type skipped (Hard tier)",
-        messageFormat: "Type '{0}' was skipped by the transition-shim generator (kind: {1}). Consumers relying on this via the Nuke.* shim will need to migrate via 'fallout-migrate'.",
+        title: "Transition-shim type skipped (actionable)",
+        messageFormat: "Type '{0}' was skipped by the transition-shim generator (kind: {1}). Consumers relying on this via the Nuke.* shim need a hand-written bridge, a canonical-side fix (un-seal / widen ctor visibility), or to migrate via 'fallout-migrate'.",
         category: "Migration",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "The transition-shim generator's Easy tier covers classes, abstract classes, interfaces, and attributes. Sealed classes, static classes, enums, and delegates need richer mechanisms (member-by-member delegation, etc.) and are deferred.");
+        description: "Covers skip kinds where an action is available: sealed-class (un-seal canonical or hand-bridge), no-accessible-ctor (widen ctor visibility, hand-bridge static surface, or fallout-migrate), and ambiguous-across-assemblies (dedup at canonical or fallout-migrate).");
+
+    // SHIM002: language-limit skips. C# can't subclass these kinds — they're
+    // intentionally not bridged and are documented fallout-migrate territory.
+    // Info severity, OFF by default; enable in .editorconfig if you want the
+    // full skip catalogue.
+    private static readonly DiagnosticDescriptor LanguageLimitSkipRule = new(
+        id: "SHIM002",
+        title: "Transition-shim type skipped (language limit; fallout-migrate territory)",
+        messageFormat: "Type '{0}' was skipped by the transition-shim generator (kind: {1}). This kind cannot be subclassed in C# — use 'fallout-migrate' to rewrite the consumer's reference to the canonical Fallout.* name.",
+        category: "Migration",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: false,
+        description: "Covers skip kinds bounded by C# language limits: enum, delegate, and struct cannot be subclassed cross-assembly, so a transparent shim is impossible. The consumer-side fix is always 'fallout-migrate'. Off by default to keep the build console quiet; opt in via dotnet_diagnostic.SHIM002.severity if you want the full inventory.");
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -229,7 +245,7 @@ public sealed class TransitionShimGenerator : IIncrementalGenerator
         if (ambiguousFqns.Contains(fqn))
         {
             ctx.ReportDiagnostic(Diagnostic.Create(
-                SkippedTypeRule,
+                ActionableSkipRule,
                 location: Location.None,
                 type.ToDisplayString(),
                 "ambiguous-across-assemblies"));
@@ -239,8 +255,9 @@ public sealed class TransitionShimGenerator : IIncrementalGenerator
         var skipReason = ClassifyForSkip(type);
         if (skipReason is not null)
         {
+            var rule = IsLanguageLimitKind(skipReason) ? LanguageLimitSkipRule : ActionableSkipRule;
             ctx.ReportDiagnostic(Diagnostic.Create(
-                SkippedTypeRule,
+                rule,
                 location: Location.None,
                 type.ToDisplayString(),
                 skipReason));
@@ -254,6 +271,9 @@ public sealed class TransitionShimGenerator : IIncrementalGenerator
         var source = EmitTopLevelShim(type, marker);
         ctx.AddSource(hint, source);
     }
+
+    private static bool IsLanguageLimitKind(string skipReason)
+        => skipReason is "enum" or "delegate" or "struct";
 
     /// <summary>
     /// Returns a one-word kind label if this type should be skipped, otherwise null.

--- a/tests/Fallout.SourceGenerators.Tests/TransitionShimGeneratorTest.EmitsShimsForEachKindAndSkipsHardTier.verified.txt
+++ b/tests/Fallout.SourceGenerators.Tests/TransitionShimGeneratorTest.EmitsShimsForEachKindAndSkipsHardTier.verified.txt
@@ -1,42 +1,28 @@
 ﻿{
   Diagnostics: [
     {
-      Message: Type 'Fallout.Common.SealedThing' was skipped by the transition-shim generator (kind: sealed-class). Consumers relying on this via the Nuke.* shim will need to migrate via 'fallout-migrate'.,
+      Message: Type 'Fallout.Common.SealedThing' was skipped by the transition-shim generator (kind: sealed-class). Consumers relying on this via the Nuke.* shim need a hand-written bridge, a canonical-side fix (un-seal / widen ctor visibility), or to migrate via 'fallout-migrate'.,
       Severity: Warning,
       WarningLevel: 1,
       Descriptor: {
         Id: SHIM001,
-        Title: Transition-shim type skipped (Hard tier),
-        Description: The transition-shim generator's Easy tier covers classes, abstract classes, interfaces, and attributes. Sealed classes, static classes, enums, and delegates need richer mechanisms (member-by-member delegation, etc.) and are deferred.,
-        MessageFormat: Type '{0}' was skipped by the transition-shim generator (kind: {1}). Consumers relying on this via the Nuke.* shim will need to migrate via 'fallout-migrate'.,
+        Title: Transition-shim type skipped (actionable),
+        Description: Covers skip kinds where an action is available: sealed-class (un-seal canonical or hand-bridge), no-accessible-ctor (widen ctor visibility, hand-bridge static surface, or fallout-migrate), and ambiguous-across-assemblies (dedup at canonical or fallout-migrate).,
+        MessageFormat: Type '{0}' was skipped by the transition-shim generator (kind: {1}). Consumers relying on this via the Nuke.* shim need a hand-written bridge, a canonical-side fix (un-seal / widen ctor visibility), or to migrate via 'fallout-migrate'.,
         Category: Migration,
         DefaultSeverity: Warning,
         IsEnabledByDefault: true
       }
     },
     {
-      Message: Type 'Fallout.Common.MyEnum' was skipped by the transition-shim generator (kind: enum). Consumers relying on this via the Nuke.* shim will need to migrate via 'fallout-migrate'.,
+      Message: Type 'Fallout.Common.PrivateCtorOnly' was skipped by the transition-shim generator (kind: no-accessible-ctor). Consumers relying on this via the Nuke.* shim need a hand-written bridge, a canonical-side fix (un-seal / widen ctor visibility), or to migrate via 'fallout-migrate'.,
       Severity: Warning,
       WarningLevel: 1,
       Descriptor: {
         Id: SHIM001,
-        Title: Transition-shim type skipped (Hard tier),
-        Description: The transition-shim generator's Easy tier covers classes, abstract classes, interfaces, and attributes. Sealed classes, static classes, enums, and delegates need richer mechanisms (member-by-member delegation, etc.) and are deferred.,
-        MessageFormat: Type '{0}' was skipped by the transition-shim generator (kind: {1}). Consumers relying on this via the Nuke.* shim will need to migrate via 'fallout-migrate'.,
-        Category: Migration,
-        DefaultSeverity: Warning,
-        IsEnabledByDefault: true
-      }
-    },
-    {
-      Message: Type 'Fallout.Common.PrivateCtorOnly' was skipped by the transition-shim generator (kind: no-accessible-ctor). Consumers relying on this via the Nuke.* shim will need to migrate via 'fallout-migrate'.,
-      Severity: Warning,
-      WarningLevel: 1,
-      Descriptor: {
-        Id: SHIM001,
-        Title: Transition-shim type skipped (Hard tier),
-        Description: The transition-shim generator's Easy tier covers classes, abstract classes, interfaces, and attributes. Sealed classes, static classes, enums, and delegates need richer mechanisms (member-by-member delegation, etc.) and are deferred.,
-        MessageFormat: Type '{0}' was skipped by the transition-shim generator (kind: {1}). Consumers relying on this via the Nuke.* shim will need to migrate via 'fallout-migrate'.,
+        Title: Transition-shim type skipped (actionable),
+        Description: Covers skip kinds where an action is available: sealed-class (un-seal canonical or hand-bridge), no-accessible-ctor (widen ctor visibility, hand-bridge static surface, or fallout-migrate), and ambiguous-across-assemblies (dedup at canonical or fallout-migrate).,
+        MessageFormat: Type '{0}' was skipped by the transition-shim generator (kind: {1}). Consumers relying on this via the Nuke.* shim need a hand-written bridge, a canonical-side fix (un-seal / widen ctor visibility), or to migrate via 'fallout-migrate'.,
         Category: Migration,
         DefaultSeverity: Warning,
         IsEnabledByDefault: true


### PR DESCRIPTION
## Summary

Splits the single `SHIM001` diagnostic into two by skip class. The current rule fires uniformly for every skipped canonical type — sealed classes, enums, delegates, structs, no-accessible-ctor types, ambiguous-across-assemblies. After sessions 4 and 5 closed out the bridgeable cases, the remaining warnings are dominated by skip-kinds that **cannot be bridged in C# at all** (76 enums, 14 delegates, 4 structs). Those 94 warnings are noise — every consumer-side answer for them is `fallout-migrate`.

## New diagnostic split

| ID | Severity | Default | Covers | Why this severity |
|---|---|---|---|---|
| **SHIM001** | Warning | **on** | sealed-class, no-accessible-ctor, ambiguous-across-assemblies | Each has a possible fix (un-seal canonical, widen ctor visibility, dedup at canonical, or hand-bridge static surface). Worth surfacing. |
| **SHIM002** | Info | **off** | enum, delegate, struct | C# can't subclass these cross-assembly — `fallout-migrate` is the only path. Reference-only; opt in via `dotnet_diagnostic.SHIM002.severity` for the full inventory. |

## Live impact (Nuke.Common shim build)

| | Before | After |
|---|---|---|
| SHIM001 (warning) | 106 | **12** |
| SHIM002 (info, off by default) | — | 94 (suppressed in normal builds) |

Remaining 12 SHIM001 break down as:
- 6 `no-accessible-ctor` (AbsolutePath, AzureKeyVault, MSBuildProject × 2 paths — documented `fallout-migrate` targets per session 5)
- 4 `ambiguous-across-assemblies` (real canonical-side dedup candidates)
- 2 `sealed-class` (GlobbingOptionsAttribute × 2 paths — one un-seal fixes both)

Every remaining warning is genuinely actionable.

## Verification

- Existing snapshot test `EmitsShimsForEachKindAndSkipsHardTier` updated: Verify automatically filters out `IsEnabledByDefault: false` diagnostics, so the snapshot now shows only the 2 actionable kinds (sealed-class + no-accessible-ctor) on SHIM001. The previous enum SHIM001 entry disappears cleanly.
- 6/6 generator tests pass
- `dotnet build` of Nuke.Common shim is clean (0 errors); SHIM001 count is 12 as expected; the 94 SHIM002 emissions are correctly invisible in the build output.

## Test plan
- [ ] CI green
- [ ] `dotnet build src/Shims/Nuke.Common/Nuke.Common.csproj` shows 12 SHIM001 warnings (not 106)
- [ ] `dotnet build` with `<NoWarn>SHIM001</NoWarn>` shows zero shim diagnostics
- [ ] (Optional) consumer enabling SHIM002 via `.editorconfig` (`dotnet_diagnostic.SHIM002.severity = warning`) brings the 94 back

🤖 Generated with [Claude Code](https://claude.com/claude-code)