### PR TITLE
docs: tidy up introduction.md (#196)

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,9 +1,8 @@
 ---
 title: Introduction
 sidebar_position: 0
+description: Fallout is a C#-first build automation framework for .NET — the hard-fork successor to NUKE. Write your CI/CD pipelines in plain C#, debug them locally, and share build steps across repositories.
 ---
-
-{/* https://docusaurus.io/docs/next/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter */}
 
 🪴 Write **automation tools and CI/CD pipelines** in plain C# and with access to all .NET libraries.
 
@@ -19,34 +18,34 @@ sidebar_position: 0
 
 ```powershell
 # terminal-command
-dotnet tool install Nuke.GlobalTool --global
+dotnet tool install Fallout.GlobalTool --global
 ```
 
 **2. Go to a repository of your choice and set up a build:**
 
 ```powershell
 # terminal-command
-nuke :setup
+fallout :setup
 ```
 
 **3. Run the build:**
 
 ```powershell
 # terminal-command
-nuke
+fallout
 ```
 
 **4. Open the build project and explore the default `Build` class.**
 
 ## Coming from Cake? 🍰
 
-Get a feeling how your Cake scripts would look like in NUKE.
+Get a feeling how your Cake scripts would look like in Fallout.
 
 **1. Install the global tool:**
 
 ```powershell
 # terminal-command
-dotnet tool install Nuke.GlobalTool --global
+dotnet tool install Fallout.GlobalTool --global
 ```
 
 **2. Go to a repository built with Cake.**
@@ -55,7 +54,7 @@ dotnet tool install Nuke.GlobalTool --global
 
 ```powershell
 # terminal-command
-nuke :cake-convert
+fallout :cake-convert
 ```
 
 **4. Inspect the outcome (errors are expected).**


### PR DESCRIPTION
## Summary

Closes #196. Two fixes on the first page every docs visitor sees:

1. **Drop a stray MDX comment** at the top of \`docs/introduction.md\` that was leaking into the page's \`<meta description>\` tag (Docusaurus picks the first content paragraph as default description when no \`description:\` frontmatter is set, and an MDX comment in MDX 3 looks textually like \`{/ ... /}\` which is what was showing up on https://docs.fallout.build/docs/introduction). Replaced with an explicit \`description:\` frontmatter field so search-engine snippets and link-unfurls quote something meaningful.
2. **Rebrand the Fast Track commands**: \`nuke :setup\` → \`fallout :setup\`, \`nuke\` → \`fallout\`, \`nuke :cake-convert\` → \`fallout :cake-convert\`, \`Nuke.GlobalTool\` → \`Fallout.GlobalTool\`. Per CLAUDE.md the structural rename has landed (\`dotnet fallout\` global tool name in place), so these were the only remaining user-facing CLI references on this page still using the old name. Also updated the prose line "how your Cake scripts would look like in NUKE" → "...in Fallout".

## Out of scope

NUKE-era branding still appears in other docs pages (e.g. \`docs/07-ide/*.md\` says "_NUKE Support extension_"). Not touched here — this PR is just introduction.md. If we want a broader sweep, separate issue.

## Test plan

- [ ] CI green (docs-only, hits the noop \`ubuntu-latest\` workflow).
- [ ] After merge, trigger a Falloutdocs rebuild and confirm: \`<meta name="description">\` on /docs/introduction is the new sentence; Fast Track shows \`fallout\` not \`nuke\`.

## Refs

- Closes #196. Noticed while verifying #193 (local search) on the live site.