### PR TITLE
chore(text.json): [Obsolete] remaining Newtonsoft surface + migrate SignPathTasks (#83)

### DIFF
--- a/src/Fallout.Common/CI/GitHubActions/GitHubActions.cs
+++ b/src/Fallout.Common/CI/GitHubActions/GitHubActions.cs
@@ -114,8 +114,10 @@ public partial class GitHubActions : Host, IBuildServer
 
     public JObject GitHubEvent => _eventContext.Value;
     public bool IsPullRequest => EventName == "pull_request";
+#pragma warning disable CS0618 // JObjectExtensions retires in v11; PullRequestNumber/Action follow when GitHubEvent migrates to JsonObject (API-break, separate PR).
     public int? PullRequestNumber => GitHubEvent.GetPropertyValue<int>("number");
     public string PullRequestAction => GitHubEvent.GetPropertyStringValue("action");
+#pragma warning restore CS0618
 
     public AbsolutePath StepSummaryFile => EnvironmentInfo.GetVariable("GITHUB_STEP_SUMMARY");
 

--- a/src/Fallout.Common/Tools/SignPath/SignPathTasks.cs
+++ b/src/Fallout.Common/Tools/SignPath/SignPathTasks.cs
@@ -10,8 +10,8 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using Fallout.Common.CI.AppVeyor;
 using Fallout.Common.IO;
 using Fallout.Common.Utilities;
@@ -71,7 +71,7 @@ public static class SignPathTasks
             using var httpClient = CreateAuthorizedHttpClient(authToken, DefaultHttpClientTimeout);
             var response = await httpClient.PostAsync(
                 GetSignPathAppVeyorIntegrationUrl(organizationId, projectSlug, signingPolicySlug),
-                new StringContent(content.ToJson(), Encoding.UTF8, contentType));
+                new StringContent(content.ToJson(JsonExtensions.DefaultSerializerOptions), Encoding.UTF8, contentType));
             response.AssertStatusCode(HttpStatusCode.Created);
 
             Log.Information("Signing request created: {Url}", response.Headers.Location.AbsoluteUri.Replace("api/v1", "Web"));
@@ -149,11 +149,11 @@ public static class SignPathTasks
             {
                 var response = SendGetRequestWithRetry(httpClient, signingRequestUrl);
                 var rawContent = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                var jsonContent = rawContent.GetJson();
-                signingRequestStatus = jsonContent["status"].NotNull().Value<string>();
+                var jsonContent = rawContent.GetJsonObject();
+                signingRequestStatus = jsonContent["status"].NotNull().GetValue<string>();
                 signedArtifactUrl = signingRequestStatus switch
                 {
-                    SigningRequestStatus.Completed => jsonContent["signedArtifactLink"].NotNull().Value<string>(),
+                    SigningRequestStatus.Completed => jsonContent["signedArtifactLink"].NotNull().GetValue<string>(),
                     SigningRequestStatus.Failed => null,
                     SigningRequestStatus.Denied => null,
                     SigningRequestStatus.Cancelled => null,
@@ -255,8 +255,8 @@ public static class SignPathTasks
         if (response.StatusCode != statusCode)
         {
             var content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-            var jobject = content.GetJson();
-            Assert.Fail($"[{response.StatusCode}] {jobject.GetChildren<JValue>("").Select(x => x.Value<string>()).JoinNewLine()}");
+            var jobject = content.GetJsonObject();
+            Assert.Fail($"[{response.StatusCode}] {jobject.GetChildren<JsonValue>("").Select(x => x.GetValue<string>()).JoinNewLine()}");
         }
 
         return response;

--- a/src/Fallout.Tooling/ProcessExtensions.cs
+++ b/src/Fallout.Tooling/ProcessExtensions.cs
@@ -52,7 +52,9 @@ public static class ProcessExtensions
 
     public static T StdToJson<T>(this IEnumerable<Output> output)
     {
+#pragma warning disable CS0618 // GetJson<T>(Newtonsoft) retires in v11; this whole StdToJson surface is part of the Fallout.Tooling migration follow-up.
         return output.StdToText().GetJson<T>();
+#pragma warning restore CS0618
     }
 
     public static JObject StdToJson(this IEnumerable<Output> output)

--- a/src/Fallout.Utilities.Text.Json/AllWritableContractResolver.cs
+++ b/src/Fallout.Utilities.Text.Json/AllWritableContractResolver.cs
@@ -14,6 +14,7 @@ namespace Fallout.Common.Tooling;
 /// <summary>
 /// Treats all properties as writable.
 /// </summary>
+[Obsolete("Newtonsoft-specific contract resolver. System.Text.Json handles records and init-only properties natively, so this workaround is unnecessary on the STJ path. Scheduled for removal in v11 (#83).")]
 internal class AllWritableContractResolver : DefaultContractResolver
 {
     protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)

--- a/src/Fallout.Utilities.Text.Json/Base64JsonConverter.cs
+++ b/src/Fallout.Utilities.Text.Json/Base64JsonConverter.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 
 namespace Fallout.Utilities.Text.Json;
 
+[Obsolete("Newtonsoft-specific Base64 JSON type converter with zero internal callers. Scheduled for removal in v11 (#83); consumers needing this should pin Newtonsoft.Json directly.")]
 public class Base64JsonConverter<T> : TypeConverter
 {
     public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)

--- a/src/Fallout.Utilities.Text.Json/JObject.GetChildren.cs
+++ b/src/Fallout.Utilities.Text.Json/JObject.GetChildren.cs
@@ -3,20 +3,27 @@
 // Distributed under the MIT License.
 // https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
 
+using System;
 using Newtonsoft.Json.Linq;
 
 namespace Fallout.Common.Utilities;
 
 public static partial class JObjectExtensions
 {
+    [Obsolete("Use the JsonObject overload in JsonNodeExtensions instead. Newtonsoft.Json surface is scheduled for removal in v11 (#83).")]
     public static JEnumerable<T> GetChildren<T>(this JObject jobject, string name)
         where T : JToken
     {
+#pragma warning disable CS0618 // Newtonsoft helpers retire together.
         return jobject.GetPropertyValue<JArray>(name).Children<T>();
+#pragma warning restore CS0618
     }
 
+    [Obsolete("Use the JsonObject overload in JsonNodeExtensions instead. Newtonsoft.Json surface is scheduled for removal in v11 (#83).")]
     public static JEnumerable<JObject> GetChildren(this JObject jobject, string name)
     {
+#pragma warning disable CS0618 // Newtonsoft helpers retire together.
         return jobject.GetChildren<JObject>(name);
+#pragma warning restore CS0618
     }
 }

--- a/src/Fallout.Utilities.Text.Json/JObject.GetPropertyValue.cs
+++ b/src/Fallout.Utilities.Text.Json/JObject.GetPropertyValue.cs
@@ -11,6 +11,7 @@ namespace Fallout.Common.Utilities;
 
 public static partial class JObjectExtensions
 {
+    [Obsolete("Use the JsonObject overload in JsonNodeExtensions instead. Newtonsoft.Json surface is scheduled for removal in v11 (#83).")]
     public static T GetPropertyValueOrNull<T>(this JObject jobject, string name)
     {
         var property = jobject.Property(name);
@@ -19,19 +20,26 @@ public static partial class JObjectExtensions
             : default;
     }
 
+    [Obsolete("Use the JsonObject overload in JsonNodeExtensions instead. Newtonsoft.Json surface is scheduled for removal in v11 (#83).")]
     public static T GetPropertyValue<T>(this JObject jobject, string name)
     {
         var property = jobject.Property(name).NotNull($"Property '{name}' not found");
         return property.Value.Value<T>();
     }
 
+    [Obsolete("Use the JsonObject overload in JsonNodeExtensions instead. Newtonsoft.Json surface is scheduled for removal in v11 (#83).")]
     public static JObject GetPropertyValue(this JObject jobject, string name)
     {
+#pragma warning disable CS0618 // Newtonsoft helpers retire together.
         return jobject.GetPropertyValue<JObject>(name);
+#pragma warning restore CS0618
     }
 
+    [Obsolete("Use the JsonObject overload in JsonNodeExtensions instead. Newtonsoft.Json surface is scheduled for removal in v11 (#83).")]
     public static string GetPropertyStringValue(this JObject jobject, string name)
     {
+#pragma warning disable CS0618 // Newtonsoft helpers retire together.
         return jobject.GetPropertyValue<string>(name);
+#pragma warning restore CS0618
     }
 }

--- a/src/Fallout.Utilities.Text.Json/JsonExtensions.cs
+++ b/src/Fallout.Utilities.Text.Json/JsonExtensions.cs
@@ -17,6 +17,8 @@ namespace Fallout.Common.Utilities;
 
 public static class JsonExtensions
 {
+    [Obsolete("Use DefaultSerializerOptions (JsonSerializerOptions) instead. Newtonsoft.Json surface is scheduled for removal in v11 (#83).")]
+#pragma warning disable CS0618 // AllWritableContractResolver retires alongside.
     public static JsonSerializerSettings DefaultSerializerSettings =
         new()
         {
@@ -24,6 +26,7 @@ public static class JsonExtensions
             DefaultValueHandling = DefaultValueHandling.Ignore,
             ContractResolver = new AllWritableContractResolver()
         };
+#pragma warning restore CS0618
 
     public static JsonSerializerOptions DefaultSerializerOptions { get; } =
         new()
@@ -46,7 +49,9 @@ public static class JsonExtensions
         JsonSerializerSettings serializerSettings = null,
         Formatting formatting = Formatting.Indented)
     {
+#pragma warning disable CS0618 // DefaultSerializerSettings retires alongside.
         return JsonConvert.SerializeObject(obj, formatting, serializerSettings ?? DefaultSerializerSettings);
+#pragma warning restore CS0618
     }
 
     /// <summary>
@@ -55,7 +60,9 @@ public static class JsonExtensions
     [Obsolete("Use the JsonSerializerOptions overload instead. Newtonsoft.Json surface is scheduled for removal in v11 as part of the System.Text.Json migration (#83).")]
     public static T GetJson<T>(this string content, JsonSerializerSettings serializerSettings = null)
     {
+#pragma warning disable CS0618 // DefaultSerializerSettings retires alongside.
         return JsonConvert.DeserializeObject<T>(content, serializerSettings ?? DefaultSerializerSettings);
+#pragma warning restore CS0618
     }
 
     /// <summary>

--- a/src/Fallout.Utilities.Text.Json/Object.ToJObject.cs
+++ b/src/Fallout.Utilities.Text.Json/Object.ToJObject.cs
@@ -18,6 +18,7 @@ namespace Fallout.Common.Utilities;
 // invisible to callers and a rename is the cleanest fix.
 public static class JsonObjectExtensions
 {
+    [Obsolete("Returns a Newtonsoft JObject. For new code, use System.Text.Json.Nodes.JsonNode.Parse(System.Text.Json.JsonSerializer.Serialize(obj)) or JsonSerializer.SerializeToNode(obj). Scheduled for removal in v11 (#83).")]
     public static JObject ToJObject(this object obj, JsonSerializer serializer = null)
     {
         serializer ??= JsonSerializer.CreateDefault();

--- a/src/Shims/Nuke.Common/Nuke.Common.csproj
+++ b/src/Shims/Nuke.Common/Nuke.Common.csproj
@@ -18,6 +18,12 @@
     <!-- Disable XML doc generation here; Directory.Build.props turns it on for packable projects,
          but the shim types' XML docs are intentionally minimal (point at the canonical type). -->
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <!-- Suppress CS0618 on the generated shim source. The TransitionShimGenerator emits delegations
+         to canonical methods, and any canonical method marked [Obsolete] propagates the warning into
+         the auto-generated shim body. Consumers calling the canonical type directly still see the
+         [Obsolete] guidance; this NoWarn just keeps the shim project's build clean. Track propagating
+         [Obsolete] through the generator as a v11 follow-up. -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Fallout.Common.Tests/SettingsTest.cs
+++ b/tests/Fallout.Common.Tests/SettingsTest.cs
@@ -173,6 +173,7 @@ public class SettingsTest
     [Fact]
     public Task TestDiscord()
     {
+#pragma warning disable CS0618 // Test pins Options.JsonSerializerSettings round-trip; STJ equivalents follow in Fallout.Tooling's #83 migration.
         var result = new DiscordMessage()
             .SetNonce("nonce")
             .SetChannelId("channel-id")
@@ -181,6 +182,7 @@ public class SettingsTest
                 .SetAuthor(_ => _
                     .SetName("author-name")))
             .ToJson(Options.JsonSerializerSettings);
+#pragma warning restore CS0618
 
         return Verifier.Verify(result);
     }

--- a/tests/Fallout.Tooling.Tests/OptionsTest.cs
+++ b/tests/Fallout.Tooling.Tests/OptionsTest.cs
@@ -147,7 +147,9 @@ public class OptionsTest
         options.Set(() => LookupValue, new LookupTable<string, int> { ["key"] = new[] { 1, 2, 3 } });
         options.Set(() => NestedValue, options);
 
+#pragma warning disable CS0618 // Test pins Options.JsonSerializerSettings round-trip; STJ equivalents follow in Fallout.Tooling's #83 migration.
         return Verifier.Verify(options.ToJson(Options.JsonSerializerSettings));
+#pragma warning restore CS0618
     }
 }
 

--- a/tests/Fallout.Tooling.Tests/ToolOptionsArgumentsTest.cs
+++ b/tests/Fallout.Tooling.Tests/ToolOptionsArgumentsTest.cs
@@ -191,7 +191,9 @@ public class ToolOptionsArgumentsTest
         where T : ToolOptions, new()
     {
         var options = new T();
+#pragma warning disable CS0618 // ToJObject (Newtonsoft) retires in v11 alongside ToolOptions.InternalOptions which is itself JObject-typed.
         options.InternalOptions = obj.ToJObject(Options.JsonSerializer);
+#pragma warning restore CS0618
         return options;
     }
 }

--- a/tests/Fallout.Utilities.Tests/Text/SerializationTest.cs
+++ b/tests/Fallout.Utilities.Tests/Text/SerializationTest.cs
@@ -20,8 +20,10 @@ public class SerializationTest
     public void JsonTest()
     {
         var data = CreateData("Json");
+#pragma warning disable CS0618 // Test pins Newtonsoft round-trip semantics; STJ equivalents will get their own test cases in v11.
         var content = data.ToJson();
         var copy = content.GetJson<Data>();
+#pragma warning restore CS0618
 
         copy.Should().BeEquivalentTo(data);
     }


### PR DESCRIPTION
## Summary

Originally scoped as a dead-code sweep — turned into a sweep + v11-marking PR after verification showed every candidate type has internal callers that need either migration or pragma suppression.

## What's marked [Obsolete] for v11 removal

**Public surface in Fallout.Utilities.Text.Json:**
- `JObjectExtensions` — all 6 methods (`GetChildren<T>`, `GetChildren`, `GetPropertyValueOrNull<T>`, `GetPropertyValue<T>`, `GetPropertyValue`, `GetPropertyStringValue`)
- `JsonObjectExtensions.ToJObject(object, JsonSerializer)` — the lone method on the renamed class (the rename in #145 was unrelated to its Newtonsoft nature)
- `AllWritableContractResolver` — internal class, Newtonsoft contract resolver
- `Base64JsonConverter<T>` — public class, zero internal callers
- `JsonExtensions.DefaultSerializerSettings` — the Newtonsoft settings field (paired with `DefaultSerializerOptions` from #166)

After this PR, **every Newtonsoft-typed surface in `Fallout.Utilities.Text.Json` is `[Obsolete]`**. The STJ overloads from #166 + the JsonObject helpers from #169 are the unmarked path forward.

## Migrations

- **`Fallout.Common.Tools.SignPath.SignPathTasks.cs`** — fully migrated to STJ. Drops `using Newtonsoft.Json.Linq;`. Lines 75 (`.ToJson()` body content) and 152-156 (`.GetJson()` + `JToken.Value<string>()` property reads) now use `JsonExtensions.DefaultSerializerOptions` / `.GetJsonObject()` / `JsonNode.GetValue<T>()`.

## Pragma suppressions (with TODO pointing at the v11 cutover)

Each is part of a separate workstream that should ultimately remove the suppression:

| File | Why suppressed |
|---|---|
| `src/Fallout.Common/CI/GitHubActions/GitHubActions.cs:117-118` | `PullRequestNumber`/`Action` use `JObjectExtensions` on the public `JObject GitHubEvent` property. Migrating the property is a breaking API change scheduled for v11. |
| `src/Fallout.Tooling/ProcessExtensions.cs:55` | `StdToJson<T>` delegates to `GetJson<T>(Newtonsoft)`. Part of the `Fallout.Tooling` migration follow-up. |
| `tests/Fallout.Common.Tests/SettingsTest.cs` | Discord test pins Newtonsoft round-trip. |
| `tests/Fallout.Tooling.Tests/OptionsTest.cs:150` | Pins `Options.JsonSerializerSettings` round-trip. |
| `tests/Fallout.Tooling.Tests/ToolOptionsArgumentsTest.cs:194` | `ToJObject` writes into `JObject`-typed `InternalOptions` (part of the Tooling migration). |
| `tests/Fallout.Utilities.Tests/Text/SerializationTest.cs:23-24` | Pins Newtonsoft serialization round-trip. |

## Shim project NoWarn

`src/Shims/Nuke.Common/Nuke.Common.csproj` adds `CS0618` to `NoWarn`. The `TransitionShimGenerator` auto-emits delegations to canonical methods; when those methods are `[Obsolete]`, the auto-generated shim body produces CS0618. Consumers calling the canonical type directly still see `[Obsolete]` guidance; this `NoWarn` just keeps the shim project's own build clean. Propagating `[Obsolete]` semantics through the generator is a v11 follow-up.

## Verification

- `dotnet build fallout.slnx` — 0 errors across whole solution
- `dotnet test tests/Fallout.SourceGenerators.Tests/Fallout.SourceGenerators.Tests.csproj` — 6/6 pass
- No leftover unsuppressed CS0618 warnings

## Test plan
- [ ] CI green
- [ ] External consumer of `Nuke.Common` (via the shim) sees no new warnings
- [ ] Consumer calling `Fallout.Common.Utilities.JObjectExtensions.GetChildren` directly sees the new `[Obsolete]` warning pointing at the v11 cutover

🤖 Generated with [Claude Code](https://claude.com/claude-code)