### PR TITLE
docs: document merge-strategy convention (squash default, rebase opt-in)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,9 @@ I confirm that the pull-request:
 - [ ] Follows the contribution guidelines
 - [ ] Is based on my own work
 - [ ] Is in compliance with my employer
+
+<!-- Optional: merge preference. Squash is the default; pick rebase only if you've -->
+<!-- curated your commits into a logical sequence and interactive-rebased away any -->
+<!-- review-fixup noise. See CONTRIBUTING.md → Merging. -->
+
+**Merge preference:** ( ) squash (default)  ( ) rebase

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,3 +76,13 @@ Tool wrapper JSON lives under `src/Fallout.Common/Tools/<Tool>/<Tool>.json`. Whe
 - The PR gate is `ubuntu-latest` only (docs-only PRs hit a noop workflow). `windows-latest` and `macos-latest` run post-merge on `main` as release validation.
 - Address review feedback in additional commits rather than force-pushing — easier to review the changes.
 - If CI fails on something unrelated to your change, ping a maintainer.
+
+### Merging
+
+The repo allows both **squash** and **rebase** merge buttons; plain merge commits are disabled (branch protection requires linear history).
+
+- **Default to squash.** One PR → one commit on `main`. Cleanest log, tidiest `Nerdbank.GitVersioning` patch-version cadence, easiest revert.
+- **Choose rebase** if you've curated your commits into a logical sequence you want preserved on `main` (and you don't mind interactive-rebasing away review-fixup noise before merge).
+- If you're using rebase, run `git rebase -i` to squash "address review feedback" / "fix typo" commits before requesting final approval — every commit landing on `main` is a bisect target.
+
+The merger (typically a CODEOWNER) picks the button; the PR description can request a preference but isn't binding.


### PR DESCRIPTION
## Summary
- New \"Merging\" subsection in CONTRIBUTING.md under \"Pull requests\" — documents that both squash and rebase merge buttons are enabled, squash is the default, rebase is for curated commit sequences.
- Optional merge-preference line in the PR template so contributors can signal which button they'd prefer.

## Out-of-band change (already applied)
- Repo setting \`allow_merge_commit\` flipped to \`false\` via API. Plain merge commits would fail the linear-history check anyway, so this just removes the UX trap of a button that always errors.

## Context
The repo has had \`allow_squash_merge\` + \`allow_rebase_merge\` both enabled the whole time, but the convention was never written down. @dennisdoomen prefers rebase; this lands the policy so external contributors know they can pick without asking. Captures the trade-offs around \`Nerdbank.GitVersioning\` patch-version drift, bisect granularity, and review-fixup hygiene.

## Notes
- Docs-only PR — no \`/src\` or \`/tests\` touched, so under the CODEOWNERS rule landed in #232 this needs only CI green to merge.
- Independent of #244 (the Build Status + stargazers README PR); both can land in any order.