### PR TITLE
ci: declare release job as deploying to nuget-org environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,21 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    # Declares the job as deploying to the `nuget-org` GitHub Environment.
+    # Effects:
+    #   - `secrets.NUGET_API_KEY` resolves from the env-scoped secret rather
+    #     than the repo-scoped one (per #273 — repo secret deleted after this
+    #     migration verifies clean).
+    #   - The environment's required-reviewer rule fires before the job runs.
+    #     Currently @ChrisonSimtian is the sole reviewer (#272).
+    #   - A deployment record is created on the GitHub Environment, visible
+    #     under Deployments tab.
+    # When #274 lands the tag-trigger + multi-channel split, this `environment:`
+    # declaration moves down to a dedicated publish-nuget-org step; Test+Pack
+    # become unguarded.
+    environment:
+      name: nuget-org
+      url: https://www.nuget.org/profiles/Fallout
     steps:
       - uses: actions/checkout@v6
         with:
@@ -51,9 +66,11 @@ jobs:
       - name: 'Run: Test, Pack, Publish'
         run: dotnet fallout Test Pack Publish
         env:
-          # Publish target is nuget.org now that Fallout.* rename has landed (#54).
-          # NUGET_API_KEY is an API key scoped to push Fallout.* packages, set in
-          # repo Settings → Secrets and variables → Actions.
+          # Publish target is nuget.org. NUGET_API_KEY is an API key scoped to
+          # push Fallout.* packages. After #273 lands the secret lives on the
+          # `nuget-org` GitHub Environment (declared above) — the env scoping
+          # is what gates the approval step. Before #273, the same secret name
+          # resolved from the repo-level scope.
           NuGetApiKey: ${{ secrets.NUGET_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
> **Draft — do not merge** until the env-secret value is in place. See "Runbook" below.

Prep PR for [#273](https://github.com/ChrisonSimtian/Fallout/issues/273). Adds `environment: nuget-org` to the release job so `secrets.NUGET_API_KEY` resolves from the env-scoped secret rather than the repo-scoped one.

## Runbook for landing this safely

1. **You** add the env secret via UI:
   - Settings → Environments → `nuget-org` → Add environment secret
   - Name: `NUGET_API_KEY`
   - Value: your nuget.org API key scoped to push `Fallout.*` (either the existing one from your password manager OR generate a fresh key as a rotation hygiene step)
2. **Mark this PR ready for review** (or I do) — CI runs and verifies the YAML parses.
3. **Merge.** From this point the workflow uses the env secret. The repo-level `NUGET_API_KEY` secret is still there as a fallback but unused.
4. **Verify with a manual run**: Actions → `release` → Run workflow on `main` → approve the env gate when prompted → workflow succeeds + publishes (or just packs, depending on whether you want a real release at the verification moment).
5. **Delete the repo-level `NUGET_API_KEY` secret** via UI (Settings → Secrets and variables → Actions). After step 4 confirms the env-scoped one works.
6. Close #273.

## What changes in this PR

- `jobs.release` gains `environment:` declaration with `name: nuget-org` and the user-facing `url: https://www.nuget.org/profiles/Fallout`.
- Comment in the workflow rewritten to reflect the env-scoped secret model.

## What this PR explicitly does NOT do

- **Doesn't add the env secret** — that has to be done via UI by Chris.
- **Doesn't split the release job** into per-environment publish steps. That's #274's job. Current shape applies the gate to the whole `Test → Pack → Publish` run, which is fine for the manual `workflow_dispatch` shape (you approve once knowing you want to release).
- **Doesn't touch `github-packages` or `github-releases` environments** — they're unguarded and the workflow doesn't currently target them; they come into play in #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)