### PR TITLE
ci: extend windows-latest + macos-latest push triggers to release/v*

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - main
+      - 'release/v*'
 
 jobs:
   macos-latest:

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - main
+      - 'release/v*'
 
 jobs:
   windows-latest:

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -1,15 +1,17 @@
 using Fallout.Common.CI.GitHubActions;
 using Fallout.Components;
 
-// macOS and Windows runs are reserved for main-branch validation (post-merge
-// and release pipelines). PRs and feature-branch pushes get Linux-only for
-// fast, cheap feedback.
+// macOS and Windows runs are reserved for post-merge validation on the
+// long-lived branches (main and release/vN). PRs and feature-branch pushes
+// get Linux-only for fast, cheap feedback. Cross-platform regressions on a
+// release branch surface as a red commit on release/v* — same fail-fast
+// model as main.
 [GitHubActions(
     "macos-latest",
     GitHubActionsImage.MacOsLatest,
     FetchDepth = 0,
     Submodules = GitHubActionsSubmodules.Recursive,
-    OnPushBranches = new[] { MainBranch },
+    OnPushBranches = new[] { MainBranch, ReleaseBranchPattern },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
     PublishArtifacts = false)]
 [GitHubActions(
@@ -17,7 +19,7 @@ using Fallout.Components;
     GitHubActionsImage.WindowsLatest,
     FetchDepth = 0,
     Submodules = GitHubActionsSubmodules.Recursive,
-    OnPushBranches = new[] { MainBranch },
+    OnPushBranches = new[] { MainBranch, ReleaseBranchPattern },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
     PublishArtifacts = false)]
 // pull_request only — same-repo branches would otherwise fire both push and


### PR DESCRIPTION
Closes [#293](https://github.com/ChrisonSimtian/Fallout/issues/293). Parity follow-up to [#291](https://github.com/ChrisonSimtian/Fallout/pull/291), which extended PR-validation triggers to `release/v*` but deliberately left push triggers alone.

## Why

After #291 + #292, PRs against `release/v*` get `ubuntu-latest`. But post-merge cross-platform validation (`windows-latest` + `macos-latest`) still only fires on push to `main`. A hotfix landing on `release/v11` with a subtle Windows or macOS regression wouldn't be caught until someone attempts a release and the cross-platform CI in `release.yml`'s Test step fails — higher-stakes path, harder to fix forward.

## What changes

- **`build/Build.CI.GitHubActions.cs`** — `OnPushBranches` on both `windows-latest` and `macos-latest` `[GitHubActions]` entries now reads `new[] { MainBranch, ReleaseBranchPattern }`. `ReleaseBranchPattern` was added in #291 alongside `MainBranch`.
- **`.github/workflows/windows-latest.yml`** — `push.branches` adds `'release/v*'`.
- **`.github/workflows/macos-latest.yml`** — same.

YAML hand-edited to match the source — next time someone runs `dotnet fallout --generate-configuration GitHubActions_windows-latest GitHubActions_macos-latest`, the regen produces identical output.

## Effect

A hotfix merged to `release/v11` now fires Windows + macOS post-merge validation. Cross-platform regressions surface immediately as a red commit on the release branch, not later during a release attempt.

## Out of scope

- **Pull-request triggers on windows/macos.** Those stay PR-only on `main`. The current PR gate (`ubuntu-latest` only) is a deliberate cost trade-off documented in `docs/agents/release-and-versioning.md` — Linux is the cheap, fast feedback loop; Windows/macOS are reserved for post-merge.

## Test plan
- [x] YAMLs parse
- [x] Build.cs compiles
- [ ] CI green on this PR
- [ ] Post-merge: confirm windows-latest + macos-latest fire when a commit lands on release/v11 (next hotfix or sentinel commit)

Refs milestone #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)