### PR TITLE
feat(build)!: rewrite SchemaUtility on STJ — drop NJsonSchema (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Breaking changes
 
+- **`SchemaUtility` rewritten on `System.Text.Json` — NJsonSchema gone** (#114, STJ-1 of #83). The build-parameter schema generator (which emits `.fallout/build.schema.json` for editor autocomplete) no longer goes through NJsonSchema. It now hand-rolls the draft-04 schema using `JsonNode`/`JsonObject` directly — same output shape, no Rico-entanglement.
+  - **Dropped packages**: `NJsonSchema`, `NJsonSchema.NewtonsoftJson`, `NJsonSchema.Annotations`, `Namotion.Reflection` — four packages and ~12 transitive dependencies gone from `Fallout.Build`. `Newtonsoft.Json` stays in the closure only via `Fallout.Common`'s `*Tasks.cs` (Slack/Twitter/Teams) until #119 lands.
+  - **API**: `SchemaUtility.GetJsonString(IFalloutBuild)` and `GetJsonDocument(IFalloutBuild)` unchanged for consumers.
+  - **Behavior preserved**: well-known definitions in canonical order (Host, ExecutableTarget, Verbosity, FalloutBuild), `allOf:[user, base]` envelope, `[CustomParameter]` subclasses render as plain string (not recursive), value-type `Nullable<T>` → `[T, "null"]`, reference-type nullables → `["null", T]` for primitives / `oneOf [null, $ref]` for refs, `[TypeConverter]`-attributed types (AbsolutePath, Solution, etc.) render as `"string"`.
+
 - **`Fallout.Tooling` engine migrated to System.Text.Json** (#117 STJ-4, #118 STJ-5). The tool-options ↔ JSON layer that powers every tool wrapper is now STJ-native:
   - `Options.InternalOptions` is now `System.Text.Json.Nodes.JsonObject` (was Newtonsoft `JObject`). `Options.JsonSerializer` and `Options.JsonSerializerSettings` are gone — use `Options.SerializerOptions` (`JsonSerializerOptions`) instead.
   - The Options→InternalOptions converter is now a `JsonConverterFactory` registered on `SerializerOptions.Converters` (STJ doesn't inherit class-level `[JsonConverter]` attributes onto subclasses). `LookupTable<,>` round-trips through a parallel `ObjectFromFieldConverter` factory; `Enumeration` subclasses go through a new `EnumerationJsonConverterFactory` that bridges `[TypeConverter]`-attributed types (which STJ doesn't honour natively).

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,6 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="NJsonSchema" Version="11.5.2" />
-    <PackageVersion Include="NJsonSchema.NewtonsoftJson" Version="11.5.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NuGet.Packaging" Version="6.14.3" />
     <PackageVersion Include="Octokit" Version="14.0.0" />

--- a/src/Fallout.Build/Fallout.Build.csproj
+++ b/src/Fallout.Build/Fallout.Build.csproj
@@ -18,8 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />
-    <PackageReference Include="NJsonSchema" />
-    <PackageReference Include="NJsonSchema.NewtonsoftJson" />
     <PackageReference Include="Serilog.Formatting.Compact" />
     <PackageReference Include="Serilog.Formatting.Compact.Reader" />
     <PackageReference Include="Serilog.Sinks.Console" />

--- a/src/Fallout.Build/Utilities/SchemaUtility.cs
+++ b/src/Fallout.Build/Utilities/SchemaUtility.cs
@@ -1,170 +1,388 @@
-﻿// Copyright 2026 Maintainers of Fallout.
+// Copyright 2026 Maintainers of Fallout.
 // Originally based on NUKE by Matthias Koch and contributors.
 // Distributed under the MIT License.
 // https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
+using System.Text.Encodings.Web;
 using System.Text.Json;
-using Namotion.Reflection;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
-using NJsonSchema;
-using NJsonSchema.Generation;
-using NJsonSchema.NewtonsoftJson.Generation;
-using NuGet.Packaging;
+using System.Text.Json.Nodes;
+using Fallout.Common.IO;
+using Fallout.Common.Tooling;
 using Fallout.Common.Utilities;
 using Fallout.Common.ValueInjection;
 using static Fallout.Common.Constants;
 
 namespace Fallout.Common.Execution;
 
-public class SchemaUtility
+/// <summary>
+/// Generates a draft-04 JSON Schema for a build's <c>[Parameter]</c>-attributed members so editors
+/// can autocomplete and validate the consumer's <c>parameters.json</c>. Hand-rolled on top of
+/// <see cref="JsonNode"/> — no NJsonSchema, no Newtonsoft. The output shape is the draft-04 envelope
+/// the NUKE ecosystem has emitted since day one (definitions block + allOf[user, base]).
+/// </summary>
+public static class SchemaUtility
 {
-    private class SchemaGenerator : JsonSchemaGenerator
+    private const string DraftSchema = "http://json-schema.org/draft-04/schema#";
+    private const string DefinitionsPrefix = "#/definitions/";
+
+    private static readonly JsonSerializerOptions s_writeOptions = new()
     {
-        private class Resolver : DefaultContractResolver
-        {
-            protected override List<MemberInfo> GetSerializableMembers(Type objectType)
-            {
-                return objectType == typeof(ExecutableTarget) || objectType == typeof(Host)
-                    ? new List<MemberInfo>()
-                    : base.GetSerializableMembers(objectType);
-            }
-        }
-
-        public static JsonSchema Generate<T>(T build) where T : IFalloutBuild
-        {
-            return new SchemaGenerator(
-                build,
-                new NewtonsoftJsonSchemaGeneratorSettings
-                {
-                    FlattenInheritanceHierarchy = true,
-                    SerializerSettings =
-                        new JsonSerializerSettings
-                        {
-                            ContractResolver = new Resolver(),
-                            Converters = new JsonConverter[] { new StringEnumConverter() }
-                        }
-                }).Generate();
-        }
-
-        private readonly IFalloutBuild _build;
-
-        private SchemaGenerator(IFalloutBuild build, JsonSchemaGeneratorSettings settings)
-            : base(settings)
-        {
-            _build = build;
-        }
-
-        private JsonSchema Generate()
-        {
-            var topLevelSchema = new JsonSchema();
-            var baseSchema = new JsonSchema();
-            var userSchema = new JsonSchema();
-            var schemaResolver = new JsonSchemaResolver(topLevelSchema, Settings);
-
-            var parameterMembers = ValueInjectionUtility.GetParameterMembers(_build.GetType(), includeUnlisted: true);
-            foreach (var parameterMember in parameterMembers)
-            {
-                var schema = parameterMember.DeclaringType == typeof(FalloutBuild) ? baseSchema : userSchema;
-                var name = ParameterService.GetParameterMemberName(parameterMember);
-                var property = CreateProperty(parameterMember, schemaResolver);
-                schema.Properties[name] = property;
-            }
-
-            // ValueInjectionUtility.GetParameterMembers(_build.GetType(), includeUnlisted: true)
-            //     // .Where(x => x.Name.EqualsAnyOrdinalIgnoreCase(
-            //     //     nameof(FalloutBuild.SkippedTargets),
-            //     //     nameof(FalloutBuild.InvokedTargets),
-            //     //     nameof(FalloutBuild.Verbosity)
-            //     // ))
-            //     .ToDictionary(ParameterService.GetParameterMemberName, x => CreateProperty(x, schemaResolver))
-            //     .ForEach(x =>
-            //     {
-            //         baseSchema.Properties[x.Key] = x.Value;
-            //     });
-
-            // TODO: why can't this use value sets?
-            var targetNames = ExecutableTargetFactory.GetTargetProperties(_build.GetType()).Select(x => x.GetDisplayShortName()).OrderBy(x => x);
-            var executableTargetSchema = UpdatePropertySchema(nameof(ExecutableTarget), targetNames);
-            baseSchema.Properties[InvokedTargetsParameterName].Item =
-                baseSchema.Properties[SkippedTargetsParameterName].Item = new JsonSchema { Reference = executableTargetSchema };
-
-            var hostNames = Host.AvailableTypes.Select(x => x.Name).OrderBy(x => x);
-            var hostSchema = UpdatePropertySchema(nameof(FalloutBuild.Host), hostNames);
-            baseSchema.Properties[nameof(FalloutBuild.Host)].Reference = hostSchema;
-
-            RemoveXEnumValues();
-
-            topLevelSchema.AllOf.Add(userSchema);
-            topLevelSchema.AllOf.Add(new JsonSchema { Reference = baseSchema });
-            topLevelSchema.Definitions[nameof(FalloutBuild)] = baseSchema;
-            return topLevelSchema;
-
-            JsonSchema UpdatePropertySchema(string name, IEnumerable<string> values)
-            {
-                var schema = topLevelSchema.Definitions[name];
-                schema.Type = JsonObjectType.String;
-                schema.AllowAdditionalProperties = true;
-                schema.Enumeration.AddRange(values);
-                return schema;
-            }
-
-            void RemoveXEnumValues()
-            {
-                foreach (var definition in topLevelSchema.Definitions.Values)
-                {
-                    definition.EnumerationNames.Clear();
-                    definition.AllowAdditionalProperties = true;
-                }
-            }
-        }
-
-        private JsonSchemaProperty CreateProperty(MemberInfo parameterMember, JsonSchemaResolver schemaResolver)
-        {
-            var property = parameterMember.GetCustomAttribute<ParameterAttribute>().NotNull().GetType() == typeof(ParameterAttribute)
-                ? GenerateWithReference<JsonSchemaProperty>(
-                    parameterMember.ToContextualAccessor().AccessorType,
-                    schemaResolver)
-                : new JsonSchemaProperty { Type = JsonObjectType.String };
-
-            property.Description = ParameterService.GetParameterDescription(parameterMember);
-            property.Default = parameterMember.HasCustomAttribute<SecretAttribute>()
-                ? "Secrets must be entered via 'nuke :secrets [profile]'"
-                : null;
-
-            var values = ParameterService.GetParameterValueSet(parameterMember, _build)
-                ?.Select(x => (object)x.Text);
-            if (values != null && !parameterMember.GetMemberType().IsEnum)
-            {
-                property.Type = !parameterMember.GetMemberType().IsCollectionLike()
-                    ? JsonObjectType.String
-                    : JsonObjectType.Array;
-                var propertySchema = property.Reference ?? property;
-                if (property.Type == JsonObjectType.String)
-                    propertySchema.Enumeration.AddRange(values);
-                else
-                    propertySchema.Item.Enumeration.AddRange(values);
-            }
-
-            if (Nullable.GetUnderlyingType(parameterMember.GetMemberType()) != null)
-                property.Type |= JsonObjectType.Null;
-
-            return property;
-        }
-    }
+        WriteIndented = true,
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
 
     public static string GetJsonString(IFalloutBuild build)
     {
-        return SchemaGenerator.Generate(build).ToJson();
+        // Trailing newline matches the legacy NJsonSchema output that consumer-side tooling expects.
+        return BuildSchema(build).ToJsonString(s_writeOptions) + "\n";
     }
 
     public static JsonDocument GetJsonDocument(IFalloutBuild build)
     {
         return JsonDocument.Parse(GetJsonString(build));
+    }
+
+    private static JsonObject BuildSchema(IFalloutBuild build)
+    {
+        var ctx = new SchemaContext();
+
+        // Pre-seed the "well-known" definitions in the legacy order: Host, ExecutableTarget, Verbosity, FalloutBuild.
+        var hostNames = Host.AvailableTypes.Select(x => x.Name).OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList();
+        ctx.Definitions["Host"] = StringEnumSchema(hostNames);
+
+        var targetNames = ExecutableTargetFactory.GetTargetProperties(build.GetType())
+            .Select(x => x.GetDisplayShortName())
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        ctx.Definitions["ExecutableTarget"] = targetNames.Count == 0
+            ? new JsonObject { ["type"] = "string" }
+            : StringEnumSchema(targetNames);
+
+        ctx.Definitions["Verbosity"] = new JsonObject
+        {
+            ["type"] = "string",
+            ["description"] = string.Empty,
+            ["enum"] = new JsonArray("Verbose", "Normal", "Minimal", "Quiet")
+        };
+
+        // Build the FalloutBuild base schema (all framework-level parameters) and the user extension
+        // schema (consumer-defined parameters). Parameters declared on FalloutBuild itself go into the
+        // base; everything else into user.
+        var baseSchema = new JsonObject();
+        var baseProperties = new JsonObject();
+        baseSchema["properties"] = baseProperties;
+
+        var userSchema = new JsonObject();
+        JsonObject userProperties = null;
+
+        foreach (var member in ValueInjectionUtility.GetParameterMembers(build.GetType(), includeUnlisted: true))
+        {
+            var name = ParameterService.GetParameterMemberName(member);
+            var property = BuildPropertySchema(member, build, ctx);
+            if (member.DeclaringType == typeof(FalloutBuild))
+            {
+                baseProperties[name] = property;
+            }
+            else
+            {
+                userProperties ??= new JsonObject();
+                userProperties[name] = property;
+            }
+        }
+
+        if (userProperties != null)
+            userSchema["properties"] = userProperties;
+
+        // Force the framework parameters Skip/Target to reference the ExecutableTarget definition.
+        if (baseProperties[InvokedTargetsParameterName] is JsonObject targetProp)
+            targetProp["items"] = new JsonObject { ["$ref"] = DefinitionsPrefix + "ExecutableTarget" };
+        if (baseProperties[SkippedTargetsParameterName] is JsonObject skipProp)
+            skipProp["items"] = new JsonObject { ["$ref"] = DefinitionsPrefix + "ExecutableTarget" };
+        ReplaceWithRef(baseProperties, nameof(FalloutBuild.Host), "Host");
+        ReplaceWithRef(baseProperties, nameof(FalloutBuild.Verbosity), "Verbosity");
+
+        ctx.Definitions[nameof(FalloutBuild)] = baseSchema;
+
+        // Compose the final document in the legacy definition order: complex types first, then the
+        // well-known ones, then FalloutBuild. Pre-seeded definitions get re-emitted in the order they
+        // were added — JsonObject preserves insertion order — so we move complex types to the front.
+        var orderedDefinitions = new JsonObject();
+        foreach (var kvp in ctx.Definitions.Where(x => !IsWellKnownDefinition(x.Key)))
+            orderedDefinitions[kvp.Key] = kvp.Value;
+        foreach (var key in new[] { "Host", "ExecutableTarget", "Verbosity", nameof(FalloutBuild) })
+        {
+            if (ctx.Definitions.TryGetValue(key, out var value))
+                orderedDefinitions[key] = value;
+        }
+
+        return new JsonObject
+        {
+            ["$schema"] = DraftSchema,
+            ["definitions"] = orderedDefinitions,
+            ["allOf"] = new JsonArray(
+                userSchema,
+                new JsonObject { ["$ref"] = DefinitionsPrefix + nameof(FalloutBuild) })
+        };
+    }
+
+    private static JsonObject ReorderArraySchemaWithDescription(JsonObject schema, string description)
+    {
+        var ordered = new JsonObject();
+        foreach (var (key, value) in schema.ToList())
+        {
+            schema.Remove(key);
+            if (key == "items")
+                ordered["description"] = description;
+            ordered[key] = value;
+        }
+        return ordered;
+    }
+
+    private static void ReplaceWithRef(JsonObject properties, string propertyName, string definitionName)
+    {
+        if (properties[propertyName] is not JsonObject existing)
+            return;
+        var description = existing["description"]?.GetValue<string>();
+        var replacement = new JsonObject();
+        if (description != null)
+            replacement["description"] = description;
+        replacement["$ref"] = DefinitionsPrefix + definitionName;
+        properties[propertyName] = replacement;
+    }
+
+    private static bool IsWellKnownDefinition(string name)
+    {
+        return name is "Host" or "ExecutableTarget" or "Verbosity" or nameof(FalloutBuild);
+    }
+
+    private static JsonObject StringEnumSchema(IEnumerable<string> values)
+    {
+        return new JsonObject
+        {
+            ["type"] = "string",
+            ["enum"] = new JsonArray(values.Select(v => (JsonNode)v).ToArray())
+        };
+    }
+
+    private static JsonObject BuildPropertySchema(MemberInfo member, IFalloutBuild build, SchemaContext ctx)
+    {
+        var memberType = member.GetMemberType();
+        // Only the exact-typed [Parameter] attribute drives a recursive schema for the member's type.
+        // Subclasses of ParameterAttribute (e.g. [CustomParameter]) render the member as plain "string".
+        var attributeType = member.GetCustomAttribute<ParameterAttribute>().NotNull().GetType();
+        var schema = attributeType == typeof(ParameterAttribute)
+            ? SchemaForType(memberType, ctx)
+            : new JsonObject { ["type"] = "string" };
+
+        var description = ParameterService.GetParameterDescription(member);
+        if (description != null)
+        {
+            // Match legacy layout: for array schemas, description sits between "type" and "items".
+            // For everything else (string, $ref, etc.), description goes at the end.
+            if (schema.ContainsKey("items"))
+            {
+                schema = ReorderArraySchemaWithDescription(schema, description);
+            }
+            else
+            {
+                schema["description"] = description;
+            }
+        }
+
+        if (member.HasCustomAttribute<SecretAttribute>())
+            schema["default"] = "Secrets must be entered via 'nuke :secrets [profile]'";
+
+        // Override-with-enumeration: parameters with a value set become string enums (or array-of-string-enums).
+        var valueSet = ParameterService.GetParameterValueSet(member, build)?.Select(x => x.Text).ToList();
+        if (valueSet != null && !memberType.IsEnum)
+        {
+            var collection = memberType.IsCollectionLike();
+            var enumSchema = collection
+                ? new JsonObject { ["type"] = "array", ["items"] = StringEnumSchema(valueSet) }
+                : StringEnumSchema(valueSet);
+            // Preserve the description we just set.
+            if (schema["description"] is JsonNode desc)
+                enumSchema["description"] = desc.GetValue<string>();
+            schema = enumSchema;
+        }
+
+        // Surface nullability for value types as [T, "null"] (matches the legacy NJsonSchema shape).
+        if (memberType.IsValueType && Nullable.GetUnderlyingType(memberType) != null && schema["type"] is JsonValue tv)
+        {
+            schema["type"] = new JsonArray(tv.GetValue<string>(), "null");
+        }
+
+        return schema;
+    }
+
+    private static JsonObject SchemaForType(Type type, SchemaContext ctx)
+    {
+        var nullableUnderlying = Nullable.GetUnderlyingType(type);
+        if (nullableUnderlying != null)
+            return SchemaForType(nullableUnderlying, ctx);
+
+        if (type == typeof(bool)) return new JsonObject { ["type"] = "boolean" };
+        if (type == typeof(string)) return new JsonObject { ["type"] = "string" };
+        if (type == typeof(int) || type == typeof(long) || type == typeof(short) || type == typeof(byte))
+            return new JsonObject { ["type"] = "integer", ["format"] = type == typeof(long) ? "int64" : "int32" };
+        if (type == typeof(double) || type == typeof(float) || type == typeof(decimal))
+            return new JsonObject { ["type"] = "number" };
+
+        // AbsolutePath, Solution, Project — anything with a string-roundtripping TypeConverter — renders as a plain string.
+        if (HasStringTypeConverter(type))
+            return new JsonObject { ["type"] = "string" };
+
+        if (typeof(Enumeration).IsAssignableFrom(type))
+            return BuildEnumerationSchema(type, ctx);
+
+        if (type.IsEnum)
+            return StringEnumSchema(Enum.GetNames(type));
+
+        if (type.IsArray)
+            return new JsonObject { ["type"] = "array", ["items"] = SchemaForType(type.GetElementType()!, ctx) };
+
+        if (type.IsGenericType)
+        {
+            var def = type.GetGenericTypeDefinition();
+            if (def == typeof(IReadOnlyList<>) || def == typeof(IReadOnlyCollection<>) ||
+                def == typeof(List<>) || def == typeof(IEnumerable<>))
+            {
+                return new JsonObject { ["type"] = "array", ["items"] = SchemaForType(type.GetGenericArguments()[0], ctx) };
+            }
+        }
+
+        // Complex reference type — register a definition (if not already present) and emit a $ref.
+        return BuildComplexTypeReference(type, ctx);
+    }
+
+    private static JsonObject BuildEnumerationSchema(Type enumerationType, SchemaContext ctx)
+    {
+        var values = enumerationType
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(f => enumerationType.IsAssignableFrom(f.FieldType))
+            .Select(f => f.Name)
+            .ToList();
+        return StringEnumSchema(values);
+    }
+
+    private static JsonObject BuildComplexTypeReference(Type type, SchemaContext ctx)
+    {
+        var name = type.Name;
+        if (!ctx.Definitions.ContainsKey(name))
+        {
+            // Insert a placeholder first so recursive types resolve via $ref.
+            ctx.Definitions[name] = new JsonObject();
+            var definition = BuildObjectSchema(type, ctx);
+            // Replace placeholder with the populated schema.
+            ctx.Definitions[name] = definition;
+        }
+
+        // For value-type-style complex shapes referenced as nullable, the original schema wrapped the
+        // ref in `oneOf: [{"type": "null"}, {"$ref": ...}]`. Reference types appear directly via $ref.
+        // The Nullable handling at the caller adds the null sibling if needed for value types; reference
+        // types stay plain $ref.
+        return new JsonObject { ["$ref"] = DefinitionsPrefix + name };
+    }
+
+    private static JsonObject BuildObjectSchema(Type type, SchemaContext ctx)
+    {
+        var properties = new JsonObject();
+        foreach (var (memberName, memberType, _) in GetSerializableMembers(type))
+        {
+            properties[memberName] = WrapNullable(memberType, SchemaForType(memberType, ctx));
+        }
+
+        return new JsonObject
+        {
+            ["type"] = "object",
+            ["properties"] = properties
+        };
+    }
+
+    private static JsonObject WrapNullable(Type memberType, JsonObject schema)
+    {
+        // Convention matched to legacy NJsonSchema output:
+        //   - Value-type Nullable<T>: ["T", "null"] (T first).
+        //   - Reference type with $ref:  oneOf [{null}, {$ref}].
+        //   - Reference type with primitive "string" / etc.: ["null", "T"] (null first).
+        //   - Reference type with "array": ["array", "null"] (array first — quirk preserved).
+        var nullableUnderlying = Nullable.GetUnderlyingType(memberType);
+        if (nullableUnderlying != null && schema["type"] is JsonValue tv)
+        {
+            schema["type"] = new JsonArray(tv.GetValue<string>(), "null");
+            return schema;
+        }
+
+        if (!memberType.IsValueType)
+        {
+            if (schema["$ref"] is JsonNode refNode)
+            {
+                return new JsonObject
+                {
+                    ["oneOf"] = new JsonArray(
+                        new JsonObject { ["type"] = "null" },
+                        new JsonObject { ["$ref"] = refNode.GetValue<string>() })
+                };
+            }
+            if (schema["type"] is JsonValue typeValue)
+            {
+                var typeName = typeValue.GetValue<string>();
+                if (typeName == "array")
+                    schema["type"] = new JsonArray("array", "null");
+                else if (typeName != "object")
+                    schema["type"] = new JsonArray("null", typeName);
+            }
+        }
+
+        return schema;
+    }
+
+    private static IEnumerable<(string Name, Type Type, MemberInfo Member)> GetSerializableMembers(Type type)
+    {
+        var bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+        foreach (var field in type.GetFields(bindingFlags))
+        {
+            if (field.IsPrivate || field.IsStatic || field.IsInitOnly || field.IsLiteral)
+                continue;
+            yield return (field.Name, field.FieldType, field);
+        }
+
+        foreach (var property in type.GetProperties(bindingFlags))
+        {
+            if (property.GetMethod is null || property.GetMethod.IsPrivate || property.GetMethod.IsStatic)
+                continue;
+            yield return (property.Name, property.PropertyType, property);
+        }
+    }
+
+    private static bool HasStringTypeConverter(Type type)
+    {
+        if (type == typeof(string)) return false;
+        // The AbsolutePath / Solution / Project / Configuration story: any user-declared
+        // [TypeConverter] that can deserialize from a string round-trips through a string in JSON.
+        // (Most converters skip overriding CanConvertTo(string) because the base ToString fallback
+        // is sufficient, so we don't enforce the symmetric check.)
+        if (type.GetCustomAttribute<TypeConverterAttribute>(inherit: true) is null)
+            return false;
+        try
+        {
+            return TypeDescriptor.GetConverter(type)?.CanConvertFrom(typeof(string)) ?? false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private class SchemaContext
+    {
+        public Dictionary<string, JsonObject> Definitions { get; } = new(StringComparer.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Summary

Replaces the NJsonSchema-based build-parameter schema generator with a self-contained STJ implementation. Drops **four packages** from `Fallout.Build`'s closure: `NJsonSchema`, `NJsonSchema.NewtonsoftJson`, `NJsonSchema.Annotations`, `Namotion.Reflection`. Same draft-04 schema output — same Verify snapshots — but no Rico-entanglement and ~12 transitive deps shaken loose.

## Why hand-roll instead of NJsonSchema's STJ flavor

NJsonSchema's `SystemTextJsonSchemaGeneratorSettings` *exists*, but the package still **hard-depends on Newtonsoft.Json 13.0.3** across every TFM in every release including 11.6.1 (April 2026). Swapping flavors would have left `Newtonsoft.dll` in the closure anyway. And NJsonSchema's STJ flavor uses its own reflection (not STJ's `TypeInfoResolver`), doesn't honour `[TypeConverter]`-as-string, and includes internal members by default — every one of those would have needed a bespoke bridge to preserve the existing schema output. Easier to write the ~200 lines of schema generation we actually need.

## What stayed identical (preserved behaviors)

- Well-known definitions in canonical order: `Host`, `ExecutableTarget`, `Verbosity`, `FalloutBuild`.
- `Host` / `ExecutableTarget` / `Verbosity` rendered as string enums and `$ref`'d from `FalloutBuild` parameters.
- `[TypeConverter]`-attributed types (`AbsolutePath`, `Solution`, etc.) render as `"string"` instead of walking their internal members.
- Subclasses of `ParameterAttribute` (e.g. `[CustomParameter]`) render the member as plain `"string"` — the legacy "don't recurse for custom attributes" gate.
- Nullable layout matched byte-for-byte to the legacy output:
  - Value-type `Nullable<T>` → `[T, "null"]`
  - Reference primitives → `["null", T]`
  - Reference `$ref`s → `oneOf [null, $ref]`
  - Arrays → `["array", "null"]`
- Complex object types include both fields *and* properties (matches Newtonsoft default).
- `description` sits between `type` and `items` in array schemas (matches legacy layout).
- `UnsafeRelaxedJsonEscaping` so apostrophes etc. emit verbatim (`'automatic'` not `'automatic'`).
- Trailing newline at end of output (matches consumer expectation).

## Closure impact (Fallout.Build)

| Package | Before | After |
|---|---|---|
| `NJsonSchema` | ✓ | ✗ |
| `NJsonSchema.NewtonsoftJson` | ✓ | ✗ |
| `NJsonSchema.Annotations` | (transitive) | ✗ |
| `Namotion.Reflection` | (transitive) | ✗ |
| `Newtonsoft.Json` | (transitive via NJsonSchema) | (transitive via Fallout.Common, until #119) |

## Tests

- [x] All 4 `SchemaUtilityTest.*` Verify snapshots match unchanged — same `verified.json` files.
- [x] `dotnet build fallout.slnx` — 0 errors.
- [x] `dotnet test fallout.slnx` — 425/425 pass across 10 DLLs.

## Closes

- #114 (STJ-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)