### PR TITLE
chore: forward-port main → experimental (CI hygiene #322/#324/#329)

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -56,14 +56,21 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-experimental-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props', 'version.json') }}
+          restore-keys: |
+            ${{ runner.os }}-experimental-
       - name: 'Setup: .NET SDK'
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: Pack'
-        run: dotnet fallout Pack
+      # build + unit-test before publishing alpha (#324). One invocation: NUKE runs
+      # this as discrete internal stages (Restore → Compile → Test → Pack) and fails
+      # at the breaking stage — separate `dotnet fallout` steps would re-run the
+      # dependency graph (double-compile), so we keep it a single invocation.
+      # If Test fails, the job stops here and nothing is published.
+      - name: 'Run: Test + Pack'
+        run: dotnet fallout Test Pack
       - name: 'Push: all *.nupkg to GitHub Packages (alpha)'
         run: |
           set -euo pipefail

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -28,6 +28,11 @@ on:
       - '.assets/**'
       - '**/*.md'
 
+# Cancel a superseded alpha build when a newer commit lands (#322). Never on release.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -44,7 +49,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0           # Nerdbank.GitVersioning needs full history
-          submodules: recursive
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:

--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -18,11 +18,20 @@ name: macos-latest
 
 on:
   push:
+    tags:
+      - 'v*'
+  pull_request:
     branches:
-      - experimental
-      - main
       - 'release/*'
       - 'support/*'
+    paths-ignore:
+      - 'docs/**'
+      - '.assets/**'
+      - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   macos-latest:
@@ -31,7 +40,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          submodules: recursive
           fetch-depth: 0
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -56,14 +56,21 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-preview-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props', 'version.json') }}
+          restore-keys: |
+            ${{ runner.os }}-preview-
       - name: 'Setup: .NET SDK'
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: Pack'
-        run: dotnet fallout Pack
+      # build + unit-test before publishing preview (#324). One invocation: NUKE runs
+      # this as discrete internal stages (Restore → Compile → Test → Pack) and fails
+      # at the breaking stage — separate `dotnet fallout` steps would re-run the
+      # dependency graph (double-compile), so we keep it a single invocation.
+      # If Test fails, the job stops here and nothing is published.
+      - name: 'Run: Test + Pack'
+        run: dotnet fallout Test Pack
       - name: 'Push: all *.nupkg to GitHub Packages (preview)'
         run: |
           set -euo pipefail

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -28,6 +28,11 @@ on:
       - '.assets/**'
       - '**/*.md'
 
+# Cancel a superseded preview build when a newer commit lands (#322). Never on release.yml.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -44,7 +49,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0           # Nerdbank.GitVersioning needs full history
-          submodules: recursive
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,6 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0           # Nerdbank.GitVersioning needs full history
-          submodules: recursive    # vendor/vs-solutionpersistence
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,8 @@ jobs:
             .fallout/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-release-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props', 'version.json') }}
+          restore-keys: |
+            ${{ runner.os }}-release-
       - name: 'Setup: .NET SDK'
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -28,6 +28,10 @@ on:
       - '.assets/**'
       - '**/*.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ubuntu-latest:
     name: ubuntu-latest
@@ -35,7 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          submodules: recursive
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.head_ref }}

--- a/.github/workflows/windows-latest.yml
+++ b/.github/workflows/windows-latest.yml
@@ -18,11 +18,20 @@ name: windows-latest
 
 on:
   push:
+    tags:
+      - 'v*'
+  pull_request:
     branches:
-      - experimental
-      - main
       - 'release/*'
       - 'support/*'
+    paths-ignore:
+      - 'docs/**'
+      - '.assets/**'
+      - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   windows-latest:
@@ -31,7 +40,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          submodules: recursive
           fetch-depth: 0
       - name: 'Cache: .fallout/temp, ~/.nuget/packages'
         uses: actions/cache@v4

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -1,37 +1,51 @@
 using Fallout.Common.CI.GitHubActions;
 using Fallout.Components;
 
-// macOS and Windows runs are reserved for post-merge validation on the
-// long-lived branches (experimental, main, release/YYYY, support/*). PRs and
-// feature-branch pushes get Linux-only for fast, cheap feedback. Cross-platform
-// regressions on those branches surface as a red commit — same fail-fast model.
+// Cross-platform (macOS/Windows) full Test+Pack is gated to RELEASE INTENT
+// (#318/#326): it runs only on a PR into a production branch (release/YYYY,
+// support/*) and on a release tag push (v*) — never on routine pushes to
+// main/experimental, never on a per-merge basis. On main/experimental "we've
+// got our edge": the ubuntu-latest PR gate + the alpha/preview pipelines.
+// (workflow_dispatch as a manual cross-platform trigger isn't emitted here —
+// the generator only writes workflow_dispatch when it has inputs; GitHub's
+// built-in run re-run covers the on-demand case.)
+//
+// concurrency cancel-in-progress (#322): superseded runs are cancelled rather
+// than stacked. Never applied to release.yml (a publish must not be cancelled).
 [GitHubActions(
     "macos-latest",
     GitHubActionsImage.MacOsLatest,
     FetchDepth = 0,
-    Submodules = GitHubActionsSubmodules.Recursive,
-    OnPushBranches = new[] { ExperimentalBranch, MainBranch, ReleaseBranchPattern, SupportBranchPattern },
+    ConcurrencyGroup = "${{ github.workflow }}-${{ github.ref }}",
+    ConcurrencyCancelInProgress = true,
+    OnPushTags = new[] { "v*" },
+    OnPullRequestBranches = new[] { ReleaseBranchPattern, SupportBranchPattern },
+    OnPullRequestExcludePaths = new[] { "docs/**", ".assets/**", "**/*.md" },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
     PublishArtifacts = false)]
 [GitHubActions(
     "windows-latest",
     GitHubActionsImage.WindowsLatest,
     FetchDepth = 0,
-    Submodules = GitHubActionsSubmodules.Recursive,
-    OnPushBranches = new[] { ExperimentalBranch, MainBranch, ReleaseBranchPattern, SupportBranchPattern },
+    ConcurrencyGroup = "${{ github.workflow }}-${{ github.ref }}",
+    ConcurrencyCancelInProgress = true,
+    OnPushTags = new[] { "v*" },
+    OnPullRequestBranches = new[] { ReleaseBranchPattern, SupportBranchPattern },
+    OnPullRequestExcludePaths = new[] { "docs/**", ".assets/**", "**/*.md" },
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
     PublishArtifacts = false)]
-// pull_request only — same-repo branches would otherwise fire both push and
-// pull_request events on every push, double-running the validation.
-//
-// CheckoutRef = github.head_ref pins checkout to the PR source branch instead of the merge SHA,
-// keeping HEAD attached so GitHubTasksTest.GitHubRepositoryFromLocalDirectoryTest (which reads
-// .git/HEAD via GitRepository.FromLocalDirectory) resolves a non-null branch.
+// The Linux PR gate — the only required status check. pull_request only:
+// feature-branch pushes run zero CI until a PR is opened against a long-lived
+// branch (#327). CheckoutRef = github.head_ref pins checkout to the PR source
+// branch instead of the merge SHA, keeping HEAD attached so
+// GitHubTasksTest.GitHubRepositoryFromLocalDirectoryTest (which reads .git/HEAD
+// via GitRepository.FromLocalDirectory) resolves a non-null branch.
 [GitHubActions(
     "ubuntu-latest",
     GitHubActionsImage.UbuntuLatest,
     FetchDepth = 0,
-    Submodules = GitHubActionsSubmodules.Recursive,
+    ConcurrencyGroup = "${{ github.workflow }}-${{ github.ref }}",
+    ConcurrencyCancelInProgress = true,
     CheckoutRef = "${{ github.head_ref }}",
     // Trigger for PRs targeting experimental, main, or any release/YYYY / support/*
     // branch — all are long-lived and protected; all require the ubuntu-latest check.

--- a/docs/agents/conventions.md
+++ b/docs/agents/conventions.md
@@ -45,6 +45,8 @@ Shaped by [milestone #18](https://github.com/ChrisonSimtian/Fallout/milestone/18
 - **`concurrency: cancel-in-progress` on every build workflow except `release.yml`** — never cancel a publish mid-flight.
 - **Canonical CI-ignore paths:** `docs/**`, `.assets/**`, `**/*.md` — applied to every PR/push trigger.
 - The `ubuntu-latest` / `windows-latest` / `macos-latest` workflows are **generated** from `build/Build.CI.GitHubActions.cs` — edit the attributes + constants there and regenerate (`./build.sh`), never hand-edit the `.yml`. `experimental.yml` / `preview.yml` / `release.yml` are hand-written.
+- **Every publishing lane runs `Test` before it publishes** (#324). `experimental.yml`, `preview.yml`, and `release.yml` all run a single `dotnet fallout Test Pack` invocation — NUKE executes it as discrete internal stages (Restore → Compile → Test → Pack) and fails at the breaking stage, so a test failure stops the job before the push step. Don't split a lane into separate `dotnet fallout Compile`/`Test`/`Pack` steps — each invocation re-runs the dependency graph (double-compile); the single invocation *is* the staged build.
+- **Caching** (#328): every workflow caches `~/.nuget/packages` + `.fallout/temp`, keyed on `global.json` + `**/*.csproj` + `Directory.Packages.props` (the dependency-affecting set), with a `restore-keys:` prefix fallback for partial restores. There is no `packages.lock.json` to add to the key, and build outputs (`bin`/`obj`) are deliberately **not** cached (stale-artifact correctness risk).
 
 ## What not to do
 

--- a/docs/agents/conventions.md
+++ b/docs/agents/conventions.md
@@ -34,9 +34,23 @@ public sealed class NewPluginHost
 - **Channel discipline differs.** On the `experimental` (alpha) / `main` (preview) test lanes, churn is expected and the attribute is a courtesy. On a `release/YYYY` **production line**, any risky-but-shipped public surface **must** wear `[Experimental]` — that contract is what keeps the stable line trustworthy while still carrying new work.
 - **Don't apply it speculatively.** Because the diagnostic is error-by-default, marking an API that's already used internally breaks the build everywhere it's referenced. Only add `[Experimental]` to a genuinely not-yet-stable API, and suppress every internal usage in the same change so the build stays green.
 
+## CI pipeline & triggers
+
+Shaped by [milestone #18](https://github.com/ChrisonSimtian/Fallout/milestone/18) and the [ADR-0004](../adr/0004-calendar-versioning-and-dual-pace-channels.md) ladder. Invariants:
+
+- **Feature branches run zero CI until a PR is opened.** Push triggers list **only** long-lived branches; nothing fires on `feature/*`, `bugfix/*`, etc. until they're PR'd against `experimental`/`main`/`release/*`/`support/*`. Do **not** add a working-branch pattern to any `OnPush*`/`branches:` trigger.
+- **The Linux PR gate (`ubuntu-latest`) is the only required check** — runs on PRs to the four long-lived branches.
+- **`experimental` (push) → `-alpha`, `main` (push) → `-preview`** to GitHub Packages (`experimental.yml` / `preview.yml`).
+- **Cross-platform `windows`/`macos` are gated to release intent** — PR-to-`release/*`/`support/*` or a `v*` tag push only. They do **not** run on `main`/`experimental` pushes. ("On `main` we've got our edge.")
+- **`concurrency: cancel-in-progress` on every build workflow except `release.yml`** — never cancel a publish mid-flight.
+- **Canonical CI-ignore paths:** `docs/**`, `.assets/**`, `**/*.md` — applied to every PR/push trigger.
+- The `ubuntu-latest` / `windows-latest` / `macos-latest` workflows are **generated** from `build/Build.CI.GitHubActions.cs` — edit the attributes + constants there and regenerate (`./build.sh`), never hand-edit the `.yml`. `experimental.yml` / `preview.yml` / `release.yml` are hand-written.
+
 ## What not to do
 
 - Don't reintroduce `source/` — production code lives under `src/`, tests under `tests/`. Same for `images/` (now `.assets/`).
+- Don't add `main`/`experimental` (or any working-branch pattern) to the **push** triggers of the cross-platform workflows — they're release-intent-gated on purpose (milestone #18 / #318 / #326).
+- Don't add `submodules: recursive` to checkouts — there are no submodules (no `.gitmodules`); it's a dead init step.
 - Don't add `secret`/`default` defaults to tool JSON files (see CONTRIBUTING.md).
 - Don't introduce a new test framework or assertion library — stay on xUnit + FluentAssertions + Verify.
 - Don't commit `output/` or any `bin/`/`obj/` directory.


### PR DESCRIPTION
Forward-ports `main` onto `experimental` so the fast lane catches up to the CI work that landed on `main` *after* `experimental` was cut (the bounded `experimental → main` divergence ADR-0004 flagged — here flowing the other way to resync).

Brings in #330 (release-intent triggers, concurrency #322, path parity #323, submodule removal #329) and #331 (test-before-publish #324 + cache restore-keys). Clean merge — **no conflicts**; `experimental`'s `version.json` stays `2026.1.0-alpha.{height}` (only the `main` side was unchanged there).

Needed so in-flight feature work on `experimental` (e.g. #333 multi-channel publish) builds on current workflows rather than the stale `Run: Pack` ones.