### PR TITLE
ci: realign triggers to the 3-tier ladder + hygiene (milestone #18)

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -28,6 +28,11 @@ on:
       - '.assets/**'
       - '**/*.md'
 
+# Cancel a superseded alpha build when a newer commit lands (#322). Never on release.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -44,7 +49,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0           # Nerdbank.GitVersioning needs full history
-          submodules: recursive
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -18,11 +18,20 @@ name: macos-latest
 
 on:
   push:
+    tags:
+      - 'v*'
+  pull_request:
     branches:
-      - experimental
-      - main
       - 'release/*'
       - 'support/*'
+    paths-ignore:
+      - 'docs/**'
+      - '.assets/**'
+      - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   macos-latest:
@@ -31,7 +40,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          submodules: recursive
           fetch-depth: 0
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -28,6 +28,11 @@ on:
       - '.assets/**'
       - '**/*.md'
 
+# Cancel a superseded preview build when a newer commit lands (#322). Never on release.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -44,7 +49,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0           # Nerdbank.GitVersioning needs full history
-          submodules: recursive
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,6 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0           # Nerdbank.GitVersioning needs full history
-          submodules: recursive    # vendor/vs-solutionpersistence
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -28,6 +28,10 @@ on:
       - '.assets/**'
       - '**/*.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ubuntu-latest:
     name: ubuntu-latest
@@ -35,7 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          submodules: recursive
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.head_ref }}

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -18,11 +18,20 @@ name: windows-latest
 
 on:
   push:
+    tags:
+      - 'v*'
+  pull_request:
     branches:
-      - experimental
-      - main
       - 'release/*'
       - 'support/*'
+    paths-ignore:
+      - 'docs/**'
+      - '.assets/**'
+      - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   windows-latest:
@@ -31,7 +40,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          submodules: recursive
           fetch-depth: 0
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -1,37 +1,51 @@
 using Fallout.Common.CI.GitHubActions;
 using Fallout.Components;
 
-// macOS and Windows runs are reserved for post-merge validation on the
-// long-lived branches (experimental, main, release/YYYY, support/*). PRs and
-// feature-branch pushes get Linux-only for fast, cheap feedback. Cross-platform
-// regressions on those branches surface as a red commit — same fail-fast model.
+// Cross-platform (macOS/Windows) full Test+Pack is gated to RELEASE INTENT
+// (#318/#326): it runs only on a PR into a production branch (release/YYYY,
+// support/*) and on a release tag push (v*) — never on routine pushes to
+// main/experimental, never on a per-merge basis. On main/experimental "we've
+// got our edge": the ubuntu-latest PR gate + the alpha/preview pipelines.
+// (workflow_dispatch as a manual cross-platform trigger isn't emitted here —
+// the generator only writes workflow_dispatch when it has inputs; GitHub's
+// built-in run re-run covers the on-demand case.)
+//
+// concurrency cancel-in-progress (#322): superseded runs are cancelled rather
+// than stacked. Never applied to release.yml (a publish must not be cancelled).
 [GitHubActions(
     "macos-latest",
     GitHubActionsImage.MacOsLatest,
     FetchDepth = 0,
-    Submodules = GitHubActionsSubmodules.Recursive,
-    OnPushBranches = new[] { ExperimentalBranch, MainBranch, ReleaseBranchPattern, SupportBranchPattern },
+    ConcurrencyGroup = "${{ github.workflow }}-${{ github.ref }}",
+    ConcurrencyCancelInProgress = true,
+    OnPushTags = new[] { "v*" },
+    OnPullRequestBranches = new[] { ReleaseBranchPattern, SupportBranchPattern },
+    OnPullRequestExcludePaths = new[] { "docs/**", ".assets/**", "**/*.md" },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
     PublishArtifacts = false)]
 [GitHubActions(
     "windows-latest",
     GitHubActionsImage.WindowsLatest,
     FetchDepth = 0,
-    Submodules = GitHubActionsSubmodules.Recursive,
-    OnPushBranches = new[] { ExperimentalBranch, MainBranch, ReleaseBranchPattern, SupportBranchPattern },
+    ConcurrencyGroup = "${{ github.workflow }}-${{ github.ref }}",
+    ConcurrencyCancelInProgress = true,
+    OnPushTags = new[] { "v*" },
+    OnPullRequestBranches = new[] { ReleaseBranchPattern, SupportBranchPattern },
+    OnPullRequestExcludePaths = new[] { "docs/**", ".assets/**", "**/*.md" },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
     PublishArtifacts = false)]
-// pull_request only — same-repo branches would otherwise fire both push and
-// pull_request events on every push, double-running the validation.
-//
-// CheckoutRef = github.head_ref pins checkout to the PR source branch instead of the merge SHA,
-// keeping HEAD attached so GitHubTasksTest.GitHubRepositoryFromLocalDirectoryTest (which reads
-// .git/HEAD via GitRepository.FromLocalDirectory) resolves a non-null branch.
+// The Linux PR gate — the only required status check. pull_request only:
+// feature-branch pushes run zero CI until a PR is opened against a long-lived
+// branch (#327). CheckoutRef = github.head_ref pins checkout to the PR source
+// branch instead of the merge SHA, keeping HEAD attached so
+// GitHubTasksTest.GitHubRepositoryFromLocalDirectoryTest (which reads .git/HEAD
+// via GitRepository.FromLocalDirectory) resolves a non-null branch.
 [GitHubActions(
     "ubuntu-latest",
     GitHubActionsImage.UbuntuLatest,
     FetchDepth = 0,
-    Submodules = GitHubActionsSubmodules.Recursive,
+    ConcurrencyGroup = "${{ github.workflow }}-${{ github.ref }}",
+    ConcurrencyCancelInProgress = true,
     CheckoutRef = "${{ github.head_ref }}",
     // Trigger for PRs targeting experimental, main, or any release/YYYY / support/*
     // branch — all are long-lived and protected; all require the ubuntu-latest check.

--- a/docs/agents/conventions.md
+++ b/docs/agents/conventions.md
@@ -34,9 +34,23 @@ public sealed class NewPluginHost
 - **Channel discipline differs.** On the `experimental` (alpha) / `main` (preview) test lanes, churn is expected and the attribute is a courtesy. On a `release/YYYY` **production line**, any risky-but-shipped public surface **must** wear `[Experimental]` — that contract is what keeps the stable line trustworthy while still carrying new work.
 - **Don't apply it speculatively.** Because the diagnostic is error-by-default, marking an API that's already used internally breaks the build everywhere it's referenced. Only add `[Experimental]` to a genuinely not-yet-stable API, and suppress every internal usage in the same change so the build stays green.
 
+## CI pipeline & triggers
+
+Shaped by [milestone #18](https://github.com/ChrisonSimtian/Fallout/milestone/18) and the [ADR-0004](../adr/0004-calendar-versioning-and-dual-pace-channels.md) ladder. Invariants:
+
+- **Feature branches run zero CI until a PR is opened.** Push triggers list **only** long-lived branches; nothing fires on `feature/*`, `bugfix/*`, etc. until they're PR'd against `experimental`/`main`/`release/*`/`support/*`. Do **not** add a working-branch pattern to any `OnPush*`/`branches:` trigger.
+- **The Linux PR gate (`ubuntu-latest`) is the only required check** — runs on PRs to the four long-lived branches.
+- **`experimental` (push) → `-alpha`, `main` (push) → `-preview`** to GitHub Packages (`experimental.yml` / `preview.yml`).
+- **Cross-platform `windows`/`macos` are gated to release intent** — PR-to-`release/*`/`support/*` or a `v*` tag push only. They do **not** run on `main`/`experimental` pushes. ("On `main` we've got our edge.")
+- **`concurrency: cancel-in-progress` on every build workflow except `release.yml`** — never cancel a publish mid-flight.
+- **Canonical CI-ignore paths:** `docs/**`, `.assets/**`, `**/*.md` — applied to every PR/push trigger.
+- The `ubuntu-latest` / `windows-latest` / `macos-latest` workflows are **generated** from `build/Build.CI.GitHubActions.cs` — edit the attributes + constants there and regenerate (`./build.sh`), never hand-edit the `.yml`. `experimental.yml` / `preview.yml` / `release.yml` are hand-written.
+
 ## What not to do
 
 - Don't reintroduce `source/` — production code lives under `src/`, tests under `tests/`. Same for `images/` (now `.assets/`).
+- Don't add `main`/`experimental` (or any working-branch pattern) to the **push** triggers of the cross-platform workflows — they're release-intent-gated on purpose (milestone #18 / #318 / #326).
+- Don't add `submodules: recursive` to checkouts — there are no submodules (no `.gitmodules`); it's a dead init step.
 - Don't add `secret`/`default` defaults to tool JSON files (see CONTRIBUTING.md).
 - Don't introduce a new test framework or assertion library — stay on xUnit + FluentAssertions + Verify.
 - Don't commit `output/` or any `bin/`/`obj/` directory.


### PR DESCRIPTION
Implements the **trigger + hygiene** slice of [milestone #18](https://github.com/ChrisonSimtian/Fallout/milestone/18). (#325 publish-lane realignment already landed with the ladder.)

## Changes

| Issue | Change |
|---|---|
| #318 / #326 | **Cross-platform gated to release intent.** `windows`/`macos` no longer run on `main`/`experimental` (or any routine push) — only on **PR-to-`release/*`/`support/*`** and **`v*` tag pushes**. |
| #322 | `concurrency: cancel-in-progress` on `ubuntu`/`windows`/`macos` + `experimental.yml` + `preview.yml`. **Not** on `release.yml` (never cancel a publish). |
| #323 / #328 | Canonical CI-ignore list (`docs/**`, `.assets/**`, `**/*.md`) on every PR/push trigger. |
| #327 | Codified *"feature branches run zero CI until PR'd"* + the trigger model in `docs/agents/conventions.md`, with what-not-to-do guards. |
| #329 | Dropped dead `submodules: recursive` from all checkouts + the generator (no `.gitmodules`; full build passes without it) + stale vendor comment. |

Generated workflows (`ubuntu`/`windows`/`macos`) regenerated from `build/Build.CI.GitHubActions.cs`.

## Notes / deferred (per maintainer: triggers+hygiene now, structural later)
- **#324** (split Build/Test/Pack into stages) and the **#328 caching deep-dive** are deferred to their own follow-ups.
- **#327 automated reflective guard-test** deferred — the doc codification + what-not-to-do bullets are the guard for now.
- **`workflow_dispatch`** on cross-platform isn't emitted — the generator only writes it with inputs; GitHub's built-in run re-run covers on-demand. (Minor note on #326.)
- `release.yml` is tag-triggered, so path-ignore is N/A there (a tagged release must always validate).

## Related (done outside this PR)
The `github-packages` **environment** deployment policy was updated (approved separately) to allow `experimental`/`main`/`release/*`/`support/*` + `v*` tags — that's what unblocks the new lanes from publishing.

Follows #320, #321. See [ADR-0004](docs/adr/0004-calendar-versioning-and-dual-pace-channels.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)