### PR TITLE
docs(claude): document milestone/target-label scheme + extend PR-creation flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,14 +85,20 @@ Validation workflows: **`ubuntu-latest`** runs on every PR targeting `main` (wit
 
 Patch increments from git-height are reserved for non-breaking fixes; carrying breaking changes under a patch series ships them to consumers silently. **Reviewer responsibility:** if a PR carries `!` (or a flagged breaking change) and `version.json`'s major is unchanged, block the merge until the bump is in the same PR. Record the breaking change under `[Unreleased] — <next-major>` in `CHANGELOG.md` as part of the PR.
 
-**PR-creation flow for breaking changes (Claude's responsibility).** When opening a PR that includes a breaking change (any commit on the branch uses `!`, has a `BREAKING CHANGE:` footer, or otherwise meets the breaking-change definition above), do all of the following at PR-creation time — not after, not as a follow-up:
+**Milestones and version targeting.** Milestones are **theme-based** (e.g. "Plugin Architecture Foundation & Rebrand Completion", "Public Plugin SDK", "Continuous Delivery Vision") and carry across releases; version targeting uses **`target/vN`** labels (`target/v11`, `target/v12`, `target/v13`). A breaking change forces a new major via the semver policy above — so its PR carries `target/v<next-major>` instead of `target/v<current-major>`.
 
-1. **Add the `breaking-change` label** to the PR: pass `--label breaking-change` to `gh pr create` (or `gh pr edit <num> --add-label breaking-change` if the PR already exists).
-2. **Open the PR body with a `⚠️ Breaking change` callout** that names the affected surface (public API, package ID, CLI flag, on-disk format, CI/CD shape, etc.) and the consumer-side impact in one sentence. This is what reviewers and downstream consumers read first.
-3. **Confirm `version.json`'s major is already bumped** for the target release. If it isn't, stop — bump it in the same branch before opening the PR. Don't open a breaking-change PR against an unchanged-major `version.json`.
-4. **Add a `CHANGELOG.md` entry** under the existing `[Unreleased] — <next-major>` heading, in the same PR, describing the breaking change and the migration path (one paragraph minimum).
+**PR-creation flow (Claude's responsibility).** At PR-creation time — not after, not as a follow-up — every PR gets:
 
-If you only discover the breaking nature mid-review, apply all four steps before requesting re-review.
+1. **A `target/vN` label** matching where it will release. Default to `target/v<current-major>` (read `version.json`'s `version` field). If the PR bumps the major (i.e. it carries a breaking change), use `target/v<new-major>` instead. Pass via `--label target/v11` to `gh pr create`.
+
+If the PR includes a **breaking change** (any commit uses `!`, has a `BREAKING CHANGE:` footer, or otherwise meets the breaking-change definition above), additionally:
+
+2. **Add the `breaking-change` label.** `gh pr create --label target/v<new-major> --label breaking-change …`.
+3. **Open the PR body with a `⚠️ Breaking change` callout** that names the affected surface (public API, package ID, CLI flag, on-disk format, CI/CD shape, etc.) and the consumer-side impact in one sentence. This is what reviewers and downstream consumers read first.
+4. **Confirm `version.json`'s major is already bumped** for the target release. If it isn't, stop — bump it in the same branch before opening the PR. Don't open a breaking-change PR against an unchanged-major `version.json`.
+5. **Add a `CHANGELOG.md` entry** under the existing `[Unreleased] — <next-major>` heading, in the same PR, describing the breaking change and the migration path (one paragraph minimum).
+
+If you only discover the breaking nature mid-review, apply all relevant steps before requesting re-review.
 
 **Release pipeline:** `.github/workflows/release.yml` — triggered on push to `main`, runs the three-step shape (`actions/setup-dotnet` → `dotnet tool restore` → `dotnet fallout Test Pack Publish`). **Publishes to nuget.org** (`https://api.nuget.org/v3/index.json`) under the `Fallout.*` package ID prefix, using the `NUGET_API_KEY` repo secret (a nuget.org API key scoped to push `Fallout.*`). Prefix reservation tracked in [#33](https://github.com/ChrisonSimtian/Fallout/issues/33).
 


### PR DESCRIPTION
## Summary

Companion to the GitHub-side restructure done out-of-band moments ago. Teaches CLAUDE.md (and therefore Claude) about the new label/milestone scheme so future PRs get tagged correctly at creation time.

## What changed in this PR

\`CLAUDE.md\` — new \`Milestones and version targeting\` paragraph + extended \`PR-creation flow\` rule covering both target-label tagging (for every PR) and the existing breaking-change-specific steps.

## What changed out-of-band (GitHub-only, no PR needed)

- **Milestones renamed** (drop version prefix):
  - #6 \`11.0 - Plugin architecture foundation & rebrand completion\` → \`Plugin Architecture Foundation & Rebrand Completion\`
  - #7 \`12.0 - Public plugin SDK\` → \`Public Plugin SDK\`
  - #8 \`13.0 - Continuous Delivery vision\` → \`Continuous Delivery Vision\`
- **Three new labels created**: \`target/v11\` (red), \`target/v12\` (orange), \`target/v13\` (yellow). Slash-namespaced so GitHub renders them as a visual group.
- **67 issues/PRs bulk-tagged** with the appropriate \`target/vN\` label across milestones #6/#7/#8 (open + closed). Existing \`v11-slip-ok\` label kept as-is (different semantic — "this can slip", not "this targets v11").

Historical milestones (#1 \`10.2.0\`, #2 \`10.3.0\`, #5 \`Fallout rebrand\`) left as-is — they're records of what shipped.

## Dogfooded

This PR is tagged \`target/v11\` at creation per the new rule, since \`version.json\` says \`11.0\` and this isn't a breaking change. If it were breaking, it'd also be tagged \`breaking-change\` and target \`v12\`.

## Test plan

- [ ] CI green.
- [ ] After merge, re-read CLAUDE.md to confirm the new flow is what you'd want me to follow on the next PR.

## Refs

- Builds on the semver policy added in #220.