### PR TITLE
test(consumers): add NUKE + Fallout consumer compatibility sentinels

### DIFF
--- a/fallout.slnx
+++ b/fallout.slnx
@@ -43,6 +43,9 @@
   <Project Path="tests\Fallout.ProjectModel.Tests\Fallout.ProjectModel.Tests.csproj" />
   <Project Path="tests\Fallout.SolutionModel.Tests\Fallout.SolutionModel.Tests.csproj" />
   <Project Path="tests\Fallout.SourceGenerators.Tests\Fallout.SourceGenerators.Tests.csproj" />
+  <Project Path="tests\Consumers\Nuke.Consumer\Nuke.Consumer.csproj" />
+  <Project Path="tests\Consumers\Fallout.Consumer.Local\Fallout.Consumer.Local.csproj" />
+  <Project Path="tests\Consumers\Fallout.Consumer.NuGet\Fallout.Consumer.NuGet.csproj" />
   <Project Path="tests\Fallout.Tooling.Tests\Fallout.Tooling.Tests.csproj" />
   <Project Path="tests\Fallout.Utilities.Tests\Fallout.Utilities.Tests.csproj" />
 </Solution>

--- a/tests/Consumers/Fallout.Consumer.Local/Build.cs
+++ b/tests/Consumers/Fallout.Consumer.Local/Build.cs
@@ -1,0 +1,25 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+//
+// Fallout consumer against this repo's local source. Catches breakage of the
+// public Fallout surface in the current PR.
+
+using Fallout.Common;
+using Fallout.Common.IO;
+using Fallout.Common.ProjectModel;
+
+class Build : FalloutBuild
+{
+    public static int Main() => Execute<Build>(x => x.Default);
+
+    [Solution] readonly Solution Solution;
+
+    Target Default => _ => _
+        .Executes(() =>
+        {
+            Serilog.Log.Information("hello from fallout consumer (local source)");
+            Serilog.Log.Information("solution name: {Name}", Solution?.Name ?? "<unbound>");
+        });
+}

--- a/tests/Consumers/Fallout.Consumer.Local/Fallout.Consumer.Local.csproj
+++ b/tests/Consumers/Fallout.Consumer.Local/Fallout.Consumer.Local.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Fallout.Consumer.Local</RootNamespace>
+    <NoWarn>$(NoWarn);CS0649</NoWarn>
+  </PropertyGroup>
+
+  <!--
+    Direct ProjectReferences against this repo's local source. Always tracks
+    HEAD. Catches breakage in the current PR.
+
+    NOTE: this references Fallout.SolutionModel (current main shape). When the
+    persistence-layering work lands (#248/#254), this csproj will need to
+    point at the new location (src/Persistence/Fallout.Solution/) and the
+    Build.cs `using Fallout.Common.ProjectModel;` will need to become
+    `using Fallout.Solutions;`. The PR doing that rename owns both updates;
+    see tests/Consumers/README.md → "Catching breaking changes".
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Fallout.Common\Fallout.Common.csproj" />
+    <ProjectReference Include="..\..\..\src\Fallout.Build\Fallout.Build.csproj" />
+    <ProjectReference Include="..\..\..\src\Fallout.SolutionModel\Fallout.SolutionModel.csproj" />
+    <ProjectReference Include="..\..\..\src\Fallout.Components\Fallout.Components.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Consumers/Fallout.Consumer.NuGet/Build.cs
+++ b/tests/Consumers/Fallout.Consumer.NuGet/Build.cs
@@ -1,0 +1,26 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+//
+// Fallout consumer against PUBLISHED Fallout.* packages (pinned in the csproj).
+// Validates that the most-recent release's surface is intact from a clean
+// consumer's perspective.
+
+using Fallout.Common;
+using Fallout.Common.IO;
+using Fallout.Common.ProjectModel;
+
+class Build : FalloutBuild
+{
+    public static int Main() => Execute<Build>(x => x.Default);
+
+    [Solution] readonly Solution Solution;
+
+    Target Default => _ => _
+        .Executes(() =>
+        {
+            Serilog.Log.Information("hello from fallout consumer (pinned nuget 11.0.8)");
+            Serilog.Log.Information("solution name: {Name}", Solution?.Name ?? "<unbound>");
+        });
+}

--- a/tests/Consumers/Fallout.Consumer.NuGet/Fallout.Consumer.NuGet.csproj
+++ b/tests/Consumers/Fallout.Consumer.NuGet/Fallout.Consumer.NuGet.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Fallout.Consumer.NuGet</RootNamespace>
+    <NoWarn>$(NoWarn);CS0649</NoWarn>
+
+    <!-- Opt out of Directory.Build.targets' smart-rewrite so PackageReferences
+         actually resolve against nuget.org instead of in-solution ProjectReferences.
+         This is the whole point of this project: validate against the LAST PUBLISHED
+         package surface, not the current source tree.
+
+         Also opt out of central package management so the inline Version="..."
+         pins below take effect. -->
+    <ReplacePackageReferences>false</ReplacePackageReferences>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!--
+    Pinned to the last release before any in-flight breaking change.
+    BUMP THIS after each release to catch upgrade-direction breaking changes.
+    See tests/Consumers/README.md → "Bumping the NuGet pin".
+  -->
+  <ItemGroup>
+    <PackageReference Include="Fallout.Common" Version="11.0.8" />
+    <PackageReference Include="Fallout.Build" Version="11.0.8" />
+    <PackageReference Include="Fallout.SolutionModel" Version="11.0.8" />
+    <PackageReference Include="Fallout.Components" Version="11.0.8" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Consumers/Nuke.Consumer/Build.cs
+++ b/tests/Consumers/Nuke.Consumer/Build.cs
@@ -1,0 +1,35 @@
+// Copyright 2026 Maintainers of Fallout.
+// Originally based on NUKE by Matthias Koch and contributors.
+// Distributed under the MIT License.
+// https://github.com/ChrisonSimtian/Fallout/blob/main/LICENSE
+//
+// Pre-rename NUKE consumer pattern, compiled against the Nuke.Common /
+// Nuke.Components transition shims. If a typical NUKE 10.x Build.cs stops
+// compiling against the latest Fallout, this fails — protecting upgrading
+// users from silent breakage.
+
+using Nuke.Common;
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+using Nuke.Components;
+
+// The shim generator skips delegates by C# language limitation (see SHIM002 —
+// can't subclass a delegate cross-assembly). `Target` is a delegate in
+// Fallout.Common, so NUKE-era code referencing `Target` needs either
+// `fallout-migrate` (which flips usings to Fallout.*) or this manual alias.
+// Including it here keeps the rest of the file NUKE-shape.
+using Target = Fallout.Common.Target;
+
+class Build : NukeBuild
+{
+    public static int Main() => Execute<Build>(x => x.Default);
+
+    [Solution] readonly Solution Solution;
+
+    Target Default => _ => _
+        .Executes(() =>
+        {
+            Serilog.Log.Information("hello from nuke consumer (via shim)");
+            Serilog.Log.Information("solution name: {Name}", Solution?.Name ?? "<unbound>");
+        });
+}

--- a/tests/Consumers/Nuke.Consumer/Nuke.Consumer.csproj
+++ b/tests/Consumers/Nuke.Consumer/Nuke.Consumer.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Nuke.Consumer</RootNamespace>
+    <!-- Build.cs uses readonly fields populated by Fallout's value injection. -->
+    <NoWarn>$(NoWarn);CS0649</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Shims\Nuke.Common\Nuke.Common.csproj" />
+    <ProjectReference Include="..\..\..\src\Shims\Nuke.Build\Nuke.Build.csproj" />
+    <ProjectReference Include="..\..\..\src\Shims\Nuke.Components\Nuke.Components.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Consumers/README.md
+++ b/tests/Consumers/README.md
@@ -1,0 +1,53 @@
+# Consumer compatibility tests
+
+Three small build-project consumers that exercise Fallout's public surface from the perspectives of real downstream users. If any of these stop **compiling**, we've broken something consumers depend on.
+
+## Projects
+
+| Project | What it exercises | Reference style |
+|---|---|---|
+| [`Nuke.Consumer`](Nuke.Consumer/) | A pre-rename NUKE consumer using `class Build : NukeBuild`, `[Solution]`, and `Target` via the `Nuke.Common` / `Nuke.Build` / `Nuke.Components` transition shims. Catches breakage of **shim coverage** — if a NUKE-shape symbol stops resolving, an upgrading NUKE user breaks. | `ProjectReference` to `src/Shims/Nuke.*/` |
+| [`Fallout.Consumer.Local`](Fallout.Consumer.Local/) | A Fallout consumer using `class Build : FalloutBuild`, `[Solution]`, `Target` against **this repo's current source**. Catches breakage of the public Fallout surface **in the current PR**. | Direct `ProjectReference` to the in-repo `Fallout.*` projects |
+| [`Fallout.Consumer.NuGet`](Fallout.Consumer.NuGet/) | A Fallout consumer against the **last published** `Fallout.*` packages (pinned in the csproj). Catches **packaging issues** (missing assemblies, wrong references) on the most-recent release, and catches upgrade-direction breakage when the pin is bumped after a release. | `PackageReference` to nuget.org with `<ReplacePackageReferences>false</ReplacePackageReferences>` and `<ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>` so the smart-rewrite doesn't kick in |
+
+## How they're validated
+
+**Compile-time validation only.** All three projects are in `fallout.slnx`, so `dotnet build fallout.slnx` (the standard CI gate) compiles them. Any consumer-facing breaking change makes the build fail.
+
+### Why not runtime validation?
+
+A runtime smoke test layer was considered (spawn each consumer via `dotnet run`, assert exit code `0`). That hits a Fallout framework requirement: `FalloutBuild.cctor()` enumerates `Host` subclasses and reflects for a static `IsRunningHost` property — minimal consumers that don't pull in the full Fallout MSBuild props/targets (`Fallout.Common.props`, `Fallout.Common.targets`) trigger `System.ArgumentException: Host type 'Host' defines no property 'IsRunningHost'` at activation. Reproducing the full build-app environment for a smoke consumer is more setup than the test's marginal value justifies — compile-time already catches the bulk of breaking changes.
+
+If runtime validation becomes worth the cost: import `Fallout.Common.props` + `Fallout.Common.targets` from the consumer csprojs (the way `build/_build.csproj` does), provide a `FalloutRootDirectory`, and the framework should activate cleanly.
+
+## Catching breaking changes
+
+The intended flow:
+
+1. These consumer projects live on `main` and reflect the **current public consumer surface**. Any PR proposing a change to consumer-facing types/namespaces/attributes…
+2. …will conflict with the consumer code in those projects (rebase or merge will surface the breakage).
+3. Resolving the conflict means either: (a) the change isn't really breaking and the conflict is trivial, or (b) the consumer code needs updating to the new shape, **which is the migration path**. Update both, document the migration in `CHANGELOG.md` under `[Unreleased] — <next-major>`, and you've simultaneously detected the breaking change AND demonstrated how consumers migrate.
+
+This works as designed only because the consumer code is **fixed to the current API shape**, not regenerated to match new code. Don't auto-update consumer Build.cs files to match a PR's renamed types — let them break, then fix them deliberately as part of the migration story.
+
+## Bumping the NuGet pin
+
+After a new `Fallout.*` release ships, edit `Fallout.Consumer.NuGet/Fallout.Consumer.NuGet.csproj` to bump the pinned version. If the consumer source still compiles, the upgrade is non-breaking. If it fails, the new release introduces a consumer-facing breaking change — record it in `CHANGELOG.md` and the migration path under `[Unreleased] — <next-major>`.
+
+The `Nuke.Consumer` doesn't pin anything (it references the in-repo shim assemblies directly), so no bump cadence there — it always tracks HEAD's shim coverage.
+
+## What's deliberately tested
+
+- **NUKE-era `class Build : NukeBuild`** — basic class identity through the shim
+- **`[Solution] readonly Solution Solution`** — value-injection attribute + facade type via shim
+- **`Target Default => _ => _.Executes(...)`** — delegate type, default target lambda
+- **`static int Main() => Execute<Build>(x => x.Default)`** — framework entry point
+
+## What's NOT tested
+
+- Actual build *execution* (see above — runtime activation is fragile)
+- CI-host integration (GitHubActions, AzurePipelines, etc.) — covered by `tests/Fallout.Common.Tests/CI/`
+- Tool wrappers — covered by their own generated tests
+- Source generator behaviour — covered by `tests/Fallout.SourceGenerators.Tests/`
+
+These consumer projects are a **sentinel for shape changes**, not a place to demo features. Don't add consumer projects covering specific subsystems — those go in their own focused tests.

--- a/tests/Fallout.SourceGenerators.Tests/StronglyTypedSolutionGeneratorTest.Test#Solution.g.verified.cs
+++ b/tests/Fallout.SourceGenerators.Tests/StronglyTypedSolutionGeneratorTest.Test#Solution.g.verified.cs
@@ -17,6 +17,8 @@ internal class Solution(SolutionModel model, AbsolutePath path) : Fallout.Common
     public Fallout.Common.ProjectModel.Project Fallout_Common => this.GetProject("Fallout.Common");
     public Fallout.Common.ProjectModel.Project Fallout_Common_Tests => this.GetProject("Fallout.Common.Tests");
     public Fallout.Common.ProjectModel.Project Fallout_Components => this.GetProject("Fallout.Components");
+    public Fallout.Common.ProjectModel.Project Fallout_Consumer_Local => this.GetProject("Fallout.Consumer.Local");
+    public Fallout.Common.ProjectModel.Project Fallout_Consumer_NuGet => this.GetProject("Fallout.Consumer.NuGet");
     public Fallout.Common.ProjectModel.Project Fallout_Migrate => this.GetProject("Fallout.Migrate");
     public Fallout.Common.ProjectModel.Project Fallout_Migrate_Analyzers => this.GetProject("Fallout.Migrate.Analyzers");
     public Fallout.Common.ProjectModel.Project Fallout_Migrate_Analyzers_Tests => this.GetProject("Fallout.Migrate.Analyzers.Tests");
@@ -44,6 +46,7 @@ internal class Solution(SolutionModel model, AbsolutePath path) : Fallout.Common
     public Fallout.Common.ProjectModel.Project Nuke_Common_Shim_Tests => this.GetProject("Nuke.Common.Shim.Tests");
     public Fallout.Common.ProjectModel.Project Nuke_Components => this.GetProject("Nuke.Components");
     public Fallout.Common.ProjectModel.Project Nuke_Components_Shim_Tests => this.GetProject("Nuke.Components.Shim.Tests");
+    public Fallout.Common.ProjectModel.Project Nuke_Consumer => this.GetProject("Nuke.Consumer");
 
     public _misc misc => Unsafe.As<_misc>(this.GetSolutionFolder("misc"));
 


### PR DESCRIPTION
Replaces #255 (closed — wrong stack ordering). This PR is **based on main** with the **current pre-rename API shape** baked into the consumer code. That makes it the breaking-change detector: any future PR that changes consumer-facing types/namespaces/attributes will conflict with the consumer code, and resolving the conflict IS the migration story.

## Three consumer projects

- **\`tests/Consumers/Nuke.Consumer/\`** — NUKE-era \`class Build : NukeBuild, [Solution], Target\` via the \`Nuke.Common\` / \`Nuke.Build\` / \`Nuke.Components\` transition shims. Catches shim-coverage breakage.
- **\`tests/Consumers/Fallout.Consumer.Local/\`** — direct \`ProjectReference\` to in-repo \`Fallout.*\`. Catches in-PR breakage of the local source.
- **\`tests/Consumers/Fallout.Consumer.NuGet/\`** — \`PackageReference\` pinned to \`Fallout.* 11.0.8\` on nuget.org with \`ReplacePackageReferences=false\` + central package management off. Catches packaging issues + upgrade-direction breakage when bumped after a release.

All in \`fallout.slnx\` — \`dotnet build fallout.slnx\` is the CI gate.

## The deliberate workflow

1. This PR lands first. \`main\` now has consumer sentinels reflecting today's consumer-facing API.
2. **#254** (vendor-fork elimination + namespace rename) rebases on top of this. Its namespace changes will conflict with the consumer code on rebase. **That conflict IS the breaking-change signal.**
3. Resolving the conflict in #254 means updating \`Fallout.Consumer.Local\`'s csproj path + \`Build.cs\` namespaces to match the new \`Fallout.Solutions\` shape. That update is the migration story — documented in #254's CHANGELOG entry.
4. After #254 lands with consumers updated, \`main\` once again has consumer sentinels reflecting the (post-rename) consumer-facing API. The cycle continues for future PRs.

This works as designed only because the consumer code is **frozen to a point-in-time API shape**, not auto-regenerated to match new code. \`tests/Consumers/README.md\` documents the intent and warns against breaking that contract.

## Runtime smoke tests deliberately excluded

\`FalloutBuild.cctor()\` enumerates \`Host\` subclasses and reflects for \`IsRunningHost\` — minimal consumers without the full Fallout.Common.props/targets environment throw \`ArgumentException: Host type 'Host' defines no property 'IsRunningHost'\` at activation. Reproducing the full build-app environment was meaningfully more setup than the runtime check's marginal value justified. Compile-time validation captures the breaking-change signal we actually need.

## Test plan
- [x] \`dotnet build fallout.slnx\` — 0 errors, all three consumers compile against current main
- [x] \`dotnet test fallout.slnx --no-build\` — all suites green (StronglyTypedSolutionGenerator snapshot regenerated for +3 projects)
- [ ] CI green on this PR
- [ ] #254 rebased on this — expects conflicts in \`Fallout.Consumer.Local/{csproj,Build.cs}\` (the namespace-rename consequence). Conflict resolution becomes the documented migration step.