### PR TITLE
docs: fix broken inter-doc links surfaced by Docusaurus (#192)

### DIFF
--- a/docs/07-ide/resharper.md
+++ b/docs/07-ide/resharper.md
@@ -4,7 +4,7 @@ title: ReSharper
 
 import DownloadButton from '@site/src/components/DownloadButton';
 
-<DownloadButton url="/download/resharper" />
+<DownloadButton />
 
 In [ReSharper](https://www.jetbrains.com/resharper) you can install the _NUKE Support extension_ to be more productive in writing, running, and debugging your builds.
 

--- a/docs/07-ide/rider.md
+++ b/docs/07-ide/rider.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 import DownloadButton from '@site/src/components/DownloadButton';
 
-<DownloadButton url="/download/rider" />
+<DownloadButton />
 
 In [JetBrains Rider](https://www.jetbrains.com/rider) you can install the _NUKE Support plugin_ to be more productive in writing, running, and debugging your builds.
 

--- a/docs/07-ide/visual-studio.md
+++ b/docs/07-ide/visual-studio.md
@@ -4,7 +4,7 @@ title: Visual Studio
 
 import DownloadButton from '@site/src/components/DownloadButton';
 
-<DownloadButton url="/download/visual-studio" />
+<DownloadButton />
 
 In [Visual Studio](https://visualstudio.microsoft.com/) you can install the _NUKE Support extension_ to be more productive in writing, running, and debugging your builds.
 

--- a/docs/migration/from-nuke.md
+++ b/docs/migration/from-nuke.md
@@ -1,6 +1,6 @@
 # Migrating from NUKE to Fallout
 
-Fallout is the hard-fork successor to [NUKE](https://github.com/nuke-build/nuke). If you maintain a NUKE-based build, this guide gets you running on Fallout in under five minutes. Why the rename and the relationship to upstream NUKE are explained in [the rebrand plan](../rebrand-plan.md).
+Fallout is the hard-fork successor to [NUKE](https://github.com/nuke-build/nuke). If you maintain a NUKE-based build, this guide gets you running on Fallout in under five minutes. Why the rename and the relationship to upstream NUKE are explained in [the rebrand plan](https://github.com/ChrisonSimtian/Fallout/blob/main/docs/rebrand-plan.md).
 
 ## TL;DR
 
@@ -132,4 +132,4 @@ If `fallout-migrate` itself crashed, also attach the stack trace.
 
 ## Staying on NUKE
 
-If you'd prefer not to migrate, that's fine — [`nuke-build/nuke`](https://github.com/nuke-build/nuke) continues under its original maintainer's direction. Fallout doesn't displace it; we hard-forked because we wanted to take the codebase in a different direction (enterprise CI/CD focus, plugin architecture — see [the roadmap](../roadmap.md)). Bug fixes and improvements may flow between the two projects, but the codebases will diverge over time. Pick the one whose direction matches your needs.
+If you'd prefer not to migrate, that's fine — [`nuke-build/nuke`](https://github.com/nuke-build/nuke) continues under its original maintainer's direction. Fallout doesn't displace it; we hard-forked because we wanted to take the codebase in a different direction (enterprise CI/CD focus, plugin architecture — see [the roadmap](https://github.com/ChrisonSimtian/Fallout/blob/main/docs/roadmap.md)). Bug fixes and improvements may flow between the two projects, but the codebases will diverge over time. Pick the one whose direction matches your needs.


### PR DESCRIPTION
## Summary

First of two PRs for #192 — fixes the content-side broken links the docs site (https://docs.fallout.build/) currently warns about. A follow-up PR on [Falloutdocs](https://github.com/ChrisonSimtian/Falloutdocs) will then fix its footer config and flip \`onBrokenLinks: 'warn'\` → \`'throw'\` so future regressions fail CI.

## What's broken (and what this PR fixes)

The most recent Falloutdocs build emitted broken-link warnings for ~45 source pages. They fell into three groups:

1. **One config bug in Falloutdocs' footer** that linked to a numbered-prefix path. Since the footer renders on every page, this single broken link accounted for ~40 of the warnings. **Fixed in the Falloutdocs PR (next).**
2. **\`migration/from-nuke.md\` links to \`../rebrand-plan.md\` and \`../roadmap.md\`** — both files are intentionally excluded from the docs site in Falloutdocs' \`docusaurus.config.ts\` (they're internal planning content, not consumer docs). Repointed to absolute GitHub blob URLs so the rendered docs site still links to the planning material at its canonical home. **Fixed in this PR.**
3. **\`07-ide/{visual-studio,resharper,rider}.md\` \`<DownloadButton url="/download/<ide>" />\`** — referenced internal \`/download/*\` routes that don't exist on the Docusaurus site (they were the old NUKE site's download proxy). Dropping the \`url\` prop renders DownloadButton's built-in "Download (coming soon)" state, which is honest — the Fallout-branded IDE extensions don't exist yet (the surrounding prose still refers to NUKE-era extensions). When Fallout extensions ship, the prop can be re-added with real URLs. **Fixed in this PR.**

## Test plan

- [ ] CI green (\`ubuntu-latest\` noop, since this is docs-only).
- [ ] After merge, trigger a Falloutdocs \`workflow_dispatch\` rebuild and confirm only the footer config warning remains (everything else clears).
- [ ] Then open the Falloutdocs follow-up: fix the footer, move the deprecated \`onBrokenMarkdownLinks\` config, flip \`onBrokenLinks: 'throw'\`.

## Refs

- Refs #192 (parent issue stays open until the Falloutdocs follow-up lands and \`onBrokenLinks: 'throw'\` is in place — that's the real "done").