### PR TITLE
feat(text.json): JsonObject helpers + migrate 3 pragma'd callers off Newtonsoft (#83)

### DIFF
--- a/src/Fallout.Common/CI/GitHubActions/GitHubActions.Client.cs
+++ b/src/Fallout.Common/CI/GitHubActions/GitHubActions.Client.cs
@@ -5,8 +5,8 @@
 
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using Fallout.Common.Utilities;
 using Fallout.Common.Utilities.Net;
 
@@ -22,16 +22,14 @@ public partial class GitHubActions
             .GetResponseAsync();
     }
 
-    private JObject GetJobDetails(long runId)
+    private JsonObject GetJobDetails(long runId)
     {
         var response = _httpClient.Value
             .CreateRequest(HttpMethod.Get, $"repos/{Repository}/actions/runs/{runId}/jobs")
             .GetResponse()
             .AssertSuccessfulStatusCode();
 
-#pragma warning disable CS0618 // GetBodyAsJson(JObject) retires in v11; migrate to GetBodyAsJsonObject + System.Text.Json.Nodes.JsonObject access patterns then.
-        return response.GetBodyAsJson().GetAwaiter().GetResult()
-#pragma warning restore CS0618
+        return response.GetBodyAsJsonObject().GetAwaiter().GetResult()
             .GetChildren("jobs")
             .Single(x => x.GetPropertyStringValue("name") == Job);
     }

--- a/src/Fallout.Common/Tools/Mastodon/MastodonTasks.cs
+++ b/src/Fallout.Common/Tools/Mastodon/MastodonTasks.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Fallout.Common.Tooling;
+using Fallout.Common.Utilities;
 using Fallout.Common.Utilities.Net;
 
 namespace Fallout.Common.Tools.Mastodon;
@@ -37,10 +38,8 @@ public static class MastodonTasks
                     .AddStreamContent("file", stream, Path.GetFileName(file)))
                 .GetResponseAsync();
 
-#pragma warning disable CS0618 // GetBodyAsJson(JObject) retires in v11; migrate to GetBodyAsJsonObject + System.Text.Json.Nodes.JsonObject access patterns then.
-            var json = await response.GetBodyAsJson();
-#pragma warning restore CS0618
-            return json["id"].NotNull().ToString();
+            var json = await response.GetBodyAsJsonObject();
+            return json.GetPropertyStringValue("id");
         }
 
         var mediaTasks = status.MediaFiles.Select(PostMediaFile).ToArray();

--- a/src/Fallout.Common/Tools/Slack/SlackTasks.cs
+++ b/src/Fallout.Common/Tools/Slack/SlackTasks.cs
@@ -51,9 +51,7 @@ public static class SlackTasks
             .WithJsonContent(message)
             .GetResponseAsync();
 
-#pragma warning disable CS0618 // GetBodyAsJson(JObject) retires in v11; migrate to GetBodyAsJsonObject + System.Text.Json.Nodes.JsonObject access patterns then.
-        var jobject = await response.GetBodyAsJson();
-#pragma warning restore CS0618
+        var jobject = await response.GetBodyAsJsonObject();
         var error = jobject.GetPropertyValueOrNull<string>("error");
         Assert.True(error == null, error);
 

--- a/src/Fallout.Utilities.Text.Json/JsonObject.GetChildren.cs
+++ b/src/Fallout.Utilities.Text.Json/JsonObject.GetChildren.cs
@@ -1,0 +1,31 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+
+namespace Fallout.Common.Utilities;
+
+public static partial class JsonNodeExtensions
+{
+    /// <summary>
+    /// Reads property <paramref name="name"/> as a <see cref="JsonArray"/> and returns its elements typed as <typeparamref name="T"/>.
+    /// </summary>
+    public static IEnumerable<T> GetChildren<T>(this JsonObject jsonObject, string name)
+        where T : JsonNode
+    {
+        var array = jsonObject[name] as JsonArray;
+        return array?.OfType<T>() ?? Enumerable.Empty<T>();
+    }
+
+    /// <summary>
+    /// Reads property <paramref name="name"/> as a <see cref="JsonArray"/> of <see cref="JsonObject"/> children.
+    /// </summary>
+    public static IEnumerable<JsonObject> GetChildren(this JsonObject jsonObject, string name)
+    {
+        return jsonObject.GetChildren<JsonObject>(name);
+    }
+}

--- a/src/Fallout.Utilities.Text.Json/JsonObject.GetPropertyValue.cs
+++ b/src/Fallout.Utilities.Text.Json/JsonObject.GetPropertyValue.cs
@@ -1,0 +1,43 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System.Text.Json.Nodes;
+
+namespace Fallout.Common.Utilities;
+
+public static partial class JsonNodeExtensions
+{
+    /// <summary>
+    /// Reads property <paramref name="name"/> as <typeparamref name="T"/>, returning <c>default</c> if absent.
+    /// </summary>
+    public static T GetPropertyValueOrNull<T>(this JsonObject jsonObject, string name)
+    {
+        return jsonObject[name] is JsonNode node ? node.GetValue<T>() : default;
+    }
+
+    /// <summary>
+    /// Reads property <paramref name="name"/> as <typeparamref name="T"/>, throwing if absent.
+    /// </summary>
+    public static T GetPropertyValue<T>(this JsonObject jsonObject, string name)
+    {
+        return jsonObject[name].NotNull($"Property '{name}' not found").GetValue<T>();
+    }
+
+    /// <summary>
+    /// Reads property <paramref name="name"/> as a nested <see cref="JsonObject"/>, throwing if absent.
+    /// </summary>
+    public static JsonObject GetPropertyValue(this JsonObject jsonObject, string name)
+    {
+        return jsonObject[name].NotNull($"Property '{name}' not found").AsObject();
+    }
+
+    /// <summary>
+    /// Reads property <paramref name="name"/> as a string, throwing if absent.
+    /// </summary>
+    public static string GetPropertyStringValue(this JsonObject jsonObject, string name)
+    {
+        return jsonObject.GetPropertyValue<string>(name);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the TODO loop from #165: the 3 `#pragma warning disable CS0618` blocks added there for callers of the now-obsolete `GetBodyAsJson() → Task<JObject>` are removed by switching to `GetBodyAsJsonObject() → Task<JsonObject>` and the new JsonObject-flavored extension methods.

## New JsonObject helpers (`JsonNodeExtensions` partial class)

| File | Methods | Mirror of |
|---|---|---|
| `JsonObject.GetPropertyValue.cs` | `GetPropertyValueOrNull<T>`, `GetPropertyValue<T>`, `GetPropertyValue` (→`JsonObject`), `GetPropertyStringValue` | Existing `JObject.GetPropertyValue.cs` |
| `JsonObject.GetChildren.cs` | `GetChildren<T>` (where `T : JsonNode`), `GetChildren` (→`IEnumerable<JsonObject>`) | Existing `JObject.GetChildren.cs` |

Signatures mirror the Newtonsoft-flavored `JObjectExtensions` methods so consumer migration is mechanical. The existing `JObject.*.cs` files stay intact — they're used by no internal caller now but kept until the v11 cleanup (no point churning if there are external consumers).

## Migrated callers (3)

| File | Pattern |
|---|---|
| `Tools/Mastodon/MastodonTasks.cs` | `GetBodyAsJsonObject` + `GetPropertyStringValue("id")` (replaces the surprising `json["id"].NotNull().ToString()` Newtonsoft idiom which doesn't translate 1:1 to JsonNode — JsonValue.ToString() wraps strings in quotes) |
| `Tools/Slack/SlackTasks.cs` | `GetBodyAsJsonObject` + `GetPropertyValueOrNull<string>("error")` + `GetPropertyStringValue("ts")` |
| `CI/GitHubActions/GitHubActions.Client.cs` | Return type of `GetJobDetails` changed from `JObject` to `JsonObject`. Uses `GetBodyAsJsonObject` + `GetChildren("jobs")` + `GetPropertyStringValue("name")`. Downstream `GetJobId` (calls `.GetPropertyValue<long>("id")` on the result) works unchanged because the new JsonObject extension has the same shape. |

All 3 `#pragma warning disable CS0618` blocks are now removed.

## Out of scope (still needs Newtonsoft)

- The `JObject`-typed `GitHubActions.GitHubEvent` public property (in `GitHubActions.cs`, not `.Client.cs`) — separate v11 API-break PR
- `Fallout.Tooling` runtime serialization (8+ files)
- `Fallout.Build` NJsonSchema swap (2 files)
- `Fallout.Tooling.Generator` + ~60 emitted `Tools/*/*.Generated.cs` files

## Verification

- `dotnet build src/Fallout.Utilities.Text.Json/Fallout.Utilities.Text.Json.csproj` — 0 errors
- `dotnet build src/Fallout.Common/Fallout.Common.csproj` — 0 errors (3 callers migrated cleanly)
- `dotnet build fallout.slnx` — 0 errors across whole solution
- `tests/Fallout.SourceGenerators.Tests` — 6/6 pass

## Test plan
- [ ] CI green
- [ ] No CS0618 warnings emitted from `Fallout.Common.csproj` (suppressions removed)
- [ ] Existing JObject-flavored `JObjectExtensions` methods stay accessible to external consumers (no breaking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)