### PR TITLE
chore(release): flip version.json to calendar versioning (ADR-0004)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -38,4 +38,22 @@
     </When>
   </Choose>
 
+  <!-- Nerdbank.GitVersioning emits its Git*/NBGV_* cloud-build variables (and build number)
+       to $GITHUB_ENV once per project. In a parallel multi-project build these concurrent,
+       unsynchronized appends race and can tear a line — e.g. the CalVer version "2026.1.0"
+       fragmenting so the tail "6.1.0" lands on its own line — which the GitHub Actions runner
+       rejects with "Unable to process file command 'env' … Invalid format". The version is
+       read via ThisAssembly at compile time and no workflow consumes these variables, so
+       suppress the emission by clearing the items/property NBGV's writer targets are gated on.
+       Order-independent: relies on BeforeTargets scheduling, not import order. See ADR-0004. -->
+  <Target Name="FalloutDisableNbgvCloudVars"
+          BeforeTargets="SetCloudBuildVersionVars;SetCloudBuildNumberWithVersion">
+    <ItemGroup>
+      <CloudBuildVersionVars Remove="@(CloudBuildVersionVars)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <CloudBuildNumber></CloudBuildNumber>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/docs/adr/0004-calendar-versioning-and-dual-pace-channels.md
+++ b/docs/adr/0004-calendar-versioning-and-dual-pace-channels.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted (2026-05-29). **Supersedes the versioning section of [ADR-0001](0001-release-branch-model.md) and extends its channel model**; the release-branch + tag-triggered multi-channel CD machinery from ADR-0001 and the nuget.org-opt-in policy from [ADR-0002](0002-v11-off-nuget-by-default.md) remain in force. Discussion thread: _(linked on publish — see References)_.
+Accepted (2026-05-29). **Supersedes the versioning section of [ADR-0001](0001-release-branch-model.md) and extends its channel model**; the release-branch + tag-triggered multi-channel CD machinery from ADR-0001 and the nuget.org-opt-in policy from [ADR-0002](0002-v11-off-nuget-by-default.md) remain in force. Discussion thread: [#302](https://github.com/ChrisonSimtian/Fallout/discussions/302).
 
 ## Context
 
@@ -138,4 +138,4 @@ Make daily builds literally `2026.05.29`.
 - [ADR-0002: v11 off nuget.org by default](0002-v11-off-nuget-by-default.md) — nuget.org-opt-in policy, retained.
 - [docs/branching-and-release.md](../branching-and-release.md) — maintainer runbook (updated for this model).
 - [docs/agents/release-and-versioning.md](../agents/release-and-versioning.md) — agent-facing branching/versioning/PR-flow reference (updated for this model).
-- Discussion thread: _(GitHub Discussions — linked on publish)_.
+- Discussion thread: [#302 — Calendar versioning + dual-pace channels (feedback)](https://github.com/ChrisonSimtian/Fallout/discussions/302).

--- a/version.json
+++ b/version.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "11.0",
+  "version": "2026.1.0-edge.{height}",
   "publicReleaseRefSpec": [
-    "^refs/heads/main$"
+    "^refs/heads/release/\\d{4}$",
+    "^refs/heads/release/v\\d+$"
   ],
   "pathFilters": [
     ":/",
@@ -16,7 +17,7 @@
   },
   "release": {
     "versionIncrement": "minor",
-    "firstUnstableTag": "preview",
-    "branchName": "release/v{version}"
+    "firstUnstableTag": "edge",
+    "branchName": "release/{version}"
   }
 }


### PR DESCRIPTION
Implements the versioning half of [ADR-0004](https://github.com/ChrisonSimtian/Fallout/blob/main/docs/adr/0004-calendar-versioning-and-dual-pace-channels.md) (landed in #301). PR 2 of the rollout sequence.

## What changes

`version.json`:
- **`"version"`: `11.0` → `2026.1.0-edge.{height}`** — `main` now produces **edge prereleases**.
- **`main` removed from `publicReleaseRefSpec`** → `main` is a non-public ref, so its builds carry the `-edge` prerelease tag (intentionally unstable). `publicReleaseRefSpec` now matches **both** `^refs/heads/release/\d{4}$` (CalVer stable trains) and `^refs/heads/release/v\d+$` (legacy `release/v10` etc.), so those resolve to clean versions.
- `firstUnstableTag` → `edge`; `branchName` → `release/{version}`.
- Backfills the Discussion [#302](https://github.com/ChrisonSimtian/Fallout/discussions/302) link into ADR-0004.

## Verified with `nbgv` (3.7.115 pinned; tested 3.9.50 CLI)

| Context | `version` | Rendered |
|---|---|---|
| `main` (non-public) | `2026.1.0-edge.{height}` | `2026.1.0-edge.N.g<commit>` — edge prerelease |
| `release/2026` (public) | `2026.0` | `2026.0.x` — clean stable |
| `release/v10` (public, own version.json) | `10.3` | `10.x` — unaffected |

Edge (`2026.1.x`) deliberately sits one minor *ahead* of the first stable train (`2026.0.x`), so edge prereleases sort above stable and there's no patch-height collision between the two public-mapped refs.

> Note: `main` doesn't auto-publish today (tag-triggered pipeline fires from `release/*`), so this only changes the *computed* version on `main` until the edge publish job lands. ubuntu-latest builds + tests everything here, so any version-string snapshot fallout surfaces in CI.

## Follow-ups
- Cut `release/2026` (pin its `version.json` to `2026.0`).
- PR 3 — `release.yml`: add the `main`→GitHub Packages edge publish job + channel mapping.
- PR 4 — `[Experimental("FALLOUT0xx")]` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)