### PR TITLE
feat(globaltool)!: PR-B — thin shims + local tool manifest + workflow regen (#203)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fallout.globaltool": {
+      "version": "10.3.37",
+      "commands": [
+        "fallout"
+      ]
+    }
+  }
+}

--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -108,6 +108,13 @@
         "Verbosity": {
           "description": "Logging verbosity during build execution. Default is 'Normal'",
           "$ref": "#/definitions/Verbosity"
+        },
+        "BuildProjectFile": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Path to the build project (.csproj) relative to the repository root. Defaults to 'build/_build.csproj' when unset. Read by the Fallout global tool's in-tool runner."
         }
       }
     }

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -37,5 +37,11 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
       - name: 'Run: Test, Pack'
-        run: ./build.cmd Test Pack
+        run: dotnet fallout Test Pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,14 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-release-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props', 'version.json') }}
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
       - name: 'Run: Test, Pack, Publish'
-        run: ./build.cmd Test Pack Publish
+        run: dotnet fallout Test Pack Publish
         env:
           # Publish target is nuget.org now that Fallout.* rename has landed (#54).
           # NUGET_API_KEY is an API key scoped to push Fallout.* packages, set in

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -42,5 +42,11 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
       - name: 'Run: Test, Pack'
-        run: ./build.cmd Test Pack
+        run: dotnet fallout Test Pack

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -37,5 +37,11 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
       - name: 'Run: Test, Pack'
-        run: ./build.cmd Test Pack
+        run: dotnet fallout Test Pack

--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,0 @@
-:; set -eo pipefail
-:; SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
-:; ${SCRIPT_DIR}/build.sh "$@"
-:; exit $?
-
-@ECHO OFF
-powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0build.ps1" %*

--- a/build.ps1
+++ b/build.ps1
@@ -13,7 +13,6 @@ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 # CONFIGURATION
 ###########################################################################
 
-$BuildProjectFile = Join-Path $PSScriptRoot 'build/_build.csproj'
 $TempDirectory = Join-Path $PSScriptRoot '.fallout/temp'
 
 $DotNetGlobalFile = Join-Path $PSScriptRoot 'global.json'
@@ -34,28 +33,17 @@ function ExecSafe([scriptblock] $cmd) {
     if ($LASTEXITCODE) { exit $LASTEXITCODE }
 }
 
-# Print environment variables
-# WARNING: Make sure that secrets are actually scrambled in build log
-# Get-Item -Path Env:* | Sort-Object -Property Name | ForEach-Object {"{0}={1}" -f $_.Name,$_.Value}
-
-# Check if any dotnet is installed
-if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue)) {
-    ExecSafe { & dotnet --info }
-}
-
-# If dotnet CLI is installed globally and it matches requested version, use for execution
+# If dotnet CLI is installed globally, use it; otherwise provision a local copy under .fallout\temp.
 if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue) -and `
     $(dotnet --version) -and $LASTEXITCODE -eq 0) {
     $env:DOTNET_EXE = (Get-Command "dotnet").Path
 }
 else {
-    # Download install script
     $DotNetInstallFile = Join-Path $TempDirectory 'dotnet-install.ps1'
     New-Item -ItemType Directory -Path $TempDirectory -Force | Out-Null
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     (New-Object System.Net.WebClient).DownloadFile($DotNetInstallUrl, $DotNetInstallFile)
 
-    # If global.json exists, load expected version
     if (Test-Path $DotNetGlobalFile) {
         $DotNetGlobal = $(Get-Content $DotNetGlobalFile | Out-String | ConvertFrom-Json)
         if ($DotNetGlobal.PSObject.Properties["sdk"] -and $DotNetGlobal.sdk.PSObject.Properties["version"]) {
@@ -63,7 +51,6 @@ else {
         }
     }
 
-    # Install by channel or version
     $DotNetDirectory = Join-Path $TempDirectory 'dotnet-win'
     if (!(Test-Path variable:DotNetVersion)) {
         ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Channel $DotNetChannel -NoPath }
@@ -76,5 +63,5 @@ else {
 
 Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
 
-ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary }
-ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }
+ExecSafe { & $env:DOTNET_EXE tool restore }
+ExecSafe { & $env:DOTNET_EXE fallout $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,6 @@ SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 # CONFIGURATION
 ###########################################################################
 
-BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
 TEMP_DIRECTORY="$SCRIPT_DIR/.fallout/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR/global.json"
@@ -29,26 +28,15 @@ function FirstJsonValue {
     perl -nle 'print $1 if m{"'"$1"'": "([^"]+)",?}' <<< "${@:2}"
 }
 
-# Print environment variables
-# WARNING: Make sure that secrets are actually scrambled in build log
-# env | sort
-
-# Check if any dotnet is installed
-if [[ -x "$(command -v dotnet)" ]]; then
-    dotnet --info
-fi
-
-# If dotnet CLI is installed globally and it matches requested version, use for execution
+# If dotnet CLI is installed globally, use it; otherwise provision a local copy under .fallout/temp.
 if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
     export DOTNET_EXE="$(command -v dotnet)"
 else
-    # Download install script
     DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"
     mkdir -p "$TEMP_DIRECTORY"
     curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
     chmod +x "$DOTNET_INSTALL_FILE"
 
-    # If global.json exists, load expected version
     if [[ -f "$DOTNET_GLOBAL_FILE" ]]; then
         DOTNET_VERSION=$(FirstJsonValue "version" "$(cat "$DOTNET_GLOBAL_FILE")")
         if [[ "$DOTNET_VERSION" == ""  ]]; then
@@ -56,7 +44,6 @@ else
         fi
     fi
 
-    # Install by channel or version
     DOTNET_DIRECTORY="$TEMP_DIRECTORY/dotnet-unix"
     if [[ -z ${DOTNET_VERSION+x} ]]; then
         "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --channel "$DOTNET_CHANNEL" --no-path
@@ -69,5 +56,5 @@ fi
 
 echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 
-"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary
-"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"
+"$DOTNET_EXE" tool restore
+exec "$DOTNET_EXE" fallout "$@"

--- a/src/Fallout.Build/CICD/ConfigurationAttributeBase.cs
+++ b/src/Fallout.Build/CICD/ConfigurationAttributeBase.cs
@@ -35,10 +35,15 @@ public abstract class ConfigurationAttributeBase : Attribute, IConfigurationGene
     public abstract CustomFileWriter CreateWriter(StreamWriter streamWriter);
     public abstract ConfigurationEntity GetConfiguration(IReadOnlyCollection<ExecutableTarget> relevantTargets);
 
+    // Used by legacy CI providers (AzurePipelines, AppVeyor, TeamCity, SpaceAutomation) that still emit
+    // ./build.cmd-style step invocations. GitHubActions doesn't read this since v11 — the generator now
+    // emits a three-step setup-dotnet / tool restore / dotnet fallout shape. Falls back to "build.cmd"
+    // when no file is found so generators don't throw mid-emit; consumers who removed build.cmd will see
+    // the broken reference at runtime instead.
     protected virtual string BuildCmdPath =>
         Build.RootDirectory.GlobFiles("build.cmd", "*/build.cmd")
-            .Select(x => Build.RootDirectory.GetUnixRelativePathTo(x))
-            .FirstOrDefault().NotNull("BuildCmdPath != null");
+            .Select(x => Build.RootDirectory.GetUnixRelativePathTo(x).ToString())
+            .FirstOrDefault() ?? "build.cmd";
 
     public void Generate(IReadOnlyCollection<ExecutableTarget> executableTargets)
     {

--- a/src/Fallout.Build/Utilities/SchemaUtility.cs
+++ b/src/Fallout.Build/Utilities/SchemaUtility.cs
@@ -99,6 +99,16 @@ public static class SchemaUtility
         if (userProperties != null)
             userSchema["properties"] = userProperties;
 
+        // BuildProjectFile is read by the Fallout global tool's in-tool runner from .fallout/parameters.json
+        // (see Fallout.GlobalTool.BuildProjectResolver). It's not a [Parameter] on the build itself, but we
+        // surface it in the schema so editors offer IntelliSense when consumers configure a non-conventional
+        // build project path.
+        baseProperties["BuildProjectFile"] = new JsonObject
+        {
+            ["type"] = new JsonArray("null", "string"),
+            ["description"] = "Path to the build project (.csproj) relative to the repository root. Defaults to 'build/_build.csproj' when unset. Read by the Fallout global tool's in-tool runner."
+        };
+
         // Force the framework parameters Skip/Target to reference the ExecutableTarget definition.
         if (baseProperties[InvokedTargetsParameterName] is JsonObject targetProp)
             targetProp["items"] = new JsonObject { ["$ref"] = DefinitionsPrefix + "ExecutableTarget" };

--- a/src/Fallout.Common/CI/GitHubActions/Configuration/GitHubActionsRunStep.cs
+++ b/src/Fallout.Common/CI/GitHubActions/Configuration/GitHubActionsRunStep.cs
@@ -3,9 +3,7 @@
 // Distributed under the MIT License.
 // https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using Fallout.Common.Utilities;
 using Fallout.Common.Utilities.Collections;
 
@@ -13,18 +11,34 @@ namespace Fallout.Common.CI.GitHubActions.Configuration;
 
 public class GitHubActionsRunStep : GitHubActionsStep
 {
-    public string BuildCmdPath { get; set; }
     public string[] InvokedTargets { get; set; }
     public Dictionary<string, string> Imports { get; set; }
 
     public override void Write(CustomFileWriter writer)
     {
-        writer.WriteLine("- name: " + $"Run: {InvokedTargets.JoinCommaSpace()}".SingleQuote());
-        writer.WriteLine($"  run: ./{BuildCmdPath} {InvokedTargets.JoinSpace()}");
-
-        if (Imports.Count > 0)
+        writer.WriteLine("- name: 'Setup: .NET SDK'");
+        using (writer.Indent())
         {
+            writer.WriteLine("uses: actions/setup-dotnet@v4");
+            writer.WriteLine("with:");
             using (writer.Indent())
+            {
+                writer.WriteLine("global-json-file: global.json");
+            }
+        }
+
+        writer.WriteLine("- name: 'Restore: dotnet tools'");
+        using (writer.Indent())
+        {
+            writer.WriteLine("run: dotnet tool restore");
+        }
+
+        writer.WriteLine("- name: " + $"Run: {InvokedTargets.JoinCommaSpace()}".SingleQuote());
+        using (writer.Indent())
+        {
+            writer.WriteLine($"run: dotnet fallout {InvokedTargets.JoinSpace()}");
+
+            if (Imports.Count > 0)
             {
                 writer.WriteLine("env:");
                 using (writer.Indent())

--- a/src/Fallout.Common/CI/GitHubActions/GitHubActionsAttribute.cs
+++ b/src/Fallout.Common/CI/GitHubActions/GitHubActionsAttribute.cs
@@ -195,7 +195,6 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
 
         yield return new GitHubActionsRunStep
                      {
-                         BuildCmdPath = BuildCmdPath,
                          InvokedTargets = InvokedTargets,
                          Imports = GetImports().ToDictionary(x => x.Key, x => x.Value)
                      };

--- a/src/Fallout.GlobalTool/Program.Setup.cs
+++ b/src/Fallout.GlobalTool/Program.Setup.cs
@@ -195,10 +195,6 @@ partial class Program
         AbsolutePath buildDirectory,
         string buildProjectName)
     {
-        (scriptDirectory / "build.cmd").WriteAllLines(
-            FillTemplate(GetTemplate("build.cmd")),
-            platformFamily: PlatformFamily.Linux);
-
         (scriptDirectory / "build.sh").WriteAllLines(
             FillTemplate(
                 GetTemplate("build.sh"),
@@ -206,8 +202,6 @@ partial class Program
                     new
                     {
                         RootDirectory = scriptDirectory.GetUnixRelativePathTo(rootDirectory),
-                        BuildDirectory = scriptDirectory.GetUnixRelativePathTo(buildDirectory),
-                        BuildProjectName = buildProjectName,
                     })),
             platformFamily: PlatformFamily.Linux);
 
@@ -218,12 +212,27 @@ partial class Program
                     new
                     {
                         RootDirectory = scriptDirectory.GetWinRelativePathTo(rootDirectory),
-                        BuildDirectory = scriptDirectory.GetWinRelativePathTo(buildDirectory),
-                        BuildProjectName = buildProjectName,
                     })),
             platformFamily: PlatformFamily.Windows);
 
-        MakeExecutable(scriptDirectory / "build.cmd");
+        // .config/dotnet-tools.json pins Fallout.GlobalTool as a local tool so the thin shims
+        // (build.sh / build.ps1) can `dotnet tool restore` and `dotnet fallout` deterministically.
+        // Skip if the consumer already has a manifest — they may have other tools pinned and we
+        // don't want to clobber. They can add the `fallout.globaltool` entry manually.
+        var toolManifest = rootDirectory / ".config" / "dotnet-tools.json";
+        if (!toolManifest.FileExists())
+        {
+            (rootDirectory / ".config").CreateDirectory();
+            toolManifest.WriteAllLines(
+                FillTemplate(
+                    GetTemplate("dotnet-tools.json"),
+                    tokens: GetDictionary(
+                        new
+                        {
+                            FalloutGlobalToolVersion = typeof(Program).GetTypeInfo().Assembly.GetVersionText(),
+                        })));
+        }
+
         MakeExecutable(scriptDirectory / "build.sh");
 
         void MakeExecutable(AbsolutePath scriptFile)

--- a/src/Fallout.GlobalTool/templates/build.cmd
+++ b/src/Fallout.GlobalTool/templates/build.cmd
@@ -1,7 +1,0 @@
-:; set -eo pipefail
-:; SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
-:; ${SCRIPT_DIR}/build.sh "$@"
-:; exit $?
-
-@ECHO OFF
-powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0build.ps1" %*

--- a/src/Fallout.GlobalTool/templates/build.ps1
+++ b/src/Fallout.GlobalTool/templates/build.ps1
@@ -13,7 +13,6 @@ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 # CONFIGURATION
 ###########################################################################
 
-$BuildProjectFile = Join-Path $PSScriptRoot '_BUILD_DIRECTORY_/_BUILD_PROJECT_NAME_.csproj'
 $TempDirectory = Join-Path $PSScriptRoot '_ROOT_DIRECTORY_/.fallout/temp'
 
 $DotNetGlobalFile = Join-Path $PSScriptRoot '_ROOT_DIRECTORY_/global.json'
@@ -32,19 +31,17 @@ function ExecSafe([scriptblock] $cmd) {
     if ($LASTEXITCODE) { exit $LASTEXITCODE }
 }
 
-# If dotnet CLI is installed globally and it matches requested version, use for execution
+# If dotnet CLI is installed globally, use it; otherwise provision a local copy under .fallout\temp.
 if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue) -and `
      $(dotnet --version) -and $LASTEXITCODE -eq 0) {
     $env:DOTNET_EXE = (Get-Command "dotnet").Path
 }
 else {
-    # Download install script
     $DotNetInstallFile = Join-Path $TempDirectory 'dotnet-install.ps1'
     New-Item -ItemType Directory -Path $TempDirectory -Force | Out-Null
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     (New-Object System.Net.WebClient).DownloadFile($DotNetInstallUrl, $DotNetInstallFile)
 
-    # If global.json exists, load expected version
     if (Test-Path $DotNetGlobalFile) {
         $DotNetGlobal = $(Get-Content $DotNetGlobalFile | Out-String | ConvertFrom-Json)
         if ($DotNetGlobal.PSObject.Properties["sdk"] -and $DotNetGlobal.sdk.PSObject.Properties["version"]) {
@@ -52,7 +49,6 @@ else {
         }
     }
 
-    # Install by channel or version
     $DotNetDirectory = Join-Path $TempDirectory 'dotnet-win'
     if (!(Test-Path variable:DotNetVersion)) {
         ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Channel $DotNetChannel -NoPath }
@@ -65,10 +61,5 @@ else {
 
 Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
 
-if (Test-Path env:NUKE_ENTERPRISE_TOKEN) {
-    & $env:DOTNET_EXE nuget remove source "nuke-enterprise" > $null
-    & $env:DOTNET_EXE nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password $env:NUKE_ENTERPRISE_TOKEN > $null
-}
-
-ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
-ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }
+ExecSafe { & $env:DOTNET_EXE tool restore }
+ExecSafe { & $env:DOTNET_EXE fallout $BuildArguments }

--- a/src/Fallout.GlobalTool/templates/build.sh
+++ b/src/Fallout.GlobalTool/templates/build.sh
@@ -9,7 +9,6 @@ SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 # CONFIGURATION
 ###########################################################################
 
-BUILD_PROJECT_FILE="$SCRIPT_DIR/_BUILD_DIRECTORY_/_BUILD_PROJECT_NAME_.csproj"
 TEMP_DIRECTORY="$SCRIPT_DIR/_ROOT_DIRECTORY_/.fallout/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR/_ROOT_DIRECTORY_/global.json"
@@ -27,17 +26,15 @@ function FirstJsonValue {
     perl -nle 'print $1 if m{"'"$1"'": "([^"]+)",?}' <<< "${@:2}"
 }
 
-# If dotnet CLI is installed globally and it matches requested version, use for execution
+# If dotnet CLI is installed globally, use it; otherwise provision a local copy under .fallout/temp.
 if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
     export DOTNET_EXE="$(command -v dotnet)"
 else
-    # Download install script
     DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"
     mkdir -p "$TEMP_DIRECTORY"
     curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
     chmod +x "$DOTNET_INSTALL_FILE"
 
-    # If global.json exists, load expected version
     if [[ -f "$DOTNET_GLOBAL_FILE" ]]; then
         DOTNET_VERSION=$(FirstJsonValue "version" "$(cat "$DOTNET_GLOBAL_FILE")")
         if [[ "$DOTNET_VERSION" == ""  ]]; then
@@ -45,7 +42,6 @@ else
         fi
     fi
 
-    # Install by channel or version
     DOTNET_DIRECTORY="$TEMP_DIRECTORY/dotnet-unix"
     if [[ -z ${DOTNET_VERSION+x} ]]; then
         "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --channel "$DOTNET_CHANNEL" --no-path
@@ -58,10 +54,5 @@ fi
 
 echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 
-if [[ ! -z ${NUKE_ENTERPRISE_TOKEN+x} && "$NUKE_ENTERPRISE_TOKEN" != "" ]]; then
-    "$DOTNET_EXE" nuget remove source "nuke-enterprise" &>/dev/null || true
-    "$DOTNET_EXE" nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password "$NUKE_ENTERPRISE_TOKEN" --store-password-in-clear-text &>/dev/null || true
-fi
-
-"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
-"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"
+"$DOTNET_EXE" tool restore
+exec "$DOTNET_EXE" fallout "$@"

--- a/src/Fallout.GlobalTool/templates/dotnet-tools.json
+++ b/src/Fallout.GlobalTool/templates/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fallout.globaltool": {
+      "version": "_FALLOUT_GLOBAL_TOOL_VERSION_",
+      "commands": [
+        "fallout"
+      ]
+    }
+  }
+}

--- a/tests/Fallout.Build.Tests/CompletionUtilityTest.TestGetCompletionItemsParameterBuild.verified.txt
+++ b/tests/Fallout.Build.Tests/CompletionUtilityTest.TestGetCompletionItemsParameterBuild.verified.txt
@@ -1,5 +1,6 @@
 ﻿{
   BooleanParam: [],
+  BuildProjectFile: [],
   ComponentInheritedParam: [],
   Continue: [],
   CustomEnumerationArrayParam: [

--- a/tests/Fallout.Build.Tests/CompletionUtilityTest.TestGetCompletionItemsTargetBuild.verified.txt
+++ b/tests/Fallout.Build.Tests/CompletionUtilityTest.TestGetCompletionItemsTargetBuild.verified.txt
@@ -1,4 +1,5 @@
 ﻿{
+  BuildProjectFile: [],
   Continue: [],
   Help: [],
   Host: [

--- a/tests/Fallout.Build.Tests/SchemaUtilityTest.TestCustomParameterAttribute.verified.json
+++ b/tests/Fallout.Build.Tests/SchemaUtilityTest.TestCustomParameterAttribute.verified.json
@@ -77,6 +77,13 @@
         "Verbosity": {
           "description": "Logging verbosity during build execution. Default is 'Normal'",
           "$ref": "#/definitions/Verbosity"
+        },
+        "BuildProjectFile": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Path to the build project (.csproj) relative to the repository root. Defaults to 'build/_build.csproj' when unset. Read by the Fallout global tool's in-tool runner."
         }
       }
     }

--- a/tests/Fallout.Build.Tests/SchemaUtilityTest.TestEmptyBuild.verified.json
+++ b/tests/Fallout.Build.Tests/SchemaUtilityTest.TestEmptyBuild.verified.json
@@ -77,6 +77,13 @@
         "Verbosity": {
           "description": "Logging verbosity during build execution. Default is 'Normal'",
           "$ref": "#/definitions/Verbosity"
+        },
+        "BuildProjectFile": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Path to the build project (.csproj) relative to the repository root. Defaults to 'build/_build.csproj' when unset. Read by the Fallout global tool's in-tool runner."
         }
       }
     }

--- a/tests/Fallout.Build.Tests/SchemaUtilityTest.TestParameterBuild.verified.json
+++ b/tests/Fallout.Build.Tests/SchemaUtilityTest.TestParameterBuild.verified.json
@@ -122,6 +122,13 @@
         "Verbosity": {
           "description": "Logging verbosity during build execution. Default is 'Normal'",
           "$ref": "#/definitions/Verbosity"
+        },
+        "BuildProjectFile": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Path to the build project (.csproj) relative to the repository root. Defaults to 'build/_build.csproj' when unset. Read by the Fallout global tool's in-tool runner."
         }
       }
     }

--- a/tests/Fallout.Build.Tests/SchemaUtilityTest.TestTargetBuild.verified.json
+++ b/tests/Fallout.Build.Tests/SchemaUtilityTest.TestTargetBuild.verified.json
@@ -83,6 +83,13 @@
         "Verbosity": {
           "description": "Logging verbosity during build execution. Default is 'Normal'",
           "$ref": "#/definitions/Verbosity"
+        },
+        "BuildProjectFile": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Path to the build project (.csproj) relative to the repository root. Defaults to 'build/_build.csproj' when unset. Read by the Fallout global tool's in-tool runner."
         }
       }
     }

--- a/tests/Fallout.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
+++ b/tests/Fallout.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
@@ -74,8 +74,14 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
       - name: 'Run: Test'
-        run: ./build.cmd Test
+        run: dotnet fallout Test
         env:
           OptionalInput: ${{ github.event.inputs.OptionalInput }}
           RequiredInput: ${{ github.event.inputs.RequiredInput }}
@@ -122,8 +128,14 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
       - name: 'Run: Test'
-        run: ./build.cmd Test
+        run: dotnet fallout Test
         env:
           OptionalInput: ${{ github.event.inputs.OptionalInput }}
           RequiredInput: ${{ github.event.inputs.RequiredInput }}
@@ -170,8 +182,14 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
       - name: 'Run: Test'
-        run: ./build.cmd Test
+        run: dotnet fallout Test
         env:
           OptionalInput: ${{ github.event.inputs.OptionalInput }}
           RequiredInput: ${{ github.event.inputs.RequiredInput }}

--- a/tests/Fallout.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=simple-triggers_attribute=GitHubActionsAttribute.verified.txt
+++ b/tests/Fallout.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=simple-triggers_attribute=GitHubActionsAttribute.verified.txt
@@ -35,8 +35,14 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
       - name: 'Run: Test'
-        run: ./build.cmd Test
+        run: dotnet fallout Test
         env:
           ApiKey: ${{ secrets.API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -67,8 +73,14 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
       - name: 'Run: Test'
-        run: ./build.cmd Test
+        run: dotnet fallout Test
         env:
           ApiKey: ${{ secrets.API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,8 +111,14 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
       - name: 'Run: Test'
-        run: ./build.cmd Test
+        run: dotnet fallout Test
         env:
           ApiKey: ${{ secrets.API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Second of three PRs from #203. PR-A (#201) shipped the in-tool runner; this PR cuts THIS repo over to thin shims, regenerates the workflows, and updates the framework so downstream consumers re-generating with v11+ get the new shape.

**Breaking change:** `[GitHubActions]` generator now emits 3 steps (`setup-dotnet` + `tool restore` + `dotnet fallout`) instead of one `./{BuildCmdPath} {targets}` line. Downstream consumers need a `.config/dotnet-tools.json` with `Fallout.GlobalTool` pinned for their next workflow regen to be runnable in CI.

## This repo's cutover

- **`.config/dotnet-tools.json`** — pins `Fallout.GlobalTool` 10.3.37 (the version just published from #201's merge).
- **`build.sh` / `build.ps1`** — thin (~60 lines each): kept the dotnet provisioning block verbatim, dropped the `BUILD_PROJECT_FILE` config + explicit `dotnet build`/`dotnet run --project` lines, end with `tool restore` + `dotnet fallout "$@"`.
- **`build.cmd`** — deleted (was a one-line dispatcher to `build.ps1`).
- **`.github/workflows/{ubuntu,windows,macos}-latest.yml`** — regenerated to the new 3-step shape.
- **`.github/workflows/release.yml`** — hand-written (kept that way per its header comment); updated to the same shape with the existing `NuGetApiKey` / `GITHUB_TOKEN` env mapping preserved.

## Framework changes

- `Fallout.Common/CI/GitHubActions/Configuration/GitHubActionsRunStep.cs` — rewritten to emit 3 steps; drops the `BuildCmdPath` field.
- `Fallout.Common/CI/GitHubActions/GitHubActionsAttribute.cs` — stops passing `BuildCmdPath` to the run step.
- `Fallout.Build/CICD/ConfigurationAttributeBase.cs` — softens `BuildCmdPath` to fall back to `"build.cmd"` instead of asserting when no file is found. Keeps the legacy CI providers (AzurePipelines, AppVeyor, TeamCity, SpaceAutomation) functional for consumers who still have `build.cmd`, without forcing this repo to keep one. Those providers are dormant / dead-code per #8.
- `Fallout.Build/Utilities/SchemaUtility.cs` — injects a synthetic `BuildProjectFile` (optional string, with description) into the `FalloutBuild` base schema. Editors now offer IntelliSense for the `BuildProjectFile` field that `BuildProjectResolver` reads from `.fallout/parameters.json`.
- `Fallout.GlobalTool/Program.Setup.cs` (`WriteBuildScripts`) — drops `build.cmd` emission, emits the thin templates, creates `.config/dotnet-tools.json` (skipped if one already exists — consumer may have other tools pinned). Drops the now-unused `BuildDirectory` / `BuildProjectName` token substitutions in shim templates.
- New template `Fallout.GlobalTool/templates/dotnet-tools.json` with `_FALLOUT_GLOBAL_TOOL_VERSION_` filled at `:setup` time from the running tool's own assembly version.

## Test updates

- `SchemaUtilityTest.Test*.verified.json` (×4) — add `BuildProjectFile` after `Verbosity`.
- `CompletionUtilityTest.TestGetCompletionItems{Target,Parameter}Build.verified.txt` — add `BuildProjectFile: []` in alphabetical position.
- `ConfigurationGenerationTest.Test_testName={simple,detailed}-triggers_attribute=GitHubActionsAttribute.verified.txt` — expect the new 3-step shape.
- `.fallout/build.schema.json` — regenerated by the build's own `HandleShellCompletionAttribute`.

## Verification

Locally on Windows:
- `dotnet test tests/Fallout.Build.Tests/` — 23/23 passed (schema + completion utility tests).
- `dotnet test tests/Fallout.Common.Tests/ --filter ConfigurationGenerationTest` — 6/6 passed.
- `dotnet test tests/Fallout.GlobalTool.Tests/` — 17/17 passed.
- End-to-end thin-shim cycle: `dotnet tool restore` resolved `Fallout.GlobalTool 10.3.37` from nuget.org, `dotnet fallout` dispatched into the in-tool runner, which built + ran `_build.csproj` with the new framework code.

## Backwards compatibility

| Scenario | Behaviour |
|---|---|
| Existing consumer repo with old fat `build.sh` / `build.ps1`, no v11 changes | Works unchanged. Their shims do their own `dotnet build` + `dotnet run --project`; the global tool isn't on their critical path. |
| Existing consumer repo upgrading to `Fallout.GlobalTool` v11 and running `fallout :setup` | `:setup` overwrites their `build.sh` / `build.ps1` with thin shims, drops `build.cmd`, and (if they don't already have one) creates `.config/dotnet-tools.json`. They commit those changes. |
| Existing consumer repo that regens `[GitHubActions]` workflows | Workflows now emit the 3-step shape. **They need `.config/dotnet-tools.json` for CI to pass.** If they re-run `:setup` first, it's created automatically; otherwise they add it manually. |
| Consumer who uses other CI providers (AzurePipelines, AppVeyor, TeamCity, SpaceAutomation) | Unchanged. Those generators still emit `./build.cmd`-style invocations and still need `build.cmd` in the consumer's repo. |
| Consumer who already has a `.config/dotnet-tools.json` with other tools pinned | `:setup` does NOT overwrite. They need to add the `fallout.globaltool` entry manually (or run `dotnet tool install Fallout.GlobalTool` from their repo root, which merges into the existing manifest). |

## Not in scope (follow-up)

- `Program.cs` `Build()` method left alive (one bootstrap caller in `Program.Complete.cs`); shim hop is now redundant but harmless. Cleanup tracked separately.
- Docs sweep tracked in #198 (PR-C).
- `Fallout.Common.targets` could surface `.config/dotnet-tools.json` in the IDE "boot" link group alongside `build.sh`/`build.ps1`. Cosmetic; deferred.

## Test plan

- [ ] `ubuntu-latest` (the only PR gate) goes green — exercises the new 3-step workflow shape end-to-end (`setup-dotnet` → `tool restore` resolves `Fallout.GlobalTool 10.3.37` from nuget.org → `dotnet fallout Test Pack` round-trips through the in-tool runner).
- [ ] Post-merge, watch `windows-latest` and `macos-latest` runs on `main` — they exercise the same shape on the other two platforms.
- [ ] Post-merge, the release pipeline pushes a new `Fallout.GlobalTool` version with PR-B's framework changes. PR-C (docs sweep, #198) can land any time after.

## Refs

- This PR: PR-B of the bootstrapper-deprecation plan in #203.
- Previous: PR-A (#201) — in-tool runner.
- Next: PR-C (#198) — docs sweep.