### PR TITLE
chore(tools): commit unlist-10.3.40-47.json batch as historical record

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -30,4 +30,4 @@ Operational helper scripts that support repo maintenance but are **not** part of
 ]
 ```
 
-Generate ad-hoc as needed — there's no need to commit one-off batch files unless the operation is worth keeping as a historical record.
+Generate ad-hoc as needed; commit if the operation is worth keeping as a historical record. See [`unlist-10.3.40-47.json`](unlist-10.3.40-47.json) — the 102-entry batch used to unlist the 10.3.x patch versions that shipped breaking changes before the v11 semver-policy fix (#220, #222).

--- a/tools/unlist-10.3.40-47.json
+++ b/tools/unlist-10.3.40-47.json
@@ -1,0 +1,410 @@
+[
+  {
+    "package": "Fallout.Build",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Build",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Build",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Build",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Build",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Build",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.Build.Shared",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Build.Shared",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Build.Shared",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Build.Shared",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Build.Shared",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Build.Shared",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.Cli",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Cli",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Cli",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Cli",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Cli",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.Common",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Common",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Common",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Common",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Common",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Common",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.Components",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Components",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Components",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Components",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Components",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Components",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.GlobalTool",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Migrate",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Migrate",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Migrate",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Migrate",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Migrate",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Migrate",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.ProjectModel",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.ProjectModel",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.ProjectModel",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.ProjectModel",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.ProjectModel",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.ProjectModel",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.SolutionModel",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.SolutionModel",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.SolutionModel",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.SolutionModel",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.SolutionModel",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.SolutionModel",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.Tooling",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Tooling",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Tooling",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Tooling",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Tooling",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Tooling",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.Tooling.Generator",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Tooling.Generator",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Tooling.Generator",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Tooling.Generator",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Tooling.Generator",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Tooling.Generator",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.Utilities",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Utilities",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Utilities",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Utilities",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Utilities",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Utilities",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.Utilities.IO.Compression",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Utilities.IO.Compression",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Utilities.IO.Compression",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Utilities.IO.Compression",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Utilities.IO.Compression",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Utilities.IO.Compression",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.Utilities.IO.Globbing",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Utilities.IO.Globbing",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Utilities.IO.Globbing",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Utilities.IO.Globbing",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Utilities.IO.Globbing",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Utilities.IO.Globbing",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.Utilities.Net",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Utilities.Net",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Utilities.Net",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Utilities.Net",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Utilities.Net",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Utilities.Net",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.Utilities.Text.Json",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Utilities.Text.Json",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Utilities.Text.Json",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Utilities.Text.Json",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Utilities.Text.Json",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Utilities.Text.Json",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.Utilities.Text.Yaml",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.Utilities.Text.Yaml",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.Utilities.Text.Yaml",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.Utilities.Text.Yaml",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.Utilities.Text.Yaml",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.Utilities.Text.Yaml",
+    "version": "10.3.47"
+  },
+  {
+    "package": "Fallout.VisualStudio.SolutionPersistence",
+    "version": "10.3.40"
+  },
+  {
+    "package": "Fallout.VisualStudio.SolutionPersistence",
+    "version": "10.3.41"
+  },
+  {
+    "package": "Fallout.VisualStudio.SolutionPersistence",
+    "version": "10.3.42"
+  },
+  {
+    "package": "Fallout.VisualStudio.SolutionPersistence",
+    "version": "10.3.44"
+  },
+  {
+    "package": "Fallout.VisualStudio.SolutionPersistence",
+    "version": "10.3.45"
+  },
+  {
+    "package": "Fallout.VisualStudio.SolutionPersistence",
+    "version": "10.3.47"
+  }
+]


### PR DESCRIPTION
## Summary

Drops the 102-entry bulk-input file alongside the script that consumes it, so the actual cleanup is reproducible / auditable from source.

\`tools/unlist-10.3.40-47.json\` — JSON array of \`{ package, version }\` covering the \`10.3.40\`-\`10.3.47\` range across all 17 affected \`Fallout.*\` packages. These are the patch versions that shipped breaking changes before the v11 semver-policy fix in #220.

To run the cleanup:

\`\`\`
pwsh ./tools/Unlist-NugetPackage.ps1 -JsonPath ./tools/unlist-10.3.40-47.json
\`\`\`

(API key from \`-ApiKey\` or \`\$env:NUGET_API_KEY\`.)

Also amends \`tools/README.md\`: the existing line about "operations worth keeping as a historical record" now points at this file as the live example.

## Test plan

- [ ] CI green (ubuntu-latest paths-ignore doesn't yet cover \`tools/\` — see follow-up note in #223 — so this triggers a full validation run despite being data-only).