### PR TITLE
feat(globaltool): add in-tool build runner (PR-A of bootstrapper deprecation)

### DIFF
--- a/src/Fallout.GlobalTool/BuildProjectResolver.cs
+++ b/src/Fallout.GlobalTool/BuildProjectResolver.cs
@@ -1,0 +1,48 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System.IO;
+using Fallout.Common;
+using Fallout.Common.IO;
+using Fallout.Common.Utilities;
+using static Fallout.Common.Constants;
+
+namespace Fallout.GlobalTool;
+
+/// <summary>
+/// Resolves the build project file (.csproj) for a Fallout-managed repository.
+/// Reads the optional <c>BuildProjectFile</c> entry from <c>.fallout/parameters.json</c> when set;
+/// otherwise falls back to the convention <c>build/_build.csproj</c>.
+/// </summary>
+internal static class BuildProjectResolver
+{
+    private const string BuildProjectFileKey = "BuildProjectFile";
+
+    public static AbsolutePath Resolve(AbsolutePath rootDirectory)
+    {
+        Assert.NotNull(rootDirectory);
+
+        var parametersFile = GetDefaultParametersFile(rootDirectory);
+        if (File.Exists(parametersFile))
+        {
+            var configured = parametersFile.ReadJsonObject()?[BuildProjectFileKey]?.GetValue<string>();
+            if (!string.IsNullOrWhiteSpace(configured))
+            {
+                var configuredPath = Path.IsPathRooted(configured)
+                    ? (AbsolutePath)configured
+                    : rootDirectory / configured;
+                Assert.True(File.Exists(configuredPath),
+                    $"BuildProjectFile '{configured}' from '{parametersFile}' does not exist (resolved as '{configuredPath}').");
+                return configuredPath;
+            }
+        }
+
+        var defaultPath = rootDirectory / "build" / "_build.csproj";
+        Assert.True(File.Exists(defaultPath),
+            $"Could not locate build project. Looked for '{defaultPath}' (convention) and 'BuildProjectFile' is not set in '{parametersFile}'. " +
+            $"Run 'fallout :setup' to scaffold a build, or set 'BuildProjectFile' in '{parametersFile}'.");
+        return defaultPath;
+    }
+}

--- a/src/Fallout.GlobalTool/Program.Run.cs
+++ b/src/Fallout.GlobalTool/Program.Run.cs
@@ -1,0 +1,106 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Fallout.Common;
+using Fallout.Common.IO;
+using Fallout.Common.Utilities;
+using static Fallout.Common.Constants;
+
+namespace Fallout.GlobalTool;
+
+partial class Program
+{
+    private static int Run(string[] forwardedArgs, AbsolutePath rootDirectory, AbsolutePath buildProjectFile)
+    {
+        var dotnet = ResolveDotnet(rootDirectory);
+
+        var buildExitCode = StartDotnet(dotnet, GetBuildArguments(buildProjectFile));
+        if (buildExitCode != 0)
+            return buildExitCode;
+
+        return StartDotnet(dotnet, GetRunArguments(buildProjectFile, forwardedArgs));
+    }
+
+    private static string ResolveDotnet(AbsolutePath rootDirectory)
+    {
+        var pathDotnet = TryGetDotnetFromPath();
+        if (pathDotnet != null)
+            return pathDotnet;
+
+        var shimDirectoryName = EnvironmentInfo.IsWin ? "dotnet-win" : "dotnet-unix";
+        var shimExecutableName = EnvironmentInfo.IsWin ? "dotnet.exe" : "dotnet";
+        var shimPath = GetTemporaryDirectory(rootDirectory) / shimDirectoryName / shimExecutableName;
+        Assert.True(File.Exists(shimPath),
+            $"Could not locate 'dotnet'. Tried PATH and '{shimPath}'. " +
+            $"Run './build.sh' (Unix) or './build.ps1' (Windows) once to provision .NET locally, then retry.");
+        return shimPath;
+    }
+
+    private static string TryGetDotnetFromPath()
+    {
+        var executable = EnvironmentInfo.IsWin ? "dotnet.exe" : "dotnet";
+        var pathVar = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        return pathVar
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Select(dir => Path.Combine(dir, executable))
+            .FirstOrDefault(File.Exists);
+    }
+
+    private static int StartDotnet(string dotnet, IEnumerable<string> arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = dotnet,
+            UseShellExecute = false
+        };
+
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+
+        startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+        startInfo.Environment["DOTNET_NOLOGO"] = "1";
+        startInfo.Environment["DOTNET_ROLL_FORWARD"] = "Major";
+        startInfo.Environment["FALLOUT_TELEMETRY_OPTOUT"] = "1";
+        startInfo.Environment[GlobalToolVersionEnvironmentKey] = typeof(Program).Assembly.GetVersionText();
+        startInfo.Environment[GlobalToolStartTimeEnvironmentKey] = DateTime.Now.ToString("O");
+
+        var process = Process.Start(startInfo).NotNull();
+        process.WaitForExit();
+        return process.ExitCode;
+    }
+
+    private static IEnumerable<string> GetBuildArguments(AbsolutePath buildProjectFile)
+    {
+        // Mirrors the dotnet build invocation in build.sh / build.ps1.
+        return new[]
+        {
+            "build",
+            buildProjectFile.ToString(),
+            "/nodeReuse:false",
+            "/p:UseSharedCompilation=false",
+            "-nologo",
+            "-clp:NoSummary"
+        };
+    }
+
+    private static IEnumerable<string> GetRunArguments(AbsolutePath buildProjectFile, string[] forwardedArgs)
+    {
+        var args = new List<string>
+        {
+            "run",
+            "--project",
+            buildProjectFile.ToString(),
+            "--no-build",
+            "--"
+        };
+        args.AddRange(forwardedArgs);
+        return args;
+    }
+}

--- a/src/Fallout.GlobalTool/Program.cs
+++ b/src/Fallout.GlobalTool/Program.cs
@@ -81,23 +81,16 @@ public partial class Program
             return (int)commandHandler.Invoke(obj: null, commandArguments).NotNull($"Command '{command}' did not return exit code");
         }
 
-        if (rootDirectory == null || buildScript == null)
+        if (rootDirectory == null)
         {
-            var missingItem = rootDirectory == null
-                ? $"{Constants.FalloutDirectoryName} directory/file"
-                : "build.ps1/sh files";
-
-            return PromptForConfirmation($"Could not find {missingItem}. Do you want to setup a build?")
-                ? Setup(new string[0], rootDirectory, buildScript: null)
+            return PromptForConfirmation($"Could not find {Constants.FalloutDirectoryName} directory/file. Do you want to setup a build?")
+                ? Setup(new string[0], rootDirectory: null, buildScript: null)
                 : 0;
         }
 
         // TODO: docker
 
-        var arguments = args.Select(x => x.DoubleQuoteIfNeeded()).JoinSpace();
-        var process = Build(buildScript, arguments);
-        process.WaitForExit();
-        return process.ExitCode;
+        return Run(args, rootDirectory, BuildProjectResolver.Resolve(rootDirectory));
     }
 
     private static Process Build(string buildScript, string arguments)

--- a/tests/Fallout.GlobalTool.Tests/BuildProjectResolverTests.cs
+++ b/tests/Fallout.GlobalTool.Tests/BuildProjectResolverTests.cs
@@ -1,0 +1,128 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System;
+using System.IO;
+using Fallout.Common.IO;
+using Fallout.Common.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.GlobalTool.Tests;
+
+public class BuildProjectResolverTests
+{
+    [Fact]
+    public void Resolve_ConventionDefault_ReturnsBuildSlashUnderscoreBuildCsproj()
+    {
+        using var root = TempRepoRoot.Create();
+        root.WriteParametersFile(parametersJson: "{}");
+        var expected = root.WriteBuildProjectAtConvention();
+
+        var actual = BuildProjectResolver.Resolve(root.Path);
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Resolve_WithExplicitBuildProjectFile_ReturnsConfiguredPath()
+    {
+        using var root = TempRepoRoot.Create();
+        var customDir = root.Path / "custom";
+        customDir.CreateDirectory();
+        var customProject = customDir / "my-build.csproj";
+        File.WriteAllText(customProject, string.Empty);
+        root.WriteParametersFile(parametersJson: """{ "BuildProjectFile": "custom/my-build.csproj" }""");
+
+        var actual = BuildProjectResolver.Resolve(root.Path);
+
+        actual.Should().Be(customProject);
+    }
+
+    [Fact]
+    public void Resolve_NoParametersFile_FallsBackToConvention()
+    {
+        using var root = TempRepoRoot.Create();
+        // .fallout/ exists (TempRepoRoot creates it) but no parameters.json.
+        var expected = root.WriteBuildProjectAtConvention();
+
+        var actual = BuildProjectResolver.Resolve(root.Path);
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Resolve_EmptyBuildProjectFileValue_FallsBackToConvention()
+    {
+        using var root = TempRepoRoot.Create();
+        root.WriteParametersFile(parametersJson: """{ "BuildProjectFile": "" }""");
+        var expected = root.WriteBuildProjectAtConvention();
+
+        var actual = BuildProjectResolver.Resolve(root.Path);
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Resolve_MissingBuildProjectAtConvention_Throws()
+    {
+        using var root = TempRepoRoot.Create();
+        root.WriteParametersFile(parametersJson: "{}");
+        // No build/_build.csproj — should throw.
+
+        var action = () => BuildProjectResolver.Resolve(root.Path);
+
+        action.Should().Throw<Exception>()
+            .WithMessage("*Could not locate build project*");
+    }
+
+    [Fact]
+    public void Resolve_MissingConfiguredBuildProjectFile_Throws()
+    {
+        using var root = TempRepoRoot.Create();
+        root.WriteParametersFile(parametersJson: """{ "BuildProjectFile": "missing/nowhere.csproj" }""");
+
+        var action = () => BuildProjectResolver.Resolve(root.Path);
+
+        action.Should().Throw<Exception>()
+            .WithMessage("*BuildProjectFile*does not exist*");
+    }
+
+    private sealed class TempRepoRoot : IDisposable
+    {
+        public AbsolutePath Path { get; }
+
+        private TempRepoRoot(AbsolutePath path)
+        {
+            Path = path;
+            (path / ".fallout").CreateDirectory();
+        }
+
+        public static TempRepoRoot Create()
+        {
+            var dir = (AbsolutePath)System.IO.Path.Combine(System.IO.Path.GetTempPath(), "fallout-test-" + Guid.NewGuid().ToString("N"));
+            dir.CreateDirectory();
+            return new TempRepoRoot(dir);
+        }
+
+        public void WriteParametersFile(string parametersJson)
+            => File.WriteAllText(Path / ".fallout" / "parameters.json", parametersJson);
+
+        public AbsolutePath WriteBuildProjectAtConvention()
+        {
+            var buildDir = Path / "build";
+            buildDir.CreateDirectory();
+            var projectFile = buildDir / "_build.csproj";
+            File.WriteAllText(projectFile, string.Empty);
+            return projectFile;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First of three PRs that deprecate the per-repo \`build.cmd\`/\`build.sh\`/\`build.ps1\` bootstrappers in favour of \`Fallout.GlobalTool\` (\`fallout\`) as the canonical entry point for running builds. This one is **purely additive** — no behaviour change for any repo with existing bootstrappers committed.

Plan & rationale: \`/Users/csimon/.claude/plans/linked-frolicking-pine.md\` (local). Three-PR sequence:

- **PR-A (this one)** — Add in-tool build runner. \`fallout <target>\` runs \`dotnet build\` + \`dotnet run --no-build\` directly instead of spawning \`./build.sh\`.
- **PR-B** — Switch this repo to thin shims, delete \`build.cmd\`, update the \`[GitHubActions]\` generator + workflows, update \`:setup\` scaffolder.
- **PR-C** — Docs cleanup (already tracked under #198).

## What's in this PR

**New files:**

- \`src/Fallout.GlobalTool/BuildProjectResolver.cs\` — resolves the build project (\`.csproj\`) from optional \`BuildProjectFile\` field in \`.fallout/parameters.json\`, falling back to convention \`build/_build.csproj\`. Six unit tests cover convention default, explicit override, missing files (both cases), and empty override values.
- \`src/Fallout.GlobalTool/Program.Run.cs\` — new in-tool runner. Resolves \`dotnet\` (PATH first; shim-provisioned \`.fallout/temp/dotnet-{unix,win}\` as fallback), seeds the same env vars the shim sets, then runs \`dotnet build\` + \`dotnet run --project --no-build -- <args>\` as subprocesses with inherited stdio (colours/progress pass through).
- \`tests/Fallout.GlobalTool.Tests/BuildProjectResolverTests.cs\` — 6 new tests, all green.

**Modified:**

- \`src/Fallout.GlobalTool/Program.cs\` — \`Handle\`'s no-\`:\` fallback now calls \`Run(args, rootDirectory, BuildProjectResolver.Resolve(rootDirectory))\` instead of \`Build(buildScript, ...)\`. The \`buildScript == null\` branch of the "Could not find" prompt is removed — we can run without a shim now — but the \`rootDirectory == null\` branch stays for empty repos.

## What this PR does NOT do (so PR-B has something to do)

- **Doesn't delete \`Build()\`** — still called from \`Program.Complete.cs\` as a bootstrap path for the first-time completion request. Removed in PR-B alongside the shim deletion.
- **Doesn't touch the shim scripts** (\`build.sh\`/\`build.ps1\`/\`build.cmd\`) — they continue to work directly via their own \`dotnet build\` + \`dotnet run --project\` invocations, independent of the global tool.
- **Doesn't touch the \`[GitHubActions]\` generator** — it still emits \`run: ./{BuildCmdPath} {targets}\`, which still works because the shims are still in place. The generator and the four \`.github/workflows/*.yml\` files get the three-step \`setup-dotnet\` + \`tool restore\` + \`dotnet fallout\` shape in PR-B.
- **Doesn't add \`BuildProjectFile\` to \`build.schema.json\`** — the schema is regenerated by \`HandleShellCompletionAttribute\` on every build run, so manual edits don't stick. The schema-generation update belongs to PR-B. The resolver works without schema support because \`parameters.json\` accepts arbitrary fields (JSON Schema default allows additional properties).

## Backwards compatibility

| Scenario | Behaviour |
|---|---|
| Existing repo, old fat bootstrapper, run \`./build.sh Compile\` | Unchanged — bootstrapper does its own \`dotnet build\` + \`dotnet run --project\`, doesn't touch the global tool. |
| Existing repo, old fat bootstrapper, run \`fallout Compile\` | Now uses the new in-tool runner. Same end result (\`dotnet build\` + \`dotnet run --no-build\`), one fewer subprocess hop. The shim's env-var exports are bypassed; the new runner sets them itself to compensate. |
| Existing repo, no \`_build.csproj\` (somehow) | Resolver throws with a helpful message pointing at \`fallout :setup\` or \`BuildProjectFile\` in \`parameters.json\`. |
| Empty directory, no \`.fallout/\` | Prompt for \`:setup\` as before. |

## Verification

- \`dotnet build src/Fallout.GlobalTool/Fallout.GlobalTool.csproj\` — green (0 errors; only pre-existing warnings unrelated to this PR).
- \`dotnet test tests/Fallout.GlobalTool.Tests/\` — 17/17 passed (11 existing + 6 new).
- Dogfood: \`dotnet run --project src/Fallout.GlobalTool -- --help\` — exercises full new path; outputs build help identical to \`./build.sh --help\`.
- CI: existing workflows still call \`./build.cmd\`, which still works because the shims are unchanged. So this PR's CI signal verifies the legacy path stays intact; the new path is verified by the unit tests + dogfooding above.

## Test plan

- [ ] CI green on \`ubuntu-latest\` (the only PR gate).
- [ ] \`Fallout.GlobalTool.Tests\` green on all three release runners post-merge (\`ubuntu-latest\`, \`macos-latest\`, \`windows-latest\`).

## Refs

- This PR: PR-A of the bootstrapper-deprecation plan.
- Next: PR-B will flip this repo to thin shims + \`actions/setup-dotnet\` + \`dotnet fallout\`, and update the \`[GitHubActions]\` generator + \`:setup\` scaffolder.
- Companion docs sweep: tracked in #198.