### PR TITLE
docs: PR-C — rebrand CLI references + new shim shape (#198, #203)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Validation workflows: **`ubuntu-latest`** runs on every PR targeting `main` (wit
 
 **Versioning:** [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) — configured in `version.json` at the repo root. Major+minor is hand-bumped; patch comes from git-height. `main` is the public-release ref (stable versions); everything else gets prerelease tags. GitVersion is still installed as a transitional helper for `MajorMinorPatchVersion` in `Build.cs`; full removal is a follow-up.
 
-**Release pipeline:** `.github/workflows/release.yml` — triggered on push to `main`, runs `./build.cmd Test Pack Publish`. **Publishes to nuget.org** (`https://api.nuget.org/v3/index.json`) under the `Fallout.*` package ID prefix, using the `NUGET_API_KEY` repo secret (a nuget.org API key scoped to push `Fallout.*`). Prefix reservation tracked in [#33](https://github.com/ChrisonSimtian/Fallout/issues/33).
+**Release pipeline:** `.github/workflows/release.yml` — triggered on push to `main`, runs the three-step shape (`actions/setup-dotnet` → `dotnet tool restore` → `dotnet fallout Test Pack Publish`). **Publishes to nuget.org** (`https://api.nuget.org/v3/index.json`) under the `Fallout.*` package ID prefix, using the `NUGET_API_KEY` repo secret (a nuget.org API key scoped to push `Fallout.*`). Prefix reservation tracked in [#33](https://github.com/ChrisonSimtian/Fallout/issues/33).
 
 ## Conventions worth respecting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,13 @@ Fallout welcomes contributions. As a community, we want to help each other, prov
 
 ## Where to start
 
-- Discuss non-trivial changes in an [issue](https://github.com/ChrisonSimtian/nuke/issues) first.
+- Discuss non-trivial changes in an [issue](https://github.com/ChrisonSimtian/Fallout/issues) first.
 - Small fixes (typos, broken links, tool wrapper additions) can go straight to a PR against `main`.
 - We're trunk-based: branch from `main`, open a PR against `main`. No `develop` or `release/*` branches.
 
 ## Baseline contributions
 
-- Star the [GitHub project](https://github.com/ChrisonSimtian/nuke/stargazers) to help others find it.
+- Star the [GitHub project](https://github.com/ChrisonSimtian/Fallout/stargazers) to help others find it.
 - File issues with concrete reproduction steps, version info, and logs.
 - Help triage existing issues — confirming bugs or pointing to fixes counts.
 
@@ -34,7 +34,7 @@ Fallout welcomes contributions. As a community, we want to help each other, prov
 
 - Bugs blocking active enterprise CI/CD usage.
 - Regressions versus the last NUKE 10.x release.
-- Rebrand-track work (see the [Fallout rebrand milestone](https://github.com/ChrisonSimtian/nuke/milestone/1)).
+- Rebrand-track work (see the [Fallout rebrand milestone](https://github.com/ChrisonSimtian/Fallout/milestone/1)).
 - Demand-driven items where multiple users have weighed in.
 
 ## Pull requests
@@ -44,7 +44,8 @@ Fallout welcomes contributions. As a community, we want to help each other, prov
 - Branch from `main`. Name your branch `feature/<slug>`, `bugfix/<slug>`, or `chore/<slug>`.
 - Make sure your employer allows the contribution.
 - Read [CLAUDE.md](CLAUDE.md) for the codebase conventions — package versions go in `Directory.Packages.props`, license headers are mechanical, tests live next to code.
-- Run `./build.ps1 Test` (or `./build.sh Test`) locally first.
+- The bootstrappers are now thin: `./build.ps1` / `./build.sh` provision .NET if needed, then run `dotnet tool restore` + `dotnet fallout "$@"`. The `Fallout.GlobalTool` version is pinned in `.config/dotnet-tools.json`.
+- Run `./build.ps1 Test` (or `./build.sh Test`, or directly `dotnet fallout Test` once your tools are restored) locally first.
 
 ### When writing the PR
 
@@ -55,7 +56,7 @@ Fallout welcomes contributions. As a community, we want to help each other, prov
 
 ### Tool wrappers
 
-Tool wrapper JSON lives under `src/Nuke.Common/Tools/<Tool>/<Tool>.json`. When adding or extending one:
+Tool wrapper JSON lives under `src/Fallout.Common/Tools/<Tool>/<Tool>.json`. When adding or extending one:
 
 - Copy the shape from a neighbouring tool.
 - Cover at least a full command with all its arguments.
@@ -72,6 +73,6 @@ Tool wrapper JSON lives under `src/Nuke.Common/Tools/<Tool>/<Tool>.json`. When a
 
 ### After opening a PR
 
-- CI runs `ubuntu-latest`, `windows-latest`, and `macos-latest` matrices.
+- The PR gate is `ubuntu-latest` only (docs-only PRs hit a noop workflow). `windows-latest` and `macos-latest` run post-merge on `main` as release validation.
 - Address review feedback in additional commits rather than force-pushing — easier to review the changes.
 - If CI fails on something unrelated to your change, ping a maintainer.

--- a/docs/01-getting-started/01-installation.md
+++ b/docs/01-getting-started/01-installation.md
@@ -2,12 +2,16 @@
 title: Installation
 ---
 
-Before you can set up a build project, you need to install NUKE's dedicated [.NET global tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools):
+Before you can set up a build project, you need to install Fallout's dedicated [.NET global tool](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools):
 
 ```powershell
 # terminal-command
-dotnet tool install Nuke.GlobalTool --global
+dotnet tool install Fallout.GlobalTool --global
 ```
+
+:::tip
+For repos that already have a `.config/dotnet-tools.json` manifest with `Fallout.GlobalTool` pinned (this is what `fallout :setup` creates), you can skip the global install and run `dotnet tool restore` instead — the local manifest version then takes precedence.
+:::
 
 From now on, you can use the global tool to:
 
@@ -35,5 +39,5 @@ echo 'export PATH=$HOME/.dotnet/tools:$PATH' >> ~/.zshrc
 :::
 
 :::info
-While theoretically, you could use NUKE by only adding its main NuGet package, we highly recommend using the dedicated global tool to set up new builds. This ensures that your repository will run consistently in different environments and that your build implementation is always properly formatted.
+While theoretically, you could use Fallout by only adding its main NuGet package, we highly recommend using the dedicated global tool to set up new builds. This ensures that your repository will run consistently in different environments and that your build implementation is always properly formatted.
 :::

--- a/docs/01-getting-started/02-setup.md
+++ b/docs/01-getting-started/02-setup.md
@@ -4,15 +4,15 @@ title: Build Setup
 
 import AsciinemaPlayer from '@site/src/components/AsciinemaPlayer';
 
-After [installing the NUKE global tool](01-installation.md), you can call it from anywhere on your machine to set up a new build:
+After [installing the Fallout global tool](01-installation.md), you can call it from anywhere on your machine to set up a new build:
 
 ```powershell
 # terminal-command
-nuke :setup
+fallout :setup
 ```
 
 :::tip
-Preferably, you should run the setup from inside an existing repository. NUKE will search for the next upwards `.git` or `.svn` directory to determine the _build root directory_. If neither is found, it will use the current directory. You can also pass the `--root` parameter to specify that the current directory should be used as a root directory.
+Preferably, you should run the setup from inside an existing repository. Fallout will search for the next upwards `.git` or `.svn` directory to determine the _build root directory_. If neither is found, it will use the current directory. You can also pass the `--root` parameter to specify that the current directory should be used as a root directory.
 :::
 
 During the setup, you'll be asked several questions to configure your build to your preferences:
@@ -33,41 +33,43 @@ The setup will create a number of files in your repository and – if you've cho
 
 ```bash
 <root-directory>
-├── .nuke                           # Root directory marker
+├── .config
+│   └── dotnet-tools.json           # Local tool manifest pinning Fallout.GlobalTool
+│
+├── .fallout                        # Root directory marker
 │   ├── build.schema.json           # Build schema file
 │   └── parameters.json             # Default parameters file
 │
 ├── build
-│   ├── .editorconfig               # Common formatting
 │   ├── _build.csproj               # Build project file
-│   ├── _build.csproj.DotSettings   # ReSharper/Rider formatting
 │   ├── Build.cs                    # Default build implementation
 │   ├── Directory.Build.props       # MSBuild stop files
 │   └── Directory.Build.targets
 │
-├── build.cmd                       # Cross-platform bootstrapping
 ├── build.ps1                       # Windows/PowerShell bootstrapping
 └── build.sh                        # Linux/Shell bootstrapping
 ```
 
 :::note
-If you prefer, you _may_ choose to delete any of the bootstrapping scripts, MSBuild stop files, or formatting settings. For instance, when you're sure that no other MSBuild files will interfere with the build project, or you don't rely on either Roslyn or ReSharper/Rider for formatting. However, note that the **bootstrapping scripts play an essential role** in CI/CD environments, and are also used for the configuration generation feature.
+The two thin bootstrappers (`build.ps1` and `build.sh`) provision the .NET SDK locally when it's not on `PATH`, then run `dotnet tool restore` and `dotnet fallout "$@"`. They're optional once you have a global `dotnet` install and have run `dotnet tool restore` at least once — but they're the safest way to run the build in CI and on a freshly-cloned machine. The `.config/dotnet-tools.json` manifest pins the exact `Fallout.GlobalTool` version your build expects.
 :::
 
 ## Project Structure
 
-While you can enjoy writing most build-relevant logic inside your build console applications, there is still a large number of files involved in the general process of build automation. NUKE organizes these files in different folders as linked files in the build project for you:
+While you can enjoy writing most build-relevant logic inside your build console applications, there is still a large number of files involved in the general process of build automation. Fallout organizes these files in different folders as linked files in the build project for you:
 
 <Tabs>
   <TabItem value="config" label="Config" default>
 
 ```powershell
 <root-directory>
-├── .nuke
+├── .config
+│   └── dotnet-tools.json    # Local tool manifest (Fallout.GlobalTool pin)
+│
+├── .fallout
 │   ├── parameters.json      # Parameters files
 │   └── parameters.*.json
 │
-├── GitVersion.yml           # GitVersion configuration
 ├── global.json              # SDK version
 ├── nuget.config             # NuGet feeds configuration
 └── version.json             # Nerdbank GitVersioning configuration
@@ -100,9 +102,8 @@ While you can enjoy writing most build-relevant logic inside your build console 
 
 ```powershell
 <root-directory>
-├── build.cmd                # Cross-platform
-├── build.ps1                # Windows/PowerShell
-└── build.sh                 # Linux/Shell
+├── build.ps1                # Windows/PowerShell — thin shim, calls dotnet fallout
+└── build.sh                 # Linux/Shell — thin shim, calls dotnet fallout
 ```
 
   </TabItem>
@@ -119,15 +120,15 @@ While you can enjoy writing most build-relevant logic inside your build console 
 </Tabs>
 
 :::info
-You can deactivate linking of the above files by removing the `NukeRootDirectory` and `NukeScriptDirectory` properties from the build project file.
+You can deactivate linking of the above files by removing the `FalloutRootDirectory` and `FalloutScriptDirectory` properties from the build project file. (Legacy `NukeRootDirectory` / `NukeScriptDirectory` properties are still recognized for migration but should be renamed.)
 
 ```xml title="_build.csproj"
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     // highlight-start
-    {/* <NukeRootDirectory>..</NukeRootDirectory> */}
-    {/* <NukeScriptDirectory>..</NukeScriptDirectory> */}
+    {/* <FalloutRootDirectory>..</FalloutRootDirectory> */}
+    {/* <FalloutScriptDirectory>..</FalloutScriptDirectory> */}
     // highlight-end
   </PropertyGroup>
 

--- a/docs/01-getting-started/03-execution.md
+++ b/docs/01-getting-started/03-execution.md
@@ -11,7 +11,7 @@ After you've [set up a build](02-setup.md) you can run it either through the glo
 
 ```powershell
 # terminal-command
-nuke [arguments]
+fallout [arguments]
 ```
 
   </TabItem>
@@ -19,7 +19,7 @@ nuke [arguments]
 
 ```powershell
 # terminal-command
-.\build.cmd [arguments]
+.\build.ps1 [arguments]
 ```
 
   </TabItem>
@@ -32,6 +32,10 @@ nuke [arguments]
 
 </TabItem>
 </Tabs>
+
+:::info
+The bootstrappers are thin: they provision the .NET SDK if it isn't already installed, run `dotnet tool restore` (to pin the `Fallout.GlobalTool` version from `.config/dotnet-tools.json`), then forward to `dotnet fallout`. Once `dotnet` is on your `PATH` and tools are restored, `fallout [arguments]` and `./build.sh [arguments]` do the same thing.
+:::
 
 :::info
 This document discusses the default build arguments (also referred to as parameters). You will learn how to [define custom parameters](../02-fundamentals/06-parameters.md) in a following chapter.
@@ -83,7 +87,7 @@ You can invoke a single target or a set of targets either through positional or 
 
 ```powershell
 # terminal-command
-nuke <target> [other-targets...]
+fallout <target> [other-targets...]
 ```
 
   </TabItem>
@@ -91,7 +95,7 @@ nuke <target> [other-targets...]
 
 ```powershell
 # terminal-command
-nuke [arguments...] --targets <target> [other-targets...]
+fallout [arguments...] --targets <target> [other-targets...]
 ```
 
   </TabItem>
@@ -110,7 +114,7 @@ You can skip all or individual targets from the execution plan that are not spec
 
 ```powershell
 # terminal-command
-nuke [targets] --skip
+fallout [targets] --skip
 ```
 
   </TabItem>
@@ -118,7 +122,7 @@ nuke [targets] --skip
 
 ```powershell
 # terminal-command
-nuke [targets] --skip <other-targets...>
+fallout [targets] --skip <other-targets...>
 ```
 
   </TabItem>
@@ -150,7 +154,7 @@ You can continue a failed or aborted build from the first point of failure:
 
 ```powershell
 # terminal-command
-nuke [arguments...] --continue
+fallout [arguments...] --continue
 ```
 
 All previously succeeded targets will be skipped automatically, which can save a lot of unnecessary execution time:
@@ -188,7 +192,7 @@ When you're coming back to a repository or build you haven't worked on in a whil
 
 ```powershell
 # terminal-command
-nuke --help
+fallout --help
 ```
 
 This allows you to inspect all available targets with their direct dependencies as well as parameters with their descriptions:
@@ -208,7 +212,7 @@ Parameters:
   --continue              Indicates to continue a previously failed build attempt.
   --help                  Shows the help text for this build assembly.
   --host                  Host for execution. Default is 'automatic'.
-  --no-logo               Disables displaying the NUKE logo.
+  --no-logo               Disables displaying the Fallout logo.
   --plan                  Shows the execution plan (HTML).
   --profile               Defines the profiles to load.
   --root                  Root directory during build execution.
@@ -225,7 +229,7 @@ In order to get a better understanding of how your builds are structured, you ca
 
 ```powershell
 # terminal-command
-nuke --plan
+fallout --plan
 ```
 
 Hovering a target will show its individual execution plan, that means, all targets that are going to be executed when one specific target is invoked. The style of an edge (solid/dashed/yellow) between two targets indicates their [dependency relation](../02-fundamentals/05-targets.md#dependencies) (execution/ordering/trigger):

--- a/docs/01-getting-started/07-telemetry.md
+++ b/docs/01-getting-started/07-telemetry.md
@@ -40,8 +40,8 @@ As a global tool and library, Fallout has [multiple events](https://github.com/C
 
 - `BuildStarted` – when a build was started
 - `TargetSucceeded` – when a target succeeded (only `Restore`, `Compile`, `Test`)
-- `BuildSetup` – when setting up a build via `nuke [:setup]`
-- `CakeConvert` – when converting Cake files via `nuke :cake-convert`
+- `BuildSetup` – when setting up a build via `fallout [:setup]`
+- `CakeConvert` – when converting Cake files via `fallout :cake-convert`
 
 :::info
 Data for `BuildStarted` and `TargetSucceeded` is only collected when `IsServerBuild` returns `true` (i.e., CI build), or the build is invoked via global tool. I.e., a contributor executing `build.ps1` or `build.sh` will not have telemetry enabled unknowingly. Likewise, when a build project targets a higher telemetry version than the installed global tool, the lower version will be used.

--- a/docs/02-fundamentals/04-builds.md
+++ b/docs/02-fundamentals/04-builds.md
@@ -2,7 +2,7 @@
 title: Build Anatomy
 ---
 
-A build project is a regular .NET console application. However, unlike regular console applications, NUKE chooses to name the main class `Build` instead of `Program`. This establishes a convention and allows easier navigation in your solution. The `Build` class must inherit from the `FalloutBuild` base class and define a `Main` method to invoke the build execution and define any number of default targets:
+A build project is a regular .NET console application. However, unlike regular console applications, Fallout chooses to name the main class `Build` instead of `Program`. This establishes a convention and allows easier navigation in your solution. The `Build` class must inherit from the `FalloutBuild` base class and define a `Main` method to invoke the build execution and define any number of default targets:
 
 <Tabs>
   <TabItem value="single" label="Single Default&nbsp;Target">

--- a/docs/02-fundamentals/06-parameters.md
+++ b/docs/02-fundamentals/06-parameters.md
@@ -2,7 +2,7 @@
 title: Parameters
 ---
 
-Another important aspect of build automation is the ability of passing input values to your build. These input values can be anything from generic texts, numeric and enum values, file and directory paths, arrays of aforementioned, boolean flags, or secrets. NUKE comes with a succinct way to declare parameters and lets you set their values in various ways.
+Another important aspect of build automation is the ability of passing input values to your build. These input values can be anything from generic texts, numeric and enum values, file and directory paths, arrays of aforementioned, boolean flags, or secrets. Fallout comes with a succinct way to declare parameters and lets you set their values in various ways.
 
 You can declare a parameter by adding the `Parameter` attribute to a field or property:
 
@@ -34,7 +34,7 @@ In the most straightforward way, you can pass parameter values from the command-
 
 ```powershell
 # terminal-command
-nuke --my-parameter <value>
+fallout --my-parameter <value>
 ```
 
 :::tip
@@ -43,7 +43,7 @@ With the global tool installed and [shell completion](../06-global-tool/00-shell
 
 ### Passing Values through Parameter Files
 
-Instead of providing default values in your `Build` class or repeatedly specifying them through the command-line, you can also define them in so-called parameter files (JSON). These files are located under the `.nuke` directory:
+Instead of providing default values in your `Build` class or repeatedly specifying them through the command-line, you can also define them in so-called parameter files (JSON). These files are located under the `.fallout` directory:
 
 ```json title=".fallout/parameters.json"
 {
@@ -56,7 +56,7 @@ Besides the default `parameters.json` file, you can create additional profiles f
 
 ```powershell
 # terminal-command
-nuke --profile <name> [other-profiles...]
+fallout --profile <name> [other-profiles...]
 ```
 
 :::info
@@ -73,16 +73,16 @@ Based on the `build.schema.json` file, you can easily configure your parameters 
 
 </p>
 
-Remember, that the `build.schema.json` file must be regenerated whenever you add or change a parameter. For instance by calling `nuke --help`.
+Remember, that the `build.schema.json` file must be regenerated whenever you add or change a parameter. For instance by calling `fallout --help`.
 :::
 
 ### Passing Values through Environment Variables
 
-You can set parameter values through environment variables, which can be really helpful when setting up global values in CI/CD pipelines. This is done in such a manner that casing and underscores are completely ignored. Also, you can use the `NUKE_` prefix to easily distinguish them from others:
+You can set parameter values through environment variables, which can be really helpful when setting up global values in CI/CD pipelines. This is done in such a manner that casing and underscores are completely ignored. Also, you can use the `FALLOUT_` prefix to easily distinguish them from others (the legacy `NUKE_` prefix is still honoured during the 10.x line for backwards compatibility):
 
 ```powershell
 SET MY_PARAMETER = <value>
-SET NUKE_MY_PARAMETER = <value>
+SET FALLOUT_MY_PARAMETER = <value>
 ```
 
 ## Required Parameters

--- a/docs/02-fundamentals/10-logging.md
+++ b/docs/02-fundamentals/10-logging.md
@@ -2,7 +2,7 @@
 title: Logging
 ---
 
-As with any other application, good logging greatly reduces the time to detect the source of errors and fix them quickly. NUKE integrates with [Serilog](https://serilog.net/) and prepares a console and file logger for you. Most functions with side effects will automatically log their performed actions. This also includes [invocations of CLI tools](../03-common/08-cli-tools.md). Of course, you can also add your own log messages:
+As with any other application, good logging greatly reduces the time to detect the source of errors and fix them quickly. Fallout integrates with [Serilog](https://serilog.net/) and prepares a console and file logger for you. Most functions with side effects will automatically log their performed actions. This also includes [invocations of CLI tools](../03-common/08-cli-tools.md). Of course, you can also add your own log messages:
 
 ```csharp
 // using Serilog;
@@ -33,7 +33,7 @@ Log messages are only written to console when the appropriate `LogLevel` is set.
 
 ```powershell
 # terminal-command
-nuke --verbosity verbose
+fallout --verbosity verbose
 ```
 
   </TabItem>
@@ -41,7 +41,7 @@ nuke --verbosity verbose
 
 ```powershell
 # terminal-command
-nuke --verbosity normal
+fallout --verbosity normal
 ```
 
   </TabItem>
@@ -49,7 +49,7 @@ nuke --verbosity normal
 
 ```powershell
 # terminal-command
-nuke --verbosity minimal
+fallout --verbosity minimal
 ```
 
   </TabItem>
@@ -57,7 +57,7 @@ nuke --verbosity minimal
 
 ```powershell
 # terminal-command
-nuke --verbosity quiet
+fallout --verbosity quiet
 ```
 
   </TabItem>

--- a/docs/03-common/03-paths.md
+++ b/docs/03-common/03-paths.md
@@ -2,7 +2,7 @@
 title: Constructing Paths
 ---
 
-Referencing files and directories seems like a trivial task. Nevertheless, developers often run into problems where relative paths no longer match the current working directory, or find themselves fixing path separator issues that stem from [historical design decisions](https://www.youtube.com/watch?v=5T3IJfBfBmI). NUKE follows the approach to use absolute paths whenever possible, which ensures explicitness and allows copying [tool invocations](08-cli-tools.md) from the log and executing them from anywhere you are.
+Referencing files and directories seems like a trivial task. Nevertheless, developers often run into problems where relative paths no longer match the current working directory, or find themselves fixing path separator issues that stem from [historical design decisions](https://www.youtube.com/watch?v=5T3IJfBfBmI). Fallout follows the approach to use absolute paths whenever possible, which ensures explicitness and allows copying [tool invocations](08-cli-tools.md) from the log and executing them from anywhere you are.
 
 Central to the idea of absolute paths is the `AbsolutePath` type and the `FalloutBuild.RootDirectory` property. From there on, you can easily construct paths through the [overloaded division operator](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/operator-overloading):
 

--- a/docs/03-common/05-repository.md
+++ b/docs/03-common/05-repository.md
@@ -67,7 +67,7 @@ The only difference between `FromUrl` and `FromLocalDirectory` is that the latte
 
 ## GitHub Integration
 
-As one of the most popular Git hosting services, NUKE provides several methods to retrieve GitHub-specific **identifiers and links** from a repository:
+As one of the most popular Git hosting services, Fallout provides several methods to retrieve GitHub-specific **identifiers and links** from a repository:
 
 {/* snippet: repository-information-github */}
 ```cs

--- a/docs/03-common/06-versioning.md
+++ b/docs/03-common/06-versioning.md
@@ -6,7 +6,7 @@ Whenever a build produces artifacts, those should be identifiable with a unique 
 
 ## Repository-based Versioning
 
-NUKE supports 4 different tools that help generating version numbers from your repository and its commits. Each of these tools comes with its own attribute that populates the field with the information calculated:
+Fallout supports 4 different tools that help generating version numbers from your repository and its commits. Each of these tools comes with its own attribute that populates the field with the information calculated:
 
 <Tabs>
   <TabItem value="gitversion" label="GitVersion" default>
@@ -17,7 +17,7 @@ Please refer to the [GitVersion documentation](https://gitversion.net/docs/refer
 
 ```powershell title="Tool Installation"
 # terminal-command
-nuke :add-package GitVersion.Tool
+fallout :add-package GitVersion.Tool
 ```
 
 ```csharp title="Build.cs"
@@ -40,7 +40,7 @@ Please refer to the [Nerdbank.GitVersioning documentation](https://github.com/do
 
 ```powershell title="Tool Installation"
 # terminal-command
-nuke :add-package Nerdbank.GitVersioning
+fallout :add-package Nerdbank.GitVersioning
 ```
 
 ```csharp title="Build.cs"
@@ -63,7 +63,7 @@ Please refer to the [OctoVersion documentation](https://github.com/OctopusDeploy
 
 ```powershell title="Tool Installation"
 # terminal-command
-nuke :add-package Octopus.OctoVersion.Tool
+fallout :add-package Octopus.OctoVersion.Tool
 ```
 
 ```csharp title="Build.cs"
@@ -86,7 +86,7 @@ Please refer to the [MinVer documentation](https://github.com/adamralph/minver#u
 
 ```powershell title="Tool Installation"
 # terminal-command
-nuke :add-package minver-cli
+fallout :add-package minver-cli
 ```
 
 ```csharp title="Build.cs"
@@ -104,12 +104,12 @@ Target Print => _ => _
 </Tabs>
 
 :::info
-Note that when the versioning tool fails to calculate version numbers, a warning will be logged and the attributed field remains uninitialized. In that case, you can try executing the issued command manually or `nuke --verbosity verbose` to reveal more detailed information. In most cases, the repository is either not initialized, has no commits, or is missing the tool-specific configuration file.
+Note that when the versioning tool fails to calculate version numbers, a warning will be logged and the attributed field remains uninitialized. In that case, you can try executing the issued command manually or `fallout --verbosity verbose` to reveal more detailed information. In most cases, the repository is either not initialized, has no commits, or is missing the tool-specific configuration file.
 :::
 
 ## Dependency-based Versioning
 
-When your versioning is affected by external dependencies, NUKE provides another mechanism to load the latest version of those prior to build execution. Each attribute provides various properties to control which versions should be considered and how it should be transformed:
+When your versioning is affected by external dependencies, Fallout provides another mechanism to load the latest version of those prior to build execution. Each attribute provides various properties to control which versions should be considered and how it should be transformed:
 
 <Tabs>
   <TabItem value="nuget" label="NuGet&nbsp;Packages" default>

--- a/docs/03-common/07-solution-project-model.md
+++ b/docs/03-common/07-solution-project-model.md
@@ -2,7 +2,7 @@
 title: Solution & Project Model
 ---
 
-Particularly when building .NET applications, your build may require information related to solution or project files. Such information is often duplicated with string literals and quickly becomes out-of-date. For instance, when publishing a project you want to build for every target framework that is defined in the project file. NUKE has best-in-class support to read and modify the .NET solution and project model.
+Particularly when building .NET applications, your build may require information related to solution or project files. Such information is often duplicated with string literals and quickly becomes out-of-date. For instance, when publishing a project you want to build for every target framework that is defined in the project file. Fallout has best-in-class support to read and modify the .NET solution and project model.
 
 ## Working with Solutions
 
@@ -33,7 +33,7 @@ With an instance of the `Solution` type you can **read and write the solution** 
 
 ```csharp
 // Gather projects
-var globalToolProject = Solution.GetProject("Nuke.GlobalTool");
+var globalToolProject = Solution.GetProject("Fallout.GlobalTool");
 var testProjects = Solution.GetAllProjects("*.Tests");
 
 // Gather all solution items
@@ -55,11 +55,11 @@ Using the `GenerateProjects` property you can enable a [source generator](https:
 [Solution(GenerateProjects = true)]
 readonly Solution Solution;
 
-Project GlobalToolProject => Solution.Nuke_GlobalTool;
+Project GlobalToolProject => Solution.Fallout_GlobalTool;
 ```
 
 :::info
-For every `SolutionAttribute` with the `GenerateProjects` property enabled, the source generator will create a new type with the same name as the field. In the example above, the type `Nuke.Common.ProjectModel.Solution` is silently replaced by a new type `global::Solution` that is local to your project. Therefore, the field name and type must always be the same.
+For every `SolutionAttribute` with the `GenerateProjects` property enabled, the source generator will create a new type with the same name as the field. In the example above, the type `Fallout.Common.ProjectModel.Solution` is silently replaced by a new type `global::Solution` that is local to your project. Therefore, the field name and type must always be the same.
 :::
 
 ### Creating Solutions

--- a/docs/03-common/08-cli-tools.md
+++ b/docs/03-common/08-cli-tools.md
@@ -6,7 +6,7 @@ import ToolConfirmation from '@site/src/components/ToolConfirmation';
 
 <ToolConfirmation />
 
-Interacting with third-party command-line interface tools (CLIs) is an essential task in build automation. This includes a wide range of aspects, such as resolution of the tool path, construction of arguments to be passed, evaluation of the exit code and capturing of standard and error output. NUKE hides these concerns in dedicated auto-generated CLI wrappers.
+Interacting with third-party command-line interface tools (CLIs) is an essential task in build automation. This includes a wide range of aspects, such as resolution of the tool path, construction of arguments to be passed, evaluation of the exit code and capturing of standard and error output. Fallout hides these concerns in dedicated auto-generated CLI wrappers.
 
 <details>
 <summary>Exhaustive list of supported tools</summary>
@@ -278,7 +278,7 @@ class Build : FalloutBuild
 
 ## Lightweight API
 
-Many of the most popular tools are already implemented. In case a certain tool is not yet supported with a proper CLI task class, NUKE allows you to use the following **injection attributes** to load them:
+Many of the most popular tools are already implemented. In case a certain tool is not yet supported with a proper CLI task class, Fallout allows you to use the following **injection attributes** to load them:
 
 {/* snippet: tool-invocation-lightweight */}
 ```csharp

--- a/docs/03-common/11-chats.md
+++ b/docs/03-common/11-chats.md
@@ -2,7 +2,7 @@
 title: Chats & Social Media
 ---
 
-As a final step of your build automation process, you may want to report errors or announce a new version through different chats and social media channels. NUKE comes with basic support for the most common platforms.
+As a final step of your build automation process, you may want to report errors or announce a new version through different chats and social media channels. Fallout comes with basic support for the most common platforms.
 
 <Tabs>
   <TabItem value="slack" label="Slack" default>
@@ -10,7 +10,7 @@ As a final step of your build automation process, you may want to report errors 
 You can send a [Slack](https://slack.com/) messages as follows:
 
 ```csharp
-// using static Nuke.Common.Tools.Slack.SlackTasks;
+// using static Fallout.Common.Tools.Slack.SlackTasks;
 
 [Parameter] [Secret] readonly string SlackWebhook;
 
@@ -18,7 +18,7 @@ Target Send => _ => _
     .Executes(async () =>
     {
         await SendSlackMessageAsync(_ => _
-                .SetText("Hello from NUKE!"),
+                .SetText("Hello from Fallout!"),
             SlackWebhook);
     });
 ```
@@ -33,7 +33,7 @@ For more advanced scenarios, check out the [SlackAPI](https://github.com/Inumedi
 You can send a [Microsoft Teams](https://www.microsoft.com/en/microsoft-teams/group-chat-software) messages as follows:
 
 ```csharp
-// using static Nuke.Common.Tools.Teams.TeamsTasks;
+// using static Fallout.Common.Tools.Teams.TeamsTasks;
 
 [Parameter] [Secret] readonly string TeamsWebhook;
 
@@ -41,7 +41,7 @@ Target Send => _ => _
     .Executes(async () =>
     {
         await SendTeamsMessageAsync(_ => _
-                .SetText("Hello from NUKE!"),
+                .SetText("Hello from Fallout!"),
             TeamsWebhook)
     });
 ```
@@ -52,7 +52,7 @@ Target Send => _ => _
 You can send a [Twitter](https://twitter.com/) messages as follows:
 
 ```csharp
-// using static Nuke.Common.Tools.Twitter.TwitterTasks;
+// using static Fallout.Common.Tools.Twitter.TwitterTasks;
 
 [Parameter] [Secret] readonly string TwitterConsumerKey;
 [Parameter] [Secret] readonly string TwitterConsumerSecret;
@@ -63,7 +63,7 @@ Target Send => _ => _
     .Executes(async () =>
     {
         await SendTweetAsync(
-            message: "Hello from NUKE",
+            message: "Hello from Fallout",
             TwitterConsumerKey,
             TwitterConsumerSecret,
             TwitterAccessToken,
@@ -81,7 +81,7 @@ For more advanced scenarios, check out the [Tweetinvi](https://github.com/linvi/
 You can send a [Gitter](https://gitter.im/) messages as follows:
 
 ```csharp
-// using static Nuke.Common.Tools.Gitter.GitterTasks;
+// using static Fallout.Common.Tools.Gitter.GitterTasks;
 
 [Parameter] readonly string GitterRoomId;
 [Parameter] [Secret] readonly string GitterAuthToken;
@@ -90,7 +90,7 @@ Target Send => _ => _
     .Executes(() =>
     {
         SendGitterMessage(
-            message: "Hello from NUKE",
+            message: "Hello from Fallout",
             GitterRoomId,
             GitterAuthToken);
     });

--- a/docs/05-cicd/azure-pipelines.md
+++ b/docs/05-cicd/azure-pipelines.md
@@ -225,10 +225,10 @@ By default, the generated pipeline file will include [caching tasks](https://doc
 
 ```yaml title="azure-pipelines.yml"
 - task: Cache@2
-  displayName: Cache (nuke-temp)
+  displayName: Cache (fallout-temp)
   inputs:
-    key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj
-    restoreKeys: $(Agent.OS) | nuke-temp
+    key: $(Agent.OS) | fallout-temp | **/global.json, **/*.csproj
+    restoreKeys: $(Agent.OS) | fallout-temp
     path: .fallout/temp
 - task: Cache@2
   displayName: Cache (nuget-packages)

--- a/docs/05-cicd/github-actions.md
+++ b/docs/05-cicd/github-actions.md
@@ -86,10 +86,20 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Run './build.cmd Compile'
-        run: ./build.cmd Compile
+      - uses: actions/checkout@v6
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
+      - name: 'Run: Compile'
+        run: dotnet fallout Compile
 ```
+
+:::info
+The generated workflow uses `actions/setup-dotnet` to install the .NET SDK on the runner, then `dotnet tool restore` to install the `Fallout.GlobalTool` version pinned in `.config/dotnet-tools.json`, then `dotnet fallout <targets>` to run your build. Your repository needs a `.config/dotnet-tools.json` manifest with `Fallout.GlobalTool` pinned — `fallout :setup` creates one automatically.
+:::
 
 </details>
 
@@ -111,7 +121,7 @@ Target Pack => _ => _
 <summary>Generated output</summary>
 
 ```yaml title=".github/workflows/continuous.yml"
-- uses: actions/upload-artifact@v1
+- uses: actions/upload-artifact@v5
   with:
     name: packages
     path: output/packages
@@ -145,8 +155,8 @@ class Build : FalloutBuild
 <summary>Generated output</summary>
 
 ```yaml title=".github/workflows/continuous.yml"
-- name: Run './build.cmd Publish'
-  run: ./build.cmd Publish
+- name: 'Run: Publish'
+  run: dotnet fallout Publish
   env:
     NuGetApiKey: ${{ secrets.NUGET_API_KEY }}
 ```
@@ -181,8 +191,8 @@ class Build : FalloutBuild
 <summary>Generated output</summary>
 
 ```yaml title=".github/workflows/continuous.yml"
-- name: Run './build.cmd Release'
-  run: ./build.cmd Publish
+- name: 'Run: Publish'
+  run: dotnet fallout Publish
   env:
     GITHUB_CONTEXT: ${{ toJSON(github) }}
 ```
@@ -197,13 +207,13 @@ By default, the generated workflow file will include a [caching step](https://gi
 <summary>Generated output</summary>
 
 ```yaml title=".github/workflows/continuous.yml"
-- name: Cache .fallout/temp, ~/.nuget/packages
-  uses: actions/cache@v2
+- name: 'Cache: .fallout/temp, ~/.nuget/packages'
+  uses: actions/cache@v4
   with:
     path: |
       .fallout/temp
       ~/.nuget/packages
-    key: ${{ runner.os }}-${{ hashFiles('global.json', 'source/**/*.csproj') }}
+    key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
 ```
 
 </details>

--- a/docs/06-global-tool/00-shell-completion.md
+++ b/docs/06-global-tool/00-shell-completion.md
@@ -9,7 +9,7 @@ Typing long target names or parameters can be tedious and error-prone. The globa
 :::info
 The shell completion feature relies on the presence of an up-to-date `.fallout/build.schema.json` file. This file is updated with every execution of your build project.
 
-Whenever you add or change one of your targets or parameters, it is recommended to trigger your build once, for instance by calling `nuke --help`.
+Whenever you add or change one of your targets or parameters, it is recommended to trigger your build once, for instance by calling `fallout --help`.
 :::
 
 ## Configuration
@@ -20,9 +20,9 @@ Add the following snippets to the configuration file of your shell:
   <TabItem value="powershell" label="PowerShell" default>
 
 ```powershell title="Microsoft.PowerShell_profile.ps1"
-Register-ArgumentCompleter -Native -CommandName nuke -ScriptBlock {
+Register-ArgumentCompleter -Native -CommandName fallout -ScriptBlock {
     param($commandName, $wordToComplete, $cursorPosition)
-    nuke :complete "$wordToComplete" | ForEach-Object {
+    fallout :complete "$wordToComplete" | ForEach-Object {
         [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
     }
 }
@@ -32,32 +32,32 @@ Register-ArgumentCompleter -Native -CommandName nuke -ScriptBlock {
   <TabItem value="zsh" label="Zsh">
 
 ```bash title=".zshrc"
-_nuke_zsh_complete()
+_fallout_zsh_complete()
 {
-    local completions=("$(nuke :complete "$words")")
+    local completions=("$(fallout :complete "$words")")
     reply=( "${(ps:\n:)completions}" )
 }
-compctl -K _nuke_zsh_complete nuke
+compctl -K _fallout_zsh_complete fallout
 ```
 
   </TabItem>
   <TabItem value="bash" label="Bash">
 
 ```bash title=".bashrc"
-_nuke_bash_complete()
+_fallout_bash_complete()
 {
     local word=${COMP_WORDS[COMP_CWORD]}
-    local completions="$(nuke :complete "${COMP_LINE}")"
+    local completions="$(fallout :complete "${COMP_LINE}")"
     COMPREPLY=( $(compgen -W "$completions" -- "$word") )
 }
-complete -f -F _nuke_bash_complete nuke
+complete -f -F _fallout_bash_complete fallout
 ```
 
   </TabItem>
   <TabItem value="fish" label="fish">
 
 ```bash title="config.fish"
-complete -fc nuke --arguments '(nuke :complete (commandline -cp))'
+complete -fc fallout --arguments '(fallout :complete (commandline -cp))'
 ```
 
   </TabItem>

--- a/docs/06-global-tool/01-packages.md
+++ b/docs/06-global-tool/01-packages.md
@@ -2,17 +2,17 @@
 title: Adding NuGet Packages
 ---
 
-In many cases, build automation relies on third-party tools. NUKE provides you with a great [API for working with CLI tools](../03-common/08-cli-tools.md), however, it is the responsibility of a build project to reference these tools in the form of NuGet packages and define their exact versions.
+In many cases, build automation relies on third-party tools. Fallout provides you with a great [API for working with CLI tools](../03-common/08-cli-tools.md), however, it is the responsibility of a build project to reference these tools in the form of NuGet packages and define their exact versions.
 
 You can add a NuGet package to a build project by calling:
 
 ```powershell
 # terminal-command
-nuke :add-package <package-id> [--version <package-version>]
+fallout :add-package <package-id> [--version <package-version>]
 ```
 
 :::info
-When no version is provided, the latest version will be used. The major benefit compared to the `dotnet add package` command is that NUKE will automatically determine if the package should be referenced through `PackageReference`, i.e. as a normal library, or through `PackageDownload`, i.e. [without affecting the dependency resolution graph](https://github.com/NuGet/Home/wiki/%5BSpec%5D-PackageDownload-support#solution):
+When no version is provided, the latest version will be used. The major benefit compared to the `dotnet add package` command is that Fallout will automatically determine if the package should be referenced through `PackageReference`, i.e. as a normal library, or through `PackageDownload`, i.e. [without affecting the dependency resolution graph](https://github.com/NuGet/Home/wiki/%5BSpec%5D-PackageDownload-support#solution):
 
 <Tabs>
   <TabItem value="package-reference" label="PackageReference" default>
@@ -63,6 +63,6 @@ When you're using a CLI task that depends on a NuGet package that is not yet ins
 ```text
 Missing package reference/download.
 Run one of the following commands to install the package:
-  - nuke :add-package coverlet.console --version 3.1.0
+  - fallout :add-package coverlet.console --version 3.1.0
 ```
 :::

--- a/docs/06-global-tool/02-secrets.md
+++ b/docs/06-global-tool/02-secrets.md
@@ -4,7 +4,7 @@ title: Managing Secrets
 
 import AsciinemaPlayer from '@site/src/components/AsciinemaPlayer';
 
-Historically, secret values like passwords or auth-tokens are often saved as environment variables on local machines or CI/CD servers. This imposes both, security issues because other processes can access these environment variables and inconveniences when a build must be executed locally for emergency reasons (server downtime). NUKE has an integrated encryption utility, which can be used to save and load secret values to and from [parameter files](../02-fundamentals/06-parameters.md#passing-values-through-parameter-files).
+Historically, secret values like passwords or auth-tokens are often saved as environment variables on local machines or CI/CD servers. This imposes both, security issues because other processes can access these environment variables and inconveniences when a build must be executed locally for emergency reasons (server downtime). Fallout has an integrated encryption utility, which can be used to save and load secret values to and from [parameter files](../02-fundamentals/06-parameters.md#passing-values-through-parameter-files).
 
 :::danger
 Our [custom encryption utility](https://github.com/ChrisonSimtian/Fallout/blob/main/src/Nuke.Utilities/Security/EncryptionUtility.cs) is provided "AS IS" without warranty of any kind.
@@ -20,7 +20,7 @@ You can start managing your secrets by calling:
 
 ```powershell
 # terminal-command
-nuke :secrets [profile]
+fallout :secrets [profile]
 ```
 
 When your parameter file does not contain secrets yet, you'll be prompted to choose a password. Otherwise, you have to provide the original password chosen.
@@ -56,4 +56,4 @@ When secrets are saved to a parameters file, they are prefixed with `v1:` to ind
 
 ## Removing Secrets
 
-If you want to delete a secret, you can simply remove it from the parameters file. In the event of a lost password, you have to remove all secrets and re-populate the parameters file via `nuke :secrets`.
+If you want to delete a secret, you can simply remove it from the parameters file. In the event of a lost password, you have to remove all secrets and re-populate the parameters file via `fallout :secrets`.

--- a/docs/06-global-tool/03-navigation.md
+++ b/docs/06-global-tool/03-navigation.md
@@ -2,30 +2,30 @@
 title: Navigation
 ---
 
-Over time, you might accumulate more and more projects that are built using NUKE. Some of these might even form a hierarchical structure, where one root directory contains several other root directories, and so on.
+Over time, you might accumulate more and more projects that are built using Fallout. Some of these might even form a hierarchical structure, where one root directory contains several other root directories, and so on.
 
 ## Configuration
 
 Add the following functions to your shell configuration (similar as for [shell completion](00-shell-completion.md)):
 
 ```
-function nuke/ { nuke :PushWithChosenRootDirectory; cd $(nuke :GetNextDirectory) }
-function nuke. { nuke :PushWithCurrentRootDirectory; cd $(nuke :GetNextDirectory) }
-function nuke.. { nuke :PushWithParentRootDirectory; cd $(nuke :GetNextDirectory) }
-function nuke- { nuke :PopDirectory; cd $(nuke :GetNextDirectory) }
+function fallout/ { fallout :PushWithChosenRootDirectory; cd $(fallout :GetNextDirectory) }
+function fallout. { fallout :PushWithCurrentRootDirectory; cd $(fallout :GetNextDirectory) }
+function fallout.. { fallout :PushWithParentRootDirectory; cd $(fallout :GetNextDirectory) }
+function fallout- { fallout :PopDirectory; cd $(fallout :GetNextDirectory) }
 ```
 
 ## Usage
 
 The global tool comes with a handful of functions for improved navigation:
 
-| Command  | Function                                       |
-|:---------|:-----------------------------------------------|
-| `nuke.`  | Navigates to the current root directory        |
-| `nuke..` | Navigates to the parent root directory         |
-| `nuke/`  | Lists subdirectories that are root directories |
-| `nuke-`  | Navigates to the last root directory           |
+| Command     | Function                                       |
+|:------------|:-----------------------------------------------|
+| `fallout.`  | Navigates to the current root directory        |
+| `fallout..` | Navigates to the parent root directory         |
+| `fallout/`  | Lists subdirectories that are root directories |
+| `fallout-`  | Navigates to the last root directory           |
 
 :::note
-The `nuke-` command is only supported on shells that set the `TERM_SESSION_ID` or `WT_SESSION` environment variable. As of now, this includes [iTerm](https://iterm2.com/) and the [Windows Terminal](https://github.com/microsoft/terminal).
+The `fallout-` command is only supported on shells that set the `TERM_SESSION_ID` or `WT_SESSION` environment variable. As of now, this includes [iTerm](https://iterm2.com/) and the [Windows Terminal](https://github.com/microsoft/terminal).
 :::

--- a/docs/06-global-tool/04-cake.md
+++ b/docs/06-global-tool/04-cake.md
@@ -5,7 +5,7 @@ title: Converting from Cake
 Over the years, the .NET community has come up with a lot of great build automation tools, including [FAKE](https://fake.build/), [Cake](https://cakebuild.net/), [FlubuCore](https://flubucore.dotnetcore.xyz/), and [BullsEye](https://github.com/adamralph/bullseye). When coming from Cake Scripting, the time for converting build scripts can be greatly reduced with a best-effort approach using [Roslyn](https://github.com/dotnet/roslyn) and its [syntax transformation](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/get-started/syntax-transformation) capabilities.
 
 :::caution
-The resulting source code is **expected to contain compilation errors** since there is no direct API mapping between Cake and NUKE. Most notably, the order of `IsDependentOn` on a single target in Cake reflects the order of execution of these dependencies, whereas in NUKE the dependencies are solely defined between the individual targets.
+The resulting source code is **expected to contain compilation errors** since there is no direct API mapping between Cake and Fallout. Most notably, the order of `IsDependentOn` on a single target in Cake reflects the order of execution of these dependencies, whereas in Fallout the dependencies are solely defined between the individual targets.
 :::
 
 ## Conversion
@@ -14,7 +14,7 @@ You can start the conversion by calling:
 
 ```powershell
 # terminal-command
-nuke :cake-convert
+fallout :cake-convert
 ```
 
 The global tool searches for all `*.cake` and converts them to `*.cs` files. During this process it transforms:
@@ -34,5 +34,5 @@ After you've fully verified the conversion, you can clear all `*.cake` files by 
 
 ```powershell
 # terminal-command
-nuke :cake-clean
+fallout :cake-clean
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,9 +16,9 @@ Canonical reference for how the Fallout repo is laid out and how the pieces fit 
 │   └── Build.*.cs            Partial classes split by concern (CI, Licenses, etc.)
 ├── docs/                     Documentation site content + architecture notes (this file)
 ├── src/                      All production library projects
-│   └── Nuke.<X>/Nuke.<X>.csproj
+│   └── Fallout.<X>/Fallout.<X>.csproj
 ├── tests/                    All test projects
-│   └── Nuke.<X>.Tests/Nuke.<X>.Tests.csproj
+│   └── Fallout.<X>.Tests/Fallout.<X>.Tests.csproj
 ├── AssemblyInfo.cs           Shared InternalsVisibleTo declarations (included by Directory.Build.props)
 ├── Directory.Build.props     Shared MSBuild properties + ItemGroups applied to every project
 ├── Directory.Build.targets   Smart PackageReference → ProjectReference logic


### PR DESCRIPTION
Closes #198 and completes PR-C of #203.

## Scope

Two related sweeps bundled into one PR:

1. **CLI/brand rebrand (closes #198)** — replace stale `nuke` CLI command examples with `fallout` across `docs/`, switch `.nuke` directory-marker references to `.fallout`, rebrand \"NUKE provides/comes/has/integrates\" phrasing to \"Fallout …\" where it describes the current product, update namespace examples (`Nuke.Common.Tools.*` → `Fallout.Common.Tools.*`, `Nuke.GlobalTool` → `Fallout.GlobalTool`), and update MSBuild property names (`NukeRootDirectory` → `FalloutRootDirectory`, with the legacy names called out as still-honoured).
2. **New shim shape (PR-C of #203)** — update `CONTRIBUTING.md`, `CLAUDE.md`, `docs/01-getting-started/{02-setup,03-execution}.md`, and `docs/05-cicd/github-actions.md` to describe the thin shims + local-tool-manifest pattern PR-B introduced: drop `build.cmd` from examples, document the new 3-step GitHub Actions shape, describe `.config/dotnet-tools.json`.

## What's NOT touched

- `docs/rebrand-plan.md` — intentionally NUKE-named throughout (it IS the rebrand plan).
- `docs/migration/from-nuke.md` — migration framing needs both names.
- Historical references like \"upstream NUKE issue #822\" and \"the original NUKE key was matkoch-owned\" — they cite the upstream project and need to stay accurate.
- `CHANGELOG.md` and package READMEs that reference the historical NUKE project for migration context.

## Files changed

22 docs + `CONTRIBUTING.md` + `CLAUDE.md` (23 files total).

Most edits are mechanical text substitutions. Substantive rewrites:

- **`docs/01-getting-started/02-setup.md`** — new file-structure example (drops `build.cmd`, adds `.config/dotnet-tools.json` and `.fallout/`), new note explaining the thin-shim role, MSBuild property names updated.
- **`docs/01-getting-started/03-execution.md`** — thin-shim explanation in the Global Tool / Windows / Linux tab block; all `nuke <target>` / `nuke --help` / `nuke --plan` / etc. switched to `fallout`.
- **`docs/05-cicd/github-actions.md`** — generated-output YAML examples updated to the 3-step shape; cache-step `actions/cache@v2` bumped to `@v4` with the current key files; `actions/upload-artifact@v1` bumped to `@v5` to match the actual generator output; new note explaining the `dotnet-tools.json` requirement.
- **`docs/06-global-tool/00-shell-completion.md`** — shell completion scripts rebranded (command name + function names: `_nuke_zsh_complete` → `_fallout_zsh_complete`, etc.).
- **`docs/06-global-tool/03-navigation.md`** — navigation function names rebranded (`nuke.` → `fallout.`, etc.).

## Verification

- Edits don't change link targets, only prose and code examples.
- Docusaurus `onBrokenLinks: 'throw'` will catch any regression at deploy time.
- PR-C is docs-only, so the noop `ubuntu-latest-docs.yml` workflow handles the GitHub PR check.

## Test plan

- [ ] `ubuntu-latest` (docs-only noop) goes green.
- [ ] After merge, docs.fallout.build deploy succeeds (no broken-link regressions thrown by Docusaurus).
- [ ] Spot-check a couple of pages on the live site: `Build Setup`, `Build Execution`, `GitHub Actions`, `Shell Completion`.

## Refs

- Closes #198 (docs CLI cleanup).
- Completes PR-C of #203 (bootstrapper-deprecation plan). PR-A (#201) and PR-B (#204) are merged.
- Companion issue #199 (CLI alias bridge guide for migrating users) is a separate enhancement, not in scope here.