### PR TITLE
ci: add edge channel (main → GitHub Packages) + CalVer-aware release routing

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -1,0 +1,76 @@
+# Hand-written. The "edge" channel (ADR-0004).
+#
+# Shape:
+#   - Trigger: push to `main`. `main` is the edge channel — the fast / AI-assisted
+#     lane. Nerdbank.GitVersioning produces a prerelease version of the form
+#     `2026.1.0-edge.<height>.g<commit>` (main is intentionally NOT a public-release
+#     ref in version.json), so these never look like a stable release.
+#   - Builds + packs, then pushes every *.nupkg to GitHub Packages ONLY.
+#   - Deliberately does NOT touch nuget.org and does NOT create a GitHub Release.
+#     Edge is intentionally unstable; GitHub Packages is opt-in for consumers
+#     (they add the feed), so edge causes none of the nuget.org Dependabot
+#     fan-out that ADR-0001 / ADR-0002 were avoiding.
+#
+# Stable + legacy releases are deliberate and tag-triggered — see release.yml.
+# Cross-platform validation on main pushes is covered by macos-latest.yml /
+# windows-latest.yml; this workflow's job is publishing, not gating.
+
+name: edge
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - '.assets/**'
+      - '**/*.md'
+
+permissions:
+  contents: read
+
+jobs:
+  edge:
+    name: edge → GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    environment:
+      name: github-packages
+      url: https://github.com/ChrisonSimtian/Fallout/packages
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0           # Nerdbank.GitVersioning needs full history
+          submodules: recursive
+      - name: 'Cache: .fallout/temp, ~/.nuget/packages'
+        uses: actions/cache@v4
+        with:
+          path: |
+            .fallout/temp
+            ~/.nuget/packages
+          key: ${{ runner.os }}-edge-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props', 'version.json') }}
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
+      - name: 'Run: Pack'
+        run: dotnet fallout Pack
+      - name: 'Push: all *.nupkg to GitHub Packages (edge)'
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          packages=(output/packages/*.nupkg)
+          if [ ${#packages[@]} -eq 0 ]; then
+            echo "::error::No packages found — nothing to publish to the edge channel."
+            exit 1
+          fi
+          for pkg in "${packages[@]}"; do
+            echo "Pushing $pkg to GitHub Packages (edge)..."
+            dotnet nuget push "$pkg" \
+              --source "https://nuget.pkg.github.com/ChrisonSimtian/index.json" \
+              --api-key "${{ secrets.GITHUB_TOKEN }}" \
+              --skip-duplicate
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,30 +2,33 @@
 # rationale (lets us bridge GitHub's NUGET_API_KEY secret to Fallout's
 # NuGetApiKey parameter, which would otherwise have to share a name).
 #
+# This is the DELIBERATE (stable + legacy) release path. The fast "edge" channel
+# (push to main → GitHub Packages) lives in edge.yml. See ADR-0004.
+#
 # Shape:
-#   - Trigger: tag push `v*` on a `release/v*` branch. Tag protection ruleset
-#     restricts who can create those tags to repo admins.
+#   - Trigger: tag push `v*` on a release branch — CalVer stable trains
+#     (release/2026 → tag v2026.1.3) or legacy semver lines (release/v10 → v10.x).
+#     Tags keep the `v` prefix so the `v*` tag-protection ruleset applies; the
+#     package version core is the bare CalVer/semver (e.g. 2026.1.3). Tag
+#     protection restricts who can create those tags to repo admins.
 #   - Optional fallback: workflow_dispatch with an existing-tag input, for
 #     re-runs after a transient publish-API failure, OR to opt into a
 #     nuget.org publish (see below).
-#   - validate-ref → test-and-pack → fan out to three publish jobs in
-#     parallel:
-#       - publish-nuget-org   (Tier 1, opt-in via workflow_dispatch flag, approval-gated)
-#       - publish-github-packages (Tier 2, all packages — Fallout.* + Nuke.*)
+#   - validate-ref → test-and-pack → fan out to three publish jobs in parallel:
+#       - publish-nuget-org   (opt-in via workflow_dispatch flag, approval-gated)
+#       - publish-github-packages (all packages — Fallout.* + Nuke.*)
 #       - publish-github-releases (artifact bundling on the tag's GH Release)
 #
-# Channel routing for v11+ (current direction):
-#   - nuget.org is reserved for v10.x and (eventually) "stabilised" v11. Tag
-#     pushes do NOT auto-publish to nuget.org. To publish Fallout.* to
-#     nuget.org you must invoke workflow_dispatch with publish-to-nugetorg=true
-#     — a conscious "this release is stabilised enough for nuget.org" switch.
+# Channel routing (ADR-0004):
+#   - nuget.org is OPT-IN. Tag pushes do NOT auto-publish there. To publish
+#     Fallout.* to nuget.org you invoke workflow_dispatch with
+#     publish-to-nugetorg=true — a conscious "this release is stabilised enough"
+#     switch, used when a release/YYYY stable train is ready for the broad
+#     consumer audience, or for a release/v10 legacy security patch.
 #   - GitHub Packages gets every Fallout.* and Nuke.* build via tag push.
-#     This is the de-facto release channel during v11 prerelease/stabilisation.
 #   - GitHub Releases bundles nupkgs on the tag's release page regardless.
 #
-# When v11 stabilises (or for cutting v10.x maintenance patches), use the
-# workflow_dispatch path with publish-to-nugetorg=true. See
-# docs/branching-and-release.md for the full runbook.
+# See docs/branching-and-release.md for the full runbook.
 
 name: release
 
@@ -63,14 +66,15 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: 'Verify tag is reachable from a release/v* branch'
+      - name: 'Verify tag is reachable from a release branch'
         run: |
           set -euo pipefail
           TAG_SHA="${{ github.sha }}"
-          REACHABLE=$(git branch -r --contains "$TAG_SHA" | grep -E 'origin/release/v[0-9]+' || true)
+          # Match CalVer stable trains (release/2026, …) and legacy semver lines (release/v10, …).
+          REACHABLE=$(git branch -r --contains "$TAG_SHA" | grep -E 'origin/release/(v[0-9]+|[0-9]{4})' || true)
           if [ -z "$REACHABLE" ]; then
-            echo "::error::Tag ${GITHUB_REF_NAME} at $TAG_SHA is not reachable from any release/v* branch."
-            echo "Tag-triggered releases only fire from release/v* branches."
+            echo "::error::Tag ${GITHUB_REF_NAME} at $TAG_SHA is not reachable from any release/ branch."
+            echo "Tag-triggered releases only fire from release/YYYY (stable) or release/v* (legacy) branches."
             exit 1
           fi
           echo "Tag ${GITHUB_REF_NAME} validated. Reachable from:"


### PR DESCRIPTION
PR 3 of the ADR-0004 rollout — the publishing half of the dual-pace model.

## `edge.yml` (new)
Push to `main` → build, pack, push every `*.nupkg` to **GitHub Packages only**.
- `main` is non-public in `version.json`, so NB.GV produces `2026.1.0-edge.<height>.g<commit>` prereleases — never stable-looking.
- **No nuget.org, no GitHub Release.** Edge is intentionally unstable; GitHub Packages is opt-in for consumers (they add the feed), so edge causes none of the nuget.org Dependabot fan-out that ADR-0001/0002 were avoiding.
- `main` is already in the `github-packages` environment's allowed deployment branches, so it deploys without an approval gate.
- Validation/gating stays elsewhere (PR `ubuntu-latest`, post-merge `macos`/`windows`); this workflow just publishes.

## `release.yml` (deliberate path — minimal change)
- `validate-ref` now accepts **CalVer stable trains** (`release/2026`, …) alongside legacy semver lines (`release/v10`, …).
- Header updated for the channel model. The gated, tag-triggered stable/legacy flow is otherwise unchanged — **nuget.org stays opt-in** (`workflow_dispatch` + env approval).

## Channel map after this PR
| Channel | From | To |
|---|---|---|
| edge | push to `main` | GitHub Packages |
| stable | tag `v2026.x` on `release/2026` | GH Packages + GH Releases (+ nuget.org opt-in) |
| legacy | tag `v10.x` on `release/v10` | GH Packages + GH Releases (+ nuget.org opt-in) |

## Follow-up (not this PR)
Before the first **stable** `v2026.*` release tag, add a CalVer pattern to the `github-packages` / `nuget-org` environment deployment-branch policies (currently `main` + `release/v*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)