### PR TITLE
feat(shim): IHaz* [Obsolete] aliases in Nuke.Components

### DIFF
--- a/fallout.slnx
+++ b/fallout.slnx
@@ -39,6 +39,7 @@
   <Project Path="tests\Fallout.Migrate.Tests\Fallout.Migrate.Tests.csproj" />
   <Project Path="tests\Fallout.Migrate.Analyzers.Tests\Fallout.Migrate.Analyzers.Tests.csproj" />
   <Project Path="tests\Nuke.Common.Shim.Tests\Nuke.Common.Shim.Tests.csproj" />
+  <Project Path="tests\Nuke.Components.Shim.Tests\Nuke.Components.Shim.Tests.csproj" />
   <Project Path="tests\Fallout.ProjectModel.Tests\Fallout.ProjectModel.Tests.csproj" />
   <Project Path="tests\Fallout.SolutionModel.Tests\Fallout.SolutionModel.Tests.csproj" />
   <Project Path="tests\Fallout.SourceGenerators.Tests\Fallout.SourceGenerators.Tests.csproj" />

--- a/src/Shims/Nuke.Components/IHazArtifacts.cs
+++ b/src/Shims/Nuke.Components/IHazArtifacts.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System;
+
+namespace Nuke.Components;
+
+[Obsolete("Renamed to IHasArtifacts. The IHaz* names were legacy NUKE conventions; renamed for clarity in Fallout v11. This alias is shipped only in the Nuke.Components transition shim and will be removed in v12.")]
+public interface IHazArtifacts : IHasArtifacts { }

--- a/src/Shims/Nuke.Components/IHazChangelog.cs
+++ b/src/Shims/Nuke.Components/IHazChangelog.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System;
+
+namespace Nuke.Components;
+
+[Obsolete("Renamed to IHasChangelog. The IHaz* names were legacy NUKE conventions; renamed for clarity in Fallout v11. This alias is shipped only in the Nuke.Components transition shim and will be removed in v12.")]
+public interface IHazChangelog : IHasChangelog { }

--- a/src/Shims/Nuke.Components/IHazConfiguration.cs
+++ b/src/Shims/Nuke.Components/IHazConfiguration.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System;
+
+namespace Nuke.Components;
+
+[Obsolete("Renamed to IHasConfiguration. The IHaz* names were legacy NUKE conventions; renamed for clarity in Fallout v11. This alias is shipped only in the Nuke.Components transition shim and will be removed in v12.")]
+public interface IHazConfiguration : IHasConfiguration { }

--- a/src/Shims/Nuke.Components/IHazGitRepository.cs
+++ b/src/Shims/Nuke.Components/IHazGitRepository.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System;
+
+namespace Nuke.Components;
+
+[Obsolete("Renamed to IHasGitRepository. The IHaz* names were legacy NUKE conventions; renamed for clarity in Fallout v11. This alias is shipped only in the Nuke.Components transition shim and will be removed in v12.")]
+public interface IHazGitRepository : IHasGitRepository { }

--- a/src/Shims/Nuke.Components/IHazGitVersion.cs
+++ b/src/Shims/Nuke.Components/IHazGitVersion.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System;
+
+namespace Nuke.Components;
+
+[Obsolete("Renamed to IHasGitVersion. The IHaz* names were legacy NUKE conventions; renamed for clarity in Fallout v11. This alias is shipped only in the Nuke.Components transition shim and will be removed in v12.")]
+public interface IHazGitVersion : IHasGitVersion { }

--- a/src/Shims/Nuke.Components/IHazNerdbankGitVersioning.cs
+++ b/src/Shims/Nuke.Components/IHazNerdbankGitVersioning.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System;
+
+namespace Nuke.Components;
+
+[Obsolete("Renamed to IHasNerdbankGitVersioning. The IHaz* names were legacy NUKE conventions; renamed for clarity in Fallout v11. This alias is shipped only in the Nuke.Components transition shim and will be removed in v12.")]
+public interface IHazNerdbankGitVersioning : IHasNerdbankGitVersioning { }

--- a/src/Shims/Nuke.Components/IHazReports.cs
+++ b/src/Shims/Nuke.Components/IHazReports.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System;
+
+namespace Nuke.Components;
+
+[Obsolete("Renamed to IHasReports. The IHaz* names were legacy NUKE conventions; renamed for clarity in Fallout v11. This alias is shipped only in the Nuke.Components transition shim and will be removed in v12.")]
+public interface IHazReports : IHasReports { }

--- a/src/Shims/Nuke.Components/IHazSolution.cs
+++ b/src/Shims/Nuke.Components/IHazSolution.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System;
+
+namespace Nuke.Components;
+
+[Obsolete("Renamed to IHasSolution. The IHaz* names were legacy NUKE conventions; renamed for clarity in Fallout v11. This alias is shipped only in the Nuke.Components transition shim and will be removed in v12.")]
+public interface IHazSolution : IHasSolution { }

--- a/src/Shims/Nuke.Components/IHazTwitterCredentials.cs
+++ b/src/Shims/Nuke.Components/IHazTwitterCredentials.cs
@@ -1,0 +1,11 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using System;
+
+namespace Nuke.Components;
+
+[Obsolete("Renamed to IHasTwitterCredentials. The IHaz* names were legacy NUKE conventions; renamed for clarity in Fallout v11. This alias is shipped only in the Nuke.Components transition shim and will be removed in v12.")]
+public interface IHazTwitterCredentials : IHasTwitterCredentials { }

--- a/tests/Fallout.SourceGenerators.Tests/StronglyTypedSolutionGeneratorTest.Test#Solution.g.verified.cs
+++ b/tests/Fallout.SourceGenerators.Tests/StronglyTypedSolutionGeneratorTest.Test#Solution.g.verified.cs
@@ -43,6 +43,7 @@ internal class Solution(SolutionModel model, AbsolutePath path) : Fallout.Common
     public Fallout.Common.ProjectModel.Project Nuke_Common => this.GetProject("Nuke.Common");
     public Fallout.Common.ProjectModel.Project Nuke_Common_Shim_Tests => this.GetProject("Nuke.Common.Shim.Tests");
     public Fallout.Common.ProjectModel.Project Nuke_Components => this.GetProject("Nuke.Components");
+    public Fallout.Common.ProjectModel.Project Nuke_Components_Shim_Tests => this.GetProject("Nuke.Components.Shim.Tests");
 
     public _misc misc => Unsafe.As<_misc>(this.GetSolutionFolder("misc"));
 

--- a/tests/Nuke.Components.Shim.Tests/Nuke.Components.Shim.Tests.csproj
+++ b/tests/Nuke.Components.Shim.Tests/Nuke.Components.Shim.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Shims\Nuke.Common\Nuke.Common.csproj" />
+    <ProjectReference Include="..\..\src\Shims\Nuke.Components\Nuke.Components.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Nuke.Components.Shim.Tests/SampleConsumerBuild.cs
+++ b/tests/Nuke.Components.Shim.Tests/SampleConsumerBuild.cs
@@ -1,0 +1,34 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+//
+// Compile-only contract test for the IHaz* obsolete aliases shipped in the
+// Nuke.Components shim. A NUKE-era consumer declaring `class Build : NukeBuild,
+// IHazSolution, IHazGitRepository` should continue to compile against Fallout —
+// they'll see CS0618 warnings pointing at the renamed IHas* form, but no hard
+// breakage. This file exercises every alias to lock the contract in.
+
+#pragma warning disable CS0618  // IHaz* are intentionally obsolete; exercising them is the point.
+
+using Nuke.Common;
+using Nuke.Components;
+
+namespace Nuke.Components.Shim.Tests;
+
+// Exercises every IHaz* alias in one type. Abstract so we don't have to
+// satisfy any concrete-build requirements — declaration alone proves the
+// inheritance chain (IHaz* → IHas* → IFalloutBuild) resolves.
+public abstract class SampleConsumerBuildWithIHazAliases
+    : NukeBuild,
+      IHazArtifacts,
+      IHazChangelog,
+      IHazConfiguration,
+      IHazGitRepository,
+      IHazGitVersion,
+      IHazNerdbankGitVersioning,
+      IHazReports,
+      IHazSolution,
+      IHazTwitterCredentials
+{
+}

--- a/tests/Nuke.Components.Shim.Tests/ShimCompilesTests.cs
+++ b/tests/Nuke.Components.Shim.Tests/ShimCompilesTests.cs
@@ -1,0 +1,23 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+
+using Xunit;
+
+namespace Nuke.Components.Shim.Tests;
+
+// The whole point of this project is to verify that SampleConsumerBuild.cs
+// compiles against the Nuke.Components shim — the build IS the test. But
+// xUnit's `dotnet test` discoverer treats a test project with zero
+// discoverable tests as an error on Windows (exit code 1) while emitting only
+// a warning on Linux/macOS. This trivial test makes discovery succeed on all
+// platforms.
+public class ShimCompilesTests
+{
+    [Fact]
+    public void Shim_Compiles_When_Test_Assembly_Loads()
+    {
+        Assert.True(true);
+    }
+}


### PR DESCRIPTION
## Summary
- 9 hand-written `[Obsolete]` `IHaz*` alias interfaces in `src/Shims/Nuke.Components/`, each inheriting from the same-named auto-generated `IHas*` sibling.
- New `tests/Nuke.Components.Shim.Tests/` compile-only test project that exercises every alias on a single abstract `SampleConsumerBuildWithIHazAliases` class.
- `fallout.slnx` registers the new test project.

## Why
The `IHaz*` → `IHas*` rename on the canonical `Fallout.Components` side ([landed previously](https://github.com/ChrisonSimtian/Fallout/issues/120#issue-body)) is a hard breaking change for NUKE-era consumers. Without aliases, `class Build : IHazSolution, IHazGitRepository` fails to compile against the next `Nuke.Components` shim release.

These aliases degrade that hard breakage into a deprecation warning (CS0618). Consumer code keeps compiling; the warning message names the canonical `IHas*` form and v12 as the removal target.

## Chain
```
Nuke.Components.IHazSolution    (this PR: hand-written, [Obsolete])
   └ Nuke.Components.IHasSolution    (existing: source-generated)
       └ Fallout.Components.IHasSolution    (existing: canonical)
```

The transition shim generator's `CollectHandBridgedFqns` pass already respects hand-written shim types, so no collision risk with auto-emitted siblings.

## Closes
- Closes #120 (aliases-first strategy supersedes the codefix-only scope; see the updated issue body)
- Follow-up codefix tracked in #242 (optional UX nicety)

## Test plan
- [x] Local `dotnet build` on `src/Shims/Nuke.Components/Nuke.Components.csproj` — green
- [x] Local `dotnet build` on `tests/Nuke.Components.Shim.Tests/` — green
- [x] Local `dotnet test` on the new project — 1 passed
- [ ] CI green on PR
- [ ] Sanity-check that a deliberate consumer reference (with the `#pragma warning disable CS0618` removed) does emit CS0618 — done implicitly: the `SampleConsumerBuildWithIHazAliases` declaration uses every alias and the suppression is needed to keep the test build clean.