### PR TITLE
ci: test before publishing on every lane + cache restore-keys (#324, #328)

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -56,14 +56,21 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-experimental-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props', 'version.json') }}
+          restore-keys: |
+            ${{ runner.os }}-experimental-
       - name: 'Setup: .NET SDK'
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: Pack'
-        run: dotnet fallout Pack
+      # build + unit-test before publishing alpha (#324). One invocation: NUKE runs
+      # this as discrete internal stages (Restore → Compile → Test → Pack) and fails
+      # at the breaking stage — separate `dotnet fallout` steps would re-run the
+      # dependency graph (double-compile), so we keep it a single invocation.
+      # If Test fails, the job stops here and nothing is published.
+      - name: 'Run: Test + Pack'
+        run: dotnet fallout Test Pack
       - name: 'Push: all *.nupkg to GitHub Packages (alpha)'
         run: |
           set -euo pipefail

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -56,14 +56,21 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-preview-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props', 'version.json') }}
+          restore-keys: |
+            ${{ runner.os }}-preview-
       - name: 'Setup: .NET SDK'
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: Pack'
-        run: dotnet fallout Pack
+      # build + unit-test before publishing preview (#324). One invocation: NUKE runs
+      # this as discrete internal stages (Restore → Compile → Test → Pack) and fails
+      # at the breaking stage — separate `dotnet fallout` steps would re-run the
+      # dependency graph (double-compile), so we keep it a single invocation.
+      # If Test fails, the job stops here and nothing is published.
+      - name: 'Run: Test + Pack'
+        run: dotnet fallout Test Pack
       - name: 'Push: all *.nupkg to GitHub Packages (preview)'
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,8 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-release-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props', 'version.json') }}
+          restore-keys: |
+            ${{ runner.os }}-release-
       - name: 'Setup: .NET SDK'
         uses: actions/setup-dotnet@v4
         with:

--- a/docs/agents/conventions.md
+++ b/docs/agents/conventions.md
@@ -45,6 +45,8 @@ Shaped by [milestone #18](https://github.com/ChrisonSimtian/Fallout/milestone/18
 - **`concurrency: cancel-in-progress` on every build workflow except `release.yml`** — never cancel a publish mid-flight.
 - **Canonical CI-ignore paths:** `docs/**`, `.assets/**`, `**/*.md` — applied to every PR/push trigger.
 - The `ubuntu-latest` / `windows-latest` / `macos-latest` workflows are **generated** from `build/Build.CI.GitHubActions.cs` — edit the attributes + constants there and regenerate (`./build.sh`), never hand-edit the `.yml`. `experimental.yml` / `preview.yml` / `release.yml` are hand-written.
+- **Every publishing lane runs `Test` before it publishes** (#324). `experimental.yml`, `preview.yml`, and `release.yml` all run a single `dotnet fallout Test Pack` invocation — NUKE executes it as discrete internal stages (Restore → Compile → Test → Pack) and fails at the breaking stage, so a test failure stops the job before the push step. Don't split a lane into separate `dotnet fallout Compile`/`Test`/`Pack` steps — each invocation re-runs the dependency graph (double-compile); the single invocation *is* the staged build.
+- **Caching** (#328): every workflow caches `~/.nuget/packages` + `.fallout/temp`, keyed on `global.json` + `**/*.csproj` + `Directory.Packages.props` (the dependency-affecting set), with a `restore-keys:` prefix fallback for partial restores. There is no `packages.lock.json` to add to the key, and build outputs (`bin`/`obj`) are deliberately **not** cached (stale-artifact correctness risk).
 
 ## What not to do
 


### PR DESCRIPTION
Picks up the structural CI items from [milestone #18](https://github.com/ChrisonSimtian/Fallout/milestone/18).

## #324 — test before publishing (the real gap)

`experimental.yml` and `preview.yml` were running `dotnet fallout Pack` **only** — publishing `-alpha`/`-preview` packages **without running any tests**. Both now run `dotnet fallout Test Pack` (release.yml + the `ubuntu-latest` PR gate already did).

**Why one invocation, not separate steps:** NUKE re-runs the dependency graph on each `dotnet fallout` call, so `Compile` then `Test` then `Pack` as separate CI steps would compile 2–3×. A single `Test Pack` invocation runs as NUKE's **discrete internal stages** (Restore → Compile → Test → Pack), failing at the breaking stage. If `Test` fails the job stops before the push step — untested packages never publish. (This is the "discrete stages + attributable + experimental builds+tests then pushes" intent, done the NUKE-idiomatic way.)

## #328 — caching + canonical exclusions

- `restore-keys:` prefix fallback added to the hand-written workflows' caches → partial restore on key miss (faster restores).
- **Evaluation:** current key (`global.json` + `**/*.csproj` + `Directory.Packages.props`) is the correct dependency set; there's **no `packages.lock.json`** to add; build-output (`bin`/`obj`) caching deliberately **not** done (stale-artifact correctness risk).
- Canonical ignore list (`docs/**`, `.assets/**`, `**/*.md`) was already applied consistently in the trigger PR (#330).

Both codified in `docs/agents/conventions.md`.

## Deferred
- **#327 automated reflective guard-test** — the doc codification + what-not-to-do bullets are the guard for now.

Follows #320, #321, #330. Closes the milestone-18 structural slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)