### PR TITLE
chore(dev): allow pwsh -NoProfile ./build.ps1 in project permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,7 @@
       "Bash(./build.sh:*)",
       "Bash(./build.cmd:*)",
       "Bash(pwsh ./build.ps1:*)",
+      "Bash(pwsh -NoProfile ./build.ps1:*)",
       "Bash(git status)",
       "Bash(git status:*)",
       "Bash(git diff:*)",


### PR DESCRIPTION
Adds `Bash(pwsh -NoProfile ./build.ps1:*)` to the project permission allowlist in `.claude/settings.json`.

The list already permits `pwsh ./build.ps1:*`, but not the `-NoProfile` variant — which is faster and cleaner for agent-driven build runs. Adds the specific **script-file** form only; deliberately **not** `pwsh -Command`, which stays blocked as an arbitrary-execution bypass vector.

Dev-tooling only — no code, no consumer impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
