### PR TITLE
chore(versioning): add release/v11 to publicReleaseRefSpec

### DIFF
--- a/version.json
+++ b/version.json
@@ -2,7 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "11.0",
   "publicReleaseRefSpec": [
-    "^refs/heads/main$"
+    "^refs/heads/main$",
+    "^refs/heads/release/v11$"
   ],
   "pathFilters": [
     ":/",


### PR DESCRIPTION
Targets `release/v11` (not main). Closes #275.

## Problem

Per the NB.GV validation under [#275](https://github.com/ChrisonSimtian/Fallout/issues/275), `release/v11` was producing git-sha-suffixed versions like `11.0.19-g4b19a8c1` instead of clean `11.0.19` because the branch wasn't in `publicReleaseRefSpec`. With [#274](https://github.com/ChrisonSimtian/Fallout/pull/288) (the tag-triggered shape) about to land, the first `v11.0.X` tag would publish to nuget.org with the suffix in the version string — confusing for consumers and not what the tag implies.

## Fix

Adds `^refs/heads/release/v11$` to `publicReleaseRefSpec` in `version.json`. Commits + tag heights on this branch now produce clean version strings.

## Why it targets release/v11 and not main

- `main` is still at `11.0` (issue #271, "bump main to 12.0", is deferred until v12 work actually starts).
- If we added `release/v11` to `main`'s `publicReleaseRefSpec` while both branches have `"version": "11.0"`, NB.GV would treat both as public-release branches for the same major+minor — patch-height collisions follow.
- The setting is intentionally branch-specific to *how this branch generates versions* — not something that needs to propagate forward.
- When v12 work begins and main bumps to `12.0`, the equivalent edit will happen on whatever next release branch is cut.

## Verification (you can spot-check post-merge)

```
git fetch
git switch release/v11
git pull
dotnet nbgv get-version    # should report 11.0.X clean, no -g<sha>
```

## Test plan
- [x] YAML/JSON parses (it's a one-line addition; CI will confirm).
- [ ] CI green on this PR.
- [ ] Post-merge: spot-check `nbgv get-version` on release/v11 produces clean output.
- [ ] Once #288 (release.yml refactor) is also merged, smoke test via workflow_dispatch confirms a tag produces a clean version string for nuget.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)