### PR TITLE
chore(tools): add tools/ directory + Unlist-NugetPackage.ps1

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,33 @@
+# tools/
+
+Operational helper scripts that support repo maintenance but are **not** part of the build or release pipeline.
+
+- **Not built.** They aren't referenced by `fallout.slnx` or any `.csproj`. The release pipeline doesn't pack or publish them.
+- **Don't bump versions.** `version.json` has `pathFilters` excluding this directory — commits touching only `tools/` don't increment patch height. A typo fix here won't produce a fresh `11.0.x` release.
+- **Cross-platform PowerShell Core 7+** by convention. Run with `pwsh` on macOS/Linux/Windows. Same script, no per-OS variants.
+
+## Conventions for new tools
+
+- One script per file. Filename matches the verb-noun PowerShell convention (`Unlist-NugetPackage.ps1`, not `unlist.ps1`).
+- Comment-based help on every script. `Get-Help ./Foo.ps1 -Full` should explain inputs, outputs, examples.
+- `[CmdletBinding(SupportsShouldProcess)]` so `-WhatIf` and `-Confirm` work for anything that mutates remote state.
+- Secrets via explicit parameter first, fallback to an env var (`-ApiKey` → `$env:NUGET_API_KEY`), fail fast if neither.
+- Idempotent where reasonable — re-running shouldn't corrupt state.
+
+## Available tools
+
+| Script | Purpose |
+|---|---|
+| [`Unlist-NugetPackage.ps1`](Unlist-NugetPackage.ps1) | Unlist one or many NuGet package versions from a feed. Single mode (Package + Version[]) or bulk JSON. API key from `-ApiKey` or `$env:NUGET_API_KEY`. |
+
+## Bulk JSON shape (used by `Unlist-NugetPackage.ps1 -JsonPath`)
+
+```json
+[
+  { "package": "Fallout.Common", "version": "10.3.45" },
+  { "package": "Fallout.Common", "version": "10.3.47" },
+  { "package": "Fallout.Cli",    "version": "10.3.45" }
+]
+```
+
+Generate ad-hoc as needed — there's no need to commit one-off batch files unless the operation is worth keeping as a historical record.

--- a/tools/Unlist-NugetPackage.ps1
+++ b/tools/Unlist-NugetPackage.ps1
@@ -1,0 +1,152 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+Unlist one or more NuGet package versions from a feed (nuget.org by default).
+
+.DESCRIPTION
+Wraps `dotnet nuget delete` with two input modes:
+
+  1. Single — pass -Package and one or more -Version values.
+  2. Bulk   — pass -JsonPath pointing at a JSON file shaped like
+             [ { "package": "Fallout.Common", "version": "10.3.45" }, ... ].
+
+The NuGet API key comes from -ApiKey if provided, otherwise from the
+NUGET_API_KEY environment variable. The script fails fast if neither
+is available.
+
+"Unlist" hides a version from search and version-listings; the binary
+remains downloadable for anyone with an explicit pin. There is no true
+"unpublish" on NuGet.
+
+.PARAMETER Package
+Package ID, e.g. 'Fallout.Common'. Required for single-mode.
+
+.PARAMETER Version
+One or more versions to unlist. Required for single-mode. Multiple values
+go through one `dotnet nuget delete` call each.
+
+.PARAMETER JsonPath
+Path to a JSON file containing an array of { package, version } objects.
+Required for bulk-mode. Mutually exclusive with -Package/-Version.
+
+.PARAMETER ApiKey
+NuGet API key. Falls back to $env:NUGET_API_KEY if omitted.
+
+.PARAMETER Source
+NuGet feed URL. Defaults to https://api.nuget.org/v3/index.json.
+
+.EXAMPLE
+./Unlist-NugetPackage.ps1 -Package Fallout.Common -Version 10.3.45
+
+.EXAMPLE
+./Unlist-NugetPackage.ps1 -Package Fallout.Common -Version 10.3.40,10.3.41,10.3.42 -WhatIf
+
+.EXAMPLE
+./Unlist-NugetPackage.ps1 -JsonPath ./batch.json
+
+.EXAMPLE
+# API key from env
+$env:NUGET_API_KEY = (security find-generic-password -s NugetApiKey -w)
+./Unlist-NugetPackage.ps1 -JsonPath ./batch.json
+#>
+[CmdletBinding(SupportsShouldProcess, DefaultParameterSetName = 'Single')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Single', Position = 0)]
+    [ValidateNotNullOrEmpty()]
+    [string] $Package,
+
+    [Parameter(Mandatory, ParameterSetName = 'Single', Position = 1)]
+    [ValidateNotNullOrEmpty()]
+    [string[]] $Version,
+
+    [Parameter(Mandatory, ParameterSetName = 'Bulk')]
+    [ValidateNotNullOrEmpty()]
+    [string] $JsonPath,
+
+    [Parameter()]
+    [string] $ApiKey,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string] $Source = 'https://api.nuget.org/v3/index.json'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $ApiKey) {
+    $ApiKey = $env:NUGET_API_KEY
+}
+if (-not $ApiKey) {
+    throw "API key not provided. Pass -ApiKey <key> or set `$env:NUGET_API_KEY."
+}
+
+$items = if ($PSCmdlet.ParameterSetName -eq 'Bulk') {
+    if (-not (Test-Path -LiteralPath $JsonPath -PathType Leaf)) {
+        throw "JSON file not found: $JsonPath"
+    }
+    $raw = Get-Content -LiteralPath $JsonPath -Raw
+    try {
+        $parsed = $raw | ConvertFrom-Json
+    } catch {
+        throw "Failed to parse JSON at $JsonPath`: $($_.Exception.Message)"
+    }
+    if ($parsed -isnot [System.Collections.IEnumerable]) {
+        throw "JSON at $JsonPath must be an array of { package, version } objects."
+    }
+    @($parsed)
+} else {
+    $Version | ForEach-Object {
+        [pscustomobject]@{ package = $Package; version = $_ }
+    }
+}
+
+$total = ($items | Measure-Object).Count
+if ($total -eq 0) {
+    Write-Host "Nothing to unlist."
+    return
+}
+
+# Validate shape
+$items | ForEach-Object {
+    if (-not $_.package -or -not $_.version) {
+        throw "Invalid item — every entry must have 'package' and 'version' fields. Offending: $($_ | ConvertTo-Json -Compress)"
+    }
+}
+
+Write-Host "Unlisting $total package version(s) from $Source"
+Write-Host ""
+
+$ok = 0
+$fail = 0
+$i = 0
+
+foreach ($item in $items) {
+    $i++
+    $pkg = $item.package
+    $ver = $item.version
+    $label = "[{0,3}/{1,3}] {2,-44} {3,-10}" -f $i, $total, $pkg, $ver
+
+    if ($PSCmdlet.ShouldProcess("$pkg $ver", "Unlist from $Source")) {
+        $output = & dotnet nuget delete $pkg $ver `
+            --api-key $ApiKey `
+            --source $Source `
+            --non-interactive 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "$label ok"
+            $ok++
+        } else {
+            Write-Host "$label FAIL"
+            Write-Host ($output | Out-String).TrimEnd()
+            $fail++
+        }
+    } else {
+        Write-Host "$label (skipped: -WhatIf)"
+    }
+}
+
+Write-Host ""
+Write-Host "Done. ok=$ok fail=$fail"
+
+if ($fail -gt 0) {
+    exit $fail
+}

--- a/version.json
+++ b/version.json
@@ -4,6 +4,10 @@
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],
+  "pathFilters": [
+    ":/",
+    ":!/tools"
+  ],
   "nuGetPackageVersion": {
     "semVer": 2
   },


### PR DESCRIPTION
## Why

Surfaced from the v11 / semver-policy work in #220: we need to unlist 102 \`Fallout.*\` package versions in the \`10.3.40\`-\`10.3.47\` range (the ones that shipped breaking changes under patch numbers). Rather than a throwaway shell loop, this PR introduces a proper, reusable tool.

## What's in this PR

- **\`tools/Unlist-NugetPackage.ps1\`** — PowerShell Core 7+ tool wrapping \`dotnet nuget delete\` with two input modes:
  - **Single**: \`-Package Foo -Version 1.2.3\` (or comma-separated \`-Version 1.0,1.1,1.2\`).
  - **Bulk**: \`-JsonPath ./batch.json\` (array of \`{ package, version }\` objects).
  - API key from \`-ApiKey\` or \`$env:NUGET_API_KEY\`. Fails fast if neither.
  - \`[CmdletBinding(SupportsShouldProcess)]\` → \`-WhatIf\` and \`-Confirm\` work.
  - Per-item ok/FAIL output; exit code = failure count. Idempotent.
- **\`tools/README.md\`** — directory conventions (not built, not version-bumped, PS Core 7+, comment-based help on every script).
- **\`version.json\`** — adds \`pathFilters: [":/", ":!/tools"]\` so commits touching only \`tools/\` don't bump patch height. A typo fix in a tool script no longer produces a phantom \`11.0.<n+1>\` release.

## Smoke-tested locally

\`\`\`
$ pwsh ./tools/Unlist-NugetPackage.ps1 -Package Foo -Version 1.0.0 -ApiKey dummy -WhatIf
Unlisting 1 package version(s) from https://api.nuget.org/v3/index.json
What if: Performing the operation "Unlist from https://api.nuget.org/v3/index.json" on target "Foo 1.0.0".
[  1/  1] Foo                                          1.0.0      (skipped: -WhatIf)
Done. ok=0 fail=0
\`\`\`

Bulk mode against a 2-entry JSON also dry-ran cleanly.

## Out of scope (follow-up)

The auto-generated CI workflows (\`.github/workflows/{ubuntu,macos,windows}-latest.yml\` + \`release.yml\`) have \`paths-ignore: [docs/**, .assets/**, **/*.md]\` — they don't yet ignore \`tools/**\`. So a \`tools/\`-only push still triggers the full CI run and release pipeline. Release won't produce a new version (pathFilters prevents height bump → \`--skip-duplicate\` no-ops on NuGet), but it's a wasted CI cycle. Worth teaching the \`[GitHubActions]\` attribute about \`tools/**\` in a separate PR — that touches the generator at \`src/Fallout.Common/CI/GitHubActions/\`.

## Test plan

- [ ] CI green.
- [ ] After merge, build the bulk JSON for our actual 10.3.40-47 case and run the tool against nuget.org with a real API key.