### PR TITLE
docs(readme): add Install section with uninstall-old-cli note

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ cd path/to/your-nuke-repo
 fallout-migrate
 ```
 
+## Install
+
+```sh
+dotnet tool install -g Fallout.Cli
+```
+
+The CLI installs as `fallout`. Verify with `fallout --help`.
+
+> [!NOTE]
+> **Upgrading from `Fallout.GlobalTool`?** The package was renamed to `Fallout.Cli` for install ergonomics — same `fallout` command, friendlier ID. Uninstall the old one first so you don't end up with two tools claiming the same command:
+>
+> ```sh
+> dotnet tool uninstall -g Fallout.GlobalTool
+> ```
+
+For per-repo manifest pinning (`.config/dotnet-tools.json`), project setup, and shell completion, see the [Installation guide on docs.fallout.build](https://docs.fallout.build/getting-started/installation).
+
 ## Table of Contents
 
 - [Elevator Pitch](#elevator-pitch)


### PR DESCRIPTION
Two gaps surfaced when Chris went to install the renamed CLI on a fresh machine:

1. The README has no `dotnet tool install -g Fallout.Cli` one-liner anywhere on the landing page. Closest was the `Fallout.Migrate` install in the migration section, which doesn't help people who just want to use the build CLI.
2. No mention of the `Fallout.GlobalTool` → `Fallout.Cli` rename for existing users. Both packages claim the `fallout` command, so `dotnet tool install -g Fallout.Cli` errors out with `Tool 'fallout' is already installed` if the old one's still around.

## Change

New \"Install\" section after \"Migrating from NUKE\":

- `dotnet tool install -g Fallout.Cli` as the install one-liner.
- A `> [!NOTE]` callout for upgraders pointing them at `dotnet tool uninstall -g Fallout.GlobalTool` first.
- Link to the full installation guide on docs.fallout.build.

## Refs

- #206 (the rename).
- Closes the loose end Chris flagged after that PR landed.