### PR TITLE
refactor(utilities): rename Json-side ObjectExtensions → JsonObjectExtensions (#69 follow-up)

### DIFF
--- a/src/Fallout.Utilities.Text.Json/Object.ToJObject.cs
+++ b/src/Fallout.Utilities.Text.Json/Object.ToJObject.cs
@@ -10,7 +10,13 @@ using Newtonsoft.Json.Linq;
 
 namespace Fallout.Common.Utilities;
 
-public static class ObjectExtensions
+// Renamed from ObjectExtensions in 2026-05: the Fallout.Utilities assembly
+// declares a same-named partial class under the same namespace (Apply/When/
+// Clone). Two assemblies declaring `Fallout.Common.Utilities.ObjectExtensions`
+// blocks the TransitionShimGenerator (CS0433 if it tried to delegate). Since
+// ToJObject is only ever called as an extension method, the class name is
+// invisible to callers and a rename is the cleanest fix.
+public static class JsonObjectExtensions
 {
     public static JObject ToJObject(this object obj, JsonSerializer serializer = null)
     {


### PR DESCRIPTION
## Summary

`Fallout.Utilities` and `Fallout.Utilities.Text.Json` both declare `public static class ObjectExtensions` under the `Fallout.Common.Utilities` namespace. Two assemblies declaring the same FQN is the documented "split-assembly extension class" pattern in C# (consumers see one unified API), but it blocks the `TransitionShimGenerator` — a shim delegating to that FQN would produce CS0433 at consumer compile. The generator's pre-pass has been flagging this as `ambiguous-across-assemblies` since session 1.

## What it is, by member

| Assembly | Members |
|---|---|
| `Fallout.Utilities` (3 partials: `Object.Apply.cs`, `Object.When.cs`, `Object.Clone.cs`) | `Apply`, `When`, `Clone`, … |
| `Fallout.Utilities.Text.Json` (single file: `Object.ToJObject.cs`) | `ToJObject` |

## Fix

Rename the Json side to `JsonObjectExtensions`. Verified that **`ToJObject` is only ever called as an extension method** (`obj.ToJObject(...)`) — there are zero `ObjectExtensions.ToJObject(...)` call sites in `src/`, `tests/`, or `build/`. The class name is invisible to callers; the rename is a pure refactor.

The base `Fallout.Utilities` side keeps the `ObjectExtensions` name (it's the larger surface, and the rename burden should sit on the smaller satellite assembly).

## Live impact

| Kind | Before | After |
|---|---|---|
| ambiguous-across-assemblies | 4 | **0** |
| no-accessible-ctor | 6 | 6 |
| sealed-class | 0 | 0 |
| **SHIM001 total** | **10** | **6** |

The 6 remaining SHIM001s are all documented `fallout-migrate` targets (`AbsolutePath`, `AzureKeyVault`, `MSBuildProject` × 2 paths each) that won't disappear via shim work. **This is the cleanest the shim build can get without `fallout-migrate`.**

## Verification

- `dotnet build tests/Fallout.Tooling.Tests/Fallout.Tooling.Tests.csproj` (the single `ToJObject` caller) compiles clean
- `dotnet build src/Shims/Nuke.Common/Nuke.Common.csproj` clean; 0 ambiguous warnings
- Two new shim types now auto-generate via the Easy-tier path:
  - `Nuke.Common.Utilities.ObjectExtensions` (mirroring Fallout.Utilities)
  - `Nuke.Common.Utilities.JsonObjectExtensions` (mirroring Fallout.Utilities.Text.Json)

## Test plan
- [ ] CI green
- [ ] Live shim build: 6 SHIM001 warnings (down from 10)
- [ ] `obj.ToJObject(...)` extension-method discovery unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)