### PR TITLE
chore(deps): drop Newtonsoft.Json from Fallout.SourceGenerators (#83 follow-up)

### DIFF
--- a/src/Fallout.SourceGenerators/Fallout.SourceGenerators.csproj
+++ b/src/Fallout.SourceGenerators/Fallout.SourceGenerators.csproj
@@ -24,13 +24,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.7.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Scriban" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="$(MSBuildProjectDirectory)\..\Fallout.VisualStudio.SolutionPersistence\bin\$(Configuration)\netstandard2.0\Microsoft.VisualStudio.SolutionPersistence.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" />
-    <None Include="$(PkgNewtonsoft_Json)\lib\netstandard2.0\*.*" CopyToOutputDirectory="PreserveNewest" Visible="false" />
     <None Include="$(PkgScriban)\lib\netstandard2.0\*.*" CopyToOutputDirectory="PreserveNewest" Visible="false" />
   </ItemGroup>
 
@@ -47,7 +45,6 @@
       <TargetPathWithTargetPlatformMoniker Include="$(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetFramework)\Fallout.Utilities.IO.Globbing.dll" IncludeRuntimeDependency="false" />
 
       <TargetPathWithTargetPlatformMoniker Include="$(MSBuildProjectDirectory)\..\Fallout.VisualStudio.SolutionPersistence\bin\$(Configuration)\netstandard2.0\Microsoft.VisualStudio.SolutionPersistence.dll" IncludeRuntimeDependency="false" />
-      <TargetPathWithTargetPlatformMoniker Include="$(PkgNewtonsoft_Json)\lib\$(TargetFramework)\*.dll" IncludeRuntimeDependency="false" />
       <TargetPathWithTargetPlatformMoniker Include="$(PkgScriban)\lib\$(TargetFramework)\*.dll" IncludeRuntimeDependency="false" />
     </ItemGroup>
   </Target>


### PR DESCRIPTION
## Summary

Cleans up dead-weight Newtonsoft.Json bundling left over from the starter PR (#83, 54a16550).

The starter migrated `StronglyTypedSolutionGenerator.cs` to `System.Text.Json.Nodes` but left:
- `<PackageReference Include="Newtonsoft.Json" PrivateAssets="all" GeneratePathProperty="true" />`
- `<None Include="$(PkgNewtonsoft_Json)\lib\netstandard2.0\*.*" CopyToOutputDirectory="PreserveNewest" Visible="false" />`
- `<TargetPathWithTargetPlatformMoniker Include="$(PkgNewtonsoft_Json)\lib\$(TargetFramework)\*.dll" IncludeRuntimeDependency="false" />`

That triplet exists for the Roslyn source-generator pattern (generators load with their full dep tree from disk, so transitive runtime deps need explicit bundling). With no generator source `using Newtonsoft` anywhere in the project, the Newtonsoft.Json.dll bundle is dead weight.

STJ is shipped by the .NET 10 SDK that hosts Roslyn, so no equivalent bundling is needed for the migration target.

## Verification

- `dotnet build src/Fallout.SourceGenerators/Fallout.SourceGenerators.csproj --no-incremental` — 0 errors; `bin/Debug/netstandard2.0/` no longer contains `Newtonsoft.Json.dll`
- `dotnet build src/Shims/Nuke.Common/Nuke.Common.csproj --no-incremental` (downstream consumer of both source generators) — 0 errors
- `dotnet build tests/Nuke.Common.Shim.Tests/Nuke.Common.Shim.Tests.csproj --no-incremental` — 0 errors
- `dotnet test tests/Fallout.SourceGenerators.Tests/Fallout.SourceGenerators.Tests.csproj` — 6/6 pass, no snapshot regression

## #83 scope after this

This is one increment. Newtonsoft.Json is still referenced by:

| Project | Files using Newtonsoft | Notes |
|---|---|---|
| `Fallout.Tooling` | `Options.cs`, `ToolOptions.*`, `NuGetPackageResolver.cs`, `NpmVersionResolver.cs`, `ObjectFromFieldConverter.cs`, `ProcessExtensions.cs` | Core serialization for tool options |
| `Fallout.Utilities.Net` | `HttpRequest.Content.cs`, `HttpResponse.Body.cs` | HTTP body serialization |
| `Fallout.Utilities.Text.Json` | All 6 source files | The Newtonsoft wrapper project itself — keystone migration target |
| `Fallout.Tooling.Generator` | All Model files + `ToolSerializer.cs` | Generator template for tool wrappers — emits Newtonsoft using-statements into all 60+ `Tools/*/*.Generated.cs` files in `Fallout.Common` |
| `Fallout.Build` | `ArgumentsFromParametersFileAttribute.cs`, `SchemaUtility.cs` | Consume `NJsonSchema.NewtonsoftJson` — swap for `NJsonSchema` STJ-native |
| `Fallout.Common` | `HandleSingleFileExecutionAttribute.cs`, `CI/GitHubActions/*.cs`, `Tools/OctoVersion/OctoVersionTasks.cs`, `Tools/SignPath/SignPathTasks.cs`, `Tools/Slack/SlackTasks.cs`, `Tools/Twitter/TwitterTasks.cs`, `Tools/Teams/Teams.Extensions.cs`, ~60 `Tools/*/*.Generated.cs` | Mix of runtime + generator output |
| `Fallout.GlobalTool` | `Program.Secrets.cs`, `Program.Update.cs` | Per the #83 issue body, "GlobalTool parameters file handling" is explicit scope |

Notable wrinkle: `Fallout.Common.CI.GitHubActions.GitHubActions.GitHubEvent` is a **public `JObject` property**. Migrating it is a breaking API change — likely belongs in a separate "v11 API breaks" PR or behind a parallel `GitHubEventJson` property.

## Test plan
- [ ] CI green
- [ ] `dotnet build src/Shims/Nuke.Common/Nuke.Common.csproj` still functional (the source-generator hosting pattern depends on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)