### PR TITLE
fix(tests): add discoverable test to Nuke.Common.Shim.Tests (fixes windows-latest on main)

### DIFF
--- a/tests/Nuke.Common.Shim.Tests/ShimCompilesTests.cs
+++ b/tests/Nuke.Common.Shim.Tests/ShimCompilesTests.cs
@@ -1,0 +1,29 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using Xunit;
+
+namespace Nuke.Common.Shim.Tests;
+
+// The whole point of this project is to verify that SampleConsumerBuild.cs
+// compiles against the Nuke.* shim — the build IS the test. But xUnit's
+// `dotnet test` discoverer treats a test project with zero discoverable tests
+// as an error on Windows (exit code 1) while emitting only a warning on
+// Linux/macOS. That platform-split silently fails the post-merge
+// windows-latest validation on main.
+//
+// This trivial test makes discovery succeed on all platforms and explicitly
+// encodes the project's contract: if you can build it, the shim covers the
+// surface SampleConsumerBuild exercises.
+public class ShimCompilesTests
+{
+    [Fact]
+    public void Shim_Compiles_When_Test_Assembly_Loads()
+    {
+        // Reaching this assertion proves the assembly loaded, which proves
+        // SampleConsumerBuild.cs (and therefore the Nuke.* shim it uses) compiled.
+        Assert.True(true);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a latent windows-latest validation failure on \`main\`. \`tests/Nuke.Common.Shim.Tests/\` is a compile-only test project by design (see \`SampleConsumerBuild.cs\` header — "If this file compiles, the MVP shim covers the surface it claims to cover. Nothing here is executed."). It had **zero \`[Fact]\` / \`[Theory]\` methods**.

xUnit's \`dotnet test\` treats "no tests discovered" differently across platforms:

- **Linux / macOS** — emits \`No test is available\` as a warning, **exit 0**.
- **Windows** — same warning, **exit 1**.

The \`Test\` target catches that exit code, throws \`ProcessException\`, and the build aborts. Every push to \`main\` has been silently failing the \`windows-latest\` post-merge validation since this project was added — e.g. [run 26443068694](https://github.com/ChrisonSimtian/Fallout/actions/runs/26443068694) from the #197 merge. \`macos-latest\` and \`ubuntu-latest\` (full) both pass cleanly with the same warning.

## Fix

Add \`ShimCompilesTests.cs\` with a single \`[Fact]\` whose body is \`Assert.True(true)\`. Discovery succeeds on all three platforms now. The comment block on the test class explains *why* this trivial assertion exists and what it actually proves:

> Reaching this assertion proves the assembly loaded, which proves SampleConsumerBuild.cs (and therefore the Nuke.* shim it uses) compiled.

\`SampleConsumerBuild.cs\` is untouched — it remains the real test surface of the shim.

## Verification

- Local \`dotnet test tests/Nuke.Common.Shim.Tests/\` — discovers and passes 1 test.
- Post-merge \`windows-latest\` should go green on the next push to \`main\`.

## Refs

- Noticed while debugging GitHub Actions trigger weirdness on PR #200/#201; not related to that work.