### PR TITLE
chore(tools): bump fallout.cli manifest pin 10.3.41 → 10.3.45

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fallout.cli": {
-      "version": "10.3.41",
+      "version": "10.3.45",
       "commands": [
         "fallout"
       ]


### PR DESCRIPTION
## Summary

Refreshes the local tool manifest to track the latest \`Fallout.Cli\` release. Picks up four patches shipped since the manifest was first introduced:

- **#212** — AES-GCM v2 secret format (per-secret salt+nonce, 600K PBKDF2). Breaking change to the secret format on disk; harmless for this repo since we don't have committed encrypted secrets, but worth running on a current version.
- **#211** — drop unused \`Build()\` + surface \`dotnet-tools.json\` in IDE config group.
- **#209** — manifest flip + ownership-gotcha doc.
- **#207** — ship README.md with every \`Fallout.*\` nupkg.

## Verification

Local: \`dotnet tool restore\` pulls \`fallout.cli\` 10.3.45 cleanly, \`dotnet fallout --help\` runs the build via the in-tool runner without issue.

## Test plan

- [ ] CI green (ubuntu-latest will hit the full validation workflow, since this is a non-\`paths-ignore\` change to \`.config/\`).