### PR TITLE
fix(packaging): ship README.md with every Fallout.* nupkg

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
     <!-- TODO: re-enable PackageIcon once we have a 256×256 PNG export of .assets/fallout-logo.svg.
          NuGet doesn't accept SVG for PackageIcon. -->
 <!--    <PackageIcon>icon.png</PackageIcon>-->
-<!--    <PackageReadmeFile>README.md</PackageReadmeFile>-->
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
@@ -30,10 +30,20 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
+  <!-- Pack a README.md into every package. Prefer a per-project README.md when present
+       (e.g. Fallout.Migrate.Analyzers, the Nuke.* transition shims) so each package can ship its own
+       landing page; otherwise fall back to the repo-root README.md. Pack="true" only includes the
+       file during `dotnet pack`; PackageReadmeFile above wires it to nuget.org's package page. -->
+  <ItemGroup Condition="Exists('$(MSBuildProjectDirectory)/README.md')">
+    <None Include="$(MSBuildProjectDirectory)/README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup Condition="!Exists('$(MSBuildProjectDirectory)/README.md')">
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
   <!-- TODO: re-enable once .assets/icon.png exists (rendered from fallout-logo.svg).
   <ItemGroup Condition="'$(_IsPacking)' == 'True'">
     <None Include="$(MSBuildThisFileDirectory).assets\icon.png" Pack="true" PackagePath="\" />
-    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   -->
 

--- a/src/Fallout.Migrate.Analyzers/Fallout.Migrate.Analyzers.csproj
+++ b/src/Fallout.Migrate.Analyzers/Fallout.Migrate.Analyzers.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-    <None Include="README.md" Pack="true" PackagePath="\" />
+    <!-- README.md is packed automatically by Directory.Build.props (per-project README when present). -->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Today's `dotnet pack` output warns on every Fallout.* package:

> The package Fallout.<X> is missing a readme. Go to https://aka.ms/nuget/authoring-best-practices/readme to learn why package readmes are important.

And nuget.org's package landing pages show the generic \"No README\" placeholder instead of the Fallout intro / install command / docs link. Surfaced when Chris went to upload the locally-packed `Fallout.Cli.*.nupkg` to reserve the new ID (#206).

## What this PR does

The plumbing was already half-wired up in `Directory.Build.props` but commented out, tied to a separate TODO about the missing `PackageIcon`. Decoupled and made smarter:

- `<PackageReadmeFile>README.md</PackageReadmeFile>` enabled unconditionally.
- New ItemGroups in `Directory.Build.props` pick the right README per package:
    - If `src/Fallout.X/README.md` exists → pack that one (per-package content wins on the nuget.org landing page).
    - Otherwise → pack the repo-root `README.md`.
- `Fallout.Migrate.Analyzers.csproj`: removed its now-redundant explicit `<None Include=\"README.md\" Pack=\"true\" PackagePath=\"\\\" />`; the Directory.Build.props auto-include handles it.
- Test projects (`IsPackable=False`) aren't affected.
- `PackageIcon` stays commented (still blocked on a 256×256 PNG export of `.assets/fallout-logo.svg`).

## Verification

Packed three representative projects locally; each gets the right README:

| Project | Per-project README? | Pack result |
|---|---|---|
| `Fallout.Common` | no | Root README packed (Fallout logo + intro). Warning gone. |
| `Fallout.Migrate.Analyzers` | yes | Its own README packed (analyzer-specific landing page). Warning gone. |
| `src/Shims/Nuke.Common` | yes | Its own README packed (shim-specific landing page). Warning gone. |

`unzip -l <pkg>.nupkg` confirms exactly one `README.md` at the root of each package; `unzip -p <pkg>.nupkg <pkg>.nuspec` confirms `<readme>README.md</readme>`.

## Test plan

- [ ] `ubuntu-latest` goes green.
- [ ] After merge, rebase #206 (Fallout.Cli rename) onto main so its pack picks up the readme fix; rebuild the local `Fallout.Cli.*.nupkg` for manual upload.
- [ ] Post-merge release pipeline: all 17+ `Fallout.*` packages publish with readmes attached. nuget.org pages show the landing content instead of the placeholder.