### PR TITLE
chore: Fallout.Cli follow-ups (manifest flip + ownership-gotcha doc)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fallout.globaltool": {
-      "version": "10.3.37",
+    "fallout.cli": {
+      "version": "10.3.41",
       "commands": [
         "fallout"
       ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,11 @@ Validation workflows: **`ubuntu-latest`** runs on every PR targeting `main` (wit
 
 **Release pipeline:** `.github/workflows/release.yml` — triggered on push to `main`, runs the three-step shape (`actions/setup-dotnet` → `dotnet tool restore` → `dotnet fallout Test Pack Publish`). **Publishes to nuget.org** (`https://api.nuget.org/v3/index.json`) under the `Fallout.*` package ID prefix, using the `NUGET_API_KEY` repo secret (a nuget.org API key scoped to push `Fallout.*`). Prefix reservation tracked in [#33](https://github.com/ChrisonSimtian/Fallout/issues/33).
 
+**Adding a new `Fallout.X` package — first-publish gotcha.** nuget.org's `Fallout.*` prefix reservation is per-ID, not per-prefix-wildcard: CI's first `nuget push` for any never-published `Fallout.X` package ID returns `403 (does not have permission to access the specified package)` until someone manually web-uploads one nupkg to register the ID. **Two traps when doing that upload:**
+
+1. **Set the package owner to the org, not your personal account.** The nuget.org upload UI doesn't prompt you; ownership defaults to the uploading user's profile. If you forget, the package ID is reserved but the org's `NUGET_API_KEY` still 403s on subsequent pushes (the key is scoped to org-owned packages). Fix via `Manage Package → Owners → Add owner → <org>` then optionally remove your personal account. Or upload using credentials of the org's service account directly. See [#208](https://github.com/ChrisonSimtian/Fallout/issues/208) for what this looks like when it goes wrong.
+2. **Validation can lag** the upload by 5–30 minutes. The package page may say "approved" while the API key permission hasn't propagated yet. Wait, then rerun the release pipeline (`gh run rerun <id> --failed`); `--skip-duplicate` makes the retry safe for already-published packages.
+
 ## Conventions worth respecting
 
 - **Centralized package versions** — add new packages to `Directory.Packages.props`, never inline. Adding a *meaningful* library (not a tiny transitive helper)? Add a row to [docs/dependencies.md](docs/dependencies.md) in the same PR — reviewers will ask.


### PR DESCRIPTION
Two small follow-ups after #206 (rename) and #208 (the first-publish 403 we hit on the release pipeline).

## 1. Flip this repo's `.config/dotnet-tools.json` to `Fallout.Cli`

`Fallout.Cli 10.3.41` is now live on nuget.org (the release pipeline rerun published it once the org-ownership issue cleared). Switching this repo's local tool manifest from the legacy `fallout.globaltool 10.3.37` pin to `fallout.cli 10.3.41`.

Verified locally:

```
> dotnet tool restore
Tool 'fallout.cli' (version '10.3.41') was restored. Available commands: fallout
Restore was successful.
```

## 2. Document the nuget.org first-publish gotcha in CLAUDE.md

The \"Release pipeline\" section in `CLAUDE.md` already mentioned the `Fallout.*` prefix reservation but didn't cover the operational footgun we just hit: the nuget.org upload UI defaults the package owner to your personal account, not the org. Even after a successful upload that reserves the ID, the org's `NUGET_API_KEY` 403s on subsequent CI pushes until ownership is transferred to the org.

Added two short paragraphs to the \"Release pipeline\" section walking through:

1. The owner-defaults-to-personal trap (with the fix), linked to #208.
2. The 5–30 min validation lag between upload-accepted and API-key-permission-propagated.

So next time someone (likely future-Claude or future-Chris) adds a new `Fallout.X` package, this footgun is the first thing they see.

## Refs

- Closes #208 (the doc follow-up was the only thing keeping it open).
- Builds on #206 (rename).

## Test plan

- [ ] `ubuntu-latest` CI goes green — verifies `dotnet tool restore` resolves `Fallout.Cli 10.3.41` from nuget.org cleanly in CI as well.