### PR TITLE
docs(readme): link to docs.fallout.build (#191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
   <img width="320" src=".assets/fallout-logo.svg" alt="Fallout — .NET build system" />
 </p>
 
+<p align="center">
+  <strong>📖 Documentation: <a href="https://docs.fallout.build/">docs.fallout.build</a></strong>
+</p>
+
 > 📦 **Fallout is the successor to NUKE.** [Migrating from NUKE →](docs/migration/from-nuke.md)
 
 # Fallout
 
 > Build automation for C#/.NET — the hard-fork successor to NUKE.
 
+[![Docs](https://img.shields.io/badge/docs-docs.fallout.build-blue?logo=readthedocs&logoColor=white)](https://docs.fallout.build/)
 [![CI](https://github.com/ChrisonSimtian/Fallout/actions/workflows/ubuntu-latest.yml/badge.svg)](https://github.com/ChrisonSimtian/Fallout/actions/workflows/ubuntu-latest.yml)
 [![NuGet](https://img.shields.io/nuget/v/Fallout.Common?label=Fallout.Common)](https://www.nuget.org/packages/Fallout.Common)
 [![NuGet downloads](https://img.shields.io/nuget/dt/Fallout.Common?label=downloads)](https://www.nuget.org/packages/Fallout.Common)


### PR DESCRIPTION
## Summary

Closes #191 — surfaces the live docs site (https://docs.fallout.build/) from the GitHub README, which currently has zero references to it.

Two additions, both above-the-fold:

1. **Centered "📖 Documentation" callout** right under the logo — primary discovery surface for first-time visitors landing on the repo from a search hit or share link.
2. **"Docs" shields.io badge** in the badge cluster — same visual weight as the CI / NuGet / .NET / License badges.

No other doc-section references in the README needed retargeting — the migration link at line 5 / line 37 stays as a relative path so it works for people browsing on GitHub.

## Test plan

- [ ] Render the README on GitHub (post-merge) — both surfaces visible.
- [ ] Both links resolve to https://docs.fallout.build/.

## Refs

- Closes #191
- Parent: #41 (closed; this is one of three follow-ups).