### PR TITLE
ci: add ubuntu-latest noop workflow for docs-only PRs

### DIFF
--- a/.github/workflows/ubuntu-latest-docs.yml
+++ b/.github/workflows/ubuntu-latest-docs.yml
@@ -1,0 +1,35 @@
+# Hand-written (not auto-generated). Companion to ubuntu-latest.yml.
+#
+# Why this exists:
+#   - main branch protection requires the `ubuntu-latest` status check.
+#   - ubuntu-latest.yml has `paths-ignore: docs/**, .assets/**, **/*.md` so
+#     it doesn't fire on docs-only PRs.
+#   - Without a substitute, docs-only PRs sit BLOCKED waiting for a check
+#     that never reports.
+#
+# This workflow fires on the inverse path set (docs-only changes), runs
+# nothing of substance, and reports success under the same `ubuntu-latest`
+# status-check context — satisfying the protection rule without spending
+# CI minutes on a real build.
+#
+# Keep the workflow `name:` and the job name aligned with ubuntu-latest.yml
+# so both files produce a status check named `ubuntu-latest`.
+
+name: ubuntu-latest
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.assets/**'
+      - '**/*.md'
+
+jobs:
+  ubuntu-latest:
+    name: ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Skip: docs-only PR, no build needed'
+        run: echo "Docs-only change — ubuntu-latest validation skipped via .github/workflows/ubuntu-latest-docs.yml."


### PR DESCRIPTION
## Summary

Fixes the branch-protection vs `paths-ignore` mismatch that left docs-only PRs (e.g. #177) BLOCKED indefinitely with no status check reporting.

## The problem

| Side | Behavior |
|---|---|
| `main` protection | Requires the `ubuntu-latest` status check (`required_status_checks.contexts: ["ubuntu-latest"]`). |
| `ubuntu-latest.yml` | Has `paths-ignore: ['docs/**', '.assets/**', '**/*.md']` — does not fire on docs-only PRs. |

Docs PR → workflow never runs → no check reported → protection rule never satisfied → PR sits BLOCKED.

## The fix

New hand-written `.github/workflows/ubuntu-latest-docs.yml`:

- Triggers on the **inverse** path set (`paths: ['docs/**', '.assets/**', '**/*.md']`).
- Workflow `name:` is `ubuntu-latest` (same as the auto-generated workflow), so it reports a status check under the same context.
- Single ~30-second job that echoes a skip line. No build, no test, no pack.

Pattern mirrors the existing hand-written `release.yml` — auto-generation via `[GitHubActions]` can't quite express the dual-workflow shape, so we keep it out-of-band.

## Why hand-written, not generator-driven

Adding this to the `[GitHubActions]` attribute would need a new property (e.g. `OnPullRequestSkipPathsEmitNoop`) that's specific to one use case. Sibling files for special cases match `release.yml`'s precedent. Documented at the top of both yamls.

## Test plan

- [ ] This PR's `ubuntu-latest` check fires from the original `ubuntu-latest.yml` (touches `.github/**`, not in paths-ignore) — proves the existing workflow still works on non-docs changes.
- [ ] After merge, push to PR #177 retriggers and the new noop workflow reports success under the `ubuntu-latest` context.
- [ ] #177 becomes mergeable.

## Related

- #177 (the immediate blocked PR motivating this)
- #175 (`CheckoutRef` — prior parallel fix for the same regen-vs-protection class of problems)

🤖 Generated with [Claude Code](https://claude.com/claude-code)