### PR TITLE
feat(publish): multi-channel, package-ID-aware publishing + dogfood the lanes (#333)

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -64,26 +64,13 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      # build + unit-test before publishing alpha (#324). One invocation: NUKE runs
-      # this as discrete internal stages (Restore → Compile → Test → Pack) and fails
-      # at the breaking stage — separate `dotnet fallout` steps would re-run the
-      # dependency graph (double-compile), so we keep it a single invocation.
-      # If Test fails, the job stops here and nothing is published.
-      - name: 'Run: Test + Pack'
-        run: dotnet fallout Test Pack
-      - name: 'Push: all *.nupkg to GitHub Packages (alpha)'
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          packages=(output/packages/*.nupkg)
-          if [ ${#packages[@]} -eq 0 ]; then
-            echo "::error::No packages found — nothing to publish to the experimental channel."
-            exit 1
-          fi
-          for pkg in "${packages[@]}"; do
-            echo "Pushing $pkg to GitHub Packages (alpha)..."
-            dotnet nuget push "$pkg" \
-              --source "https://nuget.pkg.github.com/ChrisonSimtian/index.json" \
-              --api-key "${{ secrets.GITHUB_TOKEN }}" \
-              --skip-duplicate
-          done
+      # Test + Pack + push alpha → GitHub Packages, all through our own framework (#333) —
+      # dogfooding `dotnet fallout Publish` instead of a hand-rolled `dotnet nuget push`.
+      # `Publish` depends on Test + Pack, so NUKE runs Restore → Compile → Test → Pack →
+      # Publish as discrete internal stages and fails at the breaking stage; if Test fails
+      # the job stops before any push. Which packages go where (Fallout.* + Nuke.* → GitHub
+      # Packages) is decided by Build.cs IPublish.PublishTargets, not here.
+      - name: 'Publish: alpha → GitHub Packages'
+        run: dotnet fallout Publish --publish-to github-packages
+        env:
+          GitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -64,26 +64,13 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      # build + unit-test before publishing preview (#324). One invocation: NUKE runs
-      # this as discrete internal stages (Restore → Compile → Test → Pack) and fails
-      # at the breaking stage — separate `dotnet fallout` steps would re-run the
-      # dependency graph (double-compile), so we keep it a single invocation.
-      # If Test fails, the job stops here and nothing is published.
-      - name: 'Run: Test + Pack'
-        run: dotnet fallout Test Pack
-      - name: 'Push: all *.nupkg to GitHub Packages (preview)'
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          packages=(output/packages/*.nupkg)
-          if [ ${#packages[@]} -eq 0 ]; then
-            echo "::error::No packages found — nothing to publish to the preview channel."
-            exit 1
-          fi
-          for pkg in "${packages[@]}"; do
-            echo "Pushing $pkg to GitHub Packages (preview)..."
-            dotnet nuget push "$pkg" \
-              --source "https://nuget.pkg.github.com/ChrisonSimtian/index.json" \
-              --api-key "${{ secrets.GITHUB_TOKEN }}" \
-              --skip-duplicate
-          done
+      # Test + Pack + push preview → GitHub Packages, all through our own framework (#333) —
+      # dogfooding `dotnet fallout Publish` instead of a hand-rolled `dotnet nuget push`.
+      # `Publish` depends on Test + Pack, so NUKE runs Restore → Compile → Test → Pack →
+      # Publish as discrete internal stages and fails at the breaking stage; if Test fails
+      # the job stops before any push. Which packages go where (Fallout.* + Nuke.* → GitHub
+      # Packages) is decided by Build.cs IPublish.PublishTargets, not here.
+      - name: 'Publish: preview → GitHub Packages'
+        run: dotnet fallout Publish --publish-to github-packages
+        env:
+          GitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -127,30 +127,40 @@ partial class Build
 
     [Parameter] [Secret] readonly string NuGetApiKey;
 
-    // Publishing to nuget.org now that the Fallout.* rename has landed (#54).
-    // Requires NUGET_API_KEY in repo secrets — see release.yml.
-    string IPublish.NuGetSource => "https://api.nuget.org/v3/index.json";
-    string IPublish.NuGetApiKey => NuGetApiKey;
+    // Two publish channels (FALLOUT001 — see IPublish.PublishTargets). Routing replaces the
+    // old single-feed push + the hand-rolled `dotnet nuget push` in the workflows (#333):
+    //   - github-packages: EVERY package, incl. the Nuke.* shims — that ID is owned by the
+    //     original NUKE maintainer (#47), so the shims only ever go here. Keyed by the GitHub token.
+    //   - nuget.org: Fallout.* ONLY, never the Nuke.* shims. Keyed by NUGET_API_KEY.
+    // Select per run from CI with `dotnet fallout Publish --publish-to <name>`. PublishTarget.SkipDuplicate
+    // (default true) keeps re-runs idempotent if a version already exists on a feed.
+#pragma warning disable FALLOUT001 // opting our own build into the experimental multi-channel publish surface
+    IEnumerable<PublishTarget> IPublish.PublishTargets => new[]
+    {
+        new PublishTarget
+        {
+            Name = "github-packages",
+            Source = "https://nuget.pkg.github.com/ChrisonSimtian/index.json",
+            ApiKey = From<ICreateGitHubRelease>().GitHubToken,
+        },
+        new PublishTarget
+        {
+            Name = "nuget.org",
+            Source = "https://api.nuget.org/v3/index.json",
+            ApiKey = NuGetApiKey,
+            IncludePackages = new[] { "Fallout.*" },
+            ExcludePackages = new[] { "Nuke.*" },
+        },
+    };
+#pragma warning restore FALLOUT001
 
+    // The workflows now gate which channel publishes (via --publish-to); no on-branch
+    // requirement here. Missing keys fail per-target inside Publish, so a stray local
+    // `dotnet fallout Publish` is safe (no key → clear error, no push).
     Target IPublish.Publish => _ => _
         .Inherit<IPublish>()
         .Consumes(From<IPack>().Pack)
-        .Requires(() => GitRepository.IsOnMainBranch() && Host is GitHubActions && GitHubActions.Workflow == ReleaseWorkflow)
         .WhenSkipped(DependencyBehavior.Execute);
-
-    // Filter `Nuke.*` shim packages out of the nuget.org push — that ID is owned by
-    // the original NUKE maintainer. The shims still build and pack as artifacts; they
-    // are pushed to GitHub Packages by a follow-up step in .github/workflows/release.yml
-    // (#47).
-    IEnumerable<AbsolutePath> IPublish.PushPackageFiles
-        => From<IPack>().PackagesDirectory.GlobFiles("*.nupkg")
-            .Where(x => !x.NameWithoutExtension.StartsWith("Nuke.", StringComparison.OrdinalIgnoreCase));
-
-    // `--skip-duplicate` makes nuget push idempotent: if a version is already on the feed,
-    // skip it instead of erroring. Lets us rerun release.yml safely when a single package
-    // fails mid-batch without nuking the whole pipeline on retry.
-    Configure<DotNetNuGetPushSettings> IPublish.PushSettings => _ => _
-        .EnableSkipDuplicate();
 
     IEnumerable<AbsolutePath> NuGetPackageFiles
         => From<IPack>().PackagesDirectory.GlobFiles("*.nupkg");

--- a/docs/experimental-apis.md
+++ b/docs/experimental-apis.md
@@ -48,7 +48,7 @@ Status values: **Experimental** (live, opt-in), **Promoted** (attribute removed,
 
 | ID | Surface | Introduced | Status | Notes |
 |----|---------|------------|--------|-------|
-| _none allocated yet_ | — | — | — | First experimental API to land claims `FALLOUT001`. |
+| `FALLOUT001` | `Fallout.Components.IPublish.PublishTargets` / `.PublishTo` (multi-channel publishing) | 2026.1 | Experimental | Fan a single `Pack` output across multiple feeds with per-feed package-ID routing (`PublishTarget`). Shape may change while the CD model firms up (epic #332). Promote by deleting the attribute once `ReleaseChannel`/`DeploymentTarget` (#334) settle. |
 
 <!--
 Allocation example (do not uncomment unless a real API is marked):

--- a/fallout.slnx
+++ b/fallout.slnx
@@ -36,6 +36,7 @@
   <Project Path="src\Fallout.Utilities\Fallout.Utilities.csproj" />
   <Project Path="tests\Fallout.Build.Tests\Fallout.Build.Tests.csproj" />
   <Project Path="tests\Fallout.Common.Tests\Fallout.Common.Tests.csproj" />
+  <Project Path="tests\Fallout.Components.Tests\Fallout.Components.Tests.csproj" />
   <Project Path="tests\Fallout.Core.Tests\Fallout.Core.Tests.csproj" />
   <Project Path="tests\Fallout.Cli.Tests\Fallout.Cli.Tests.csproj" />
   <Project Path="tests\Fallout.Migrate.Tests\Fallout.Migrate.Tests.csproj" />

--- a/src/Fallout.Components/IPublish.cs
+++ b/src/Fallout.Components/IPublish.cs
@@ -1,10 +1,14 @@
-﻿using System;
+#nullable enable
+using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Fallout.Common;
 using Fallout.Common.IO;
 using Fallout.Common.Tooling;
 using Fallout.Common.Tools.DotNet;
+using Fallout.Common.Utilities;
+using Fallout.Common.Utilities.Collections;
 using static Fallout.Common.Tools.DotNet.DotNetTasks;
 
 namespace Fallout.Components;
@@ -14,31 +18,74 @@ public interface IPublish : IPack, ITest
     [Parameter] string NuGetSource => TryGetValue(() => NuGetSource) ?? "https://api.nuget.org/v3/index.json";
     [Parameter] [Secret] string NuGetApiKey => TryGetValue(() => NuGetApiKey);
 
-    Target Publish => _ => _
-        .DependsOn(Test, Pack)
-        .Requires(() => NuGetApiKey)
-        // .Requires(() => GitHasCleanWorkingCopy())
-        .Executes(() =>
-        {
-            DotNetNuGetPush(_ => _
-                    .Apply(PushSettingsBase)
-                    .Apply(PushSettings)
-                    .CombineWith(PushPackageFiles, (_, v) => _
-                        .SetTargetPath(v))
-                    .Apply(PackagePushSettings),
-                PushDegreeOfParallelism,
-                PushCompleteOnFailure);
-        });
+    /// <summary>
+    /// The channels this build publishes to (<c>FALLOUT001</c>). Override to fan a single
+    /// <c>Pack</c> output across multiple feeds with per-feed package routing (e.g. GitHub
+    /// Packages for everything, nuget.org for <c>Fallout.*</c> only). The default reproduces
+    /// the legacy single-feed push from <see cref="NuGetSource"/> / <see cref="NuGetApiKey"/>.
+    /// </summary>
+    [Experimental("FALLOUT001")]
+    IEnumerable<PublishTarget> PublishTargets =>
+        new[] { new PublishTarget { Name = "default", Source = NuGetSource, ApiKey = NuGetApiKey } };
 
-    sealed Configure<DotNetNuGetPushSettings> PushSettingsBase => _ => _
-        .SetSource(NuGetSource)
-        .SetApiKey(NuGetApiKey);
+    /// <summary>
+    /// Names of the configured <see cref="PublishTargets"/> to push to this run (<c>FALLOUT001</c>).
+    /// Empty selects all. Wire from the CLI as <c>--publish-to github-packages nuget.org</c>.
+    /// </summary>
+    [Parameter("Publish only to these named targets (default: all configured PublishTargets).")]
+    [Experimental("FALLOUT001")]
+    string[] PublishTo => TryGetValue(() => PublishTo) ?? Array.Empty<string>();
 
+    /// <summary>Extra per-push configuration applied to every target's <c>dotnet nuget push</c>.</summary>
     Configure<DotNetNuGetPushSettings> PushSettings => _ => _;
-    Configure<DotNetNuGetPushSettings> PackagePushSettings => _ => _;
 
+    /// <summary>Candidate package set routed across the selected targets. Defaults to every packed <c>*.nupkg</c>.</summary>
     IEnumerable<AbsolutePath> PushPackageFiles => PackagesDirectory.GlobFiles("*.nupkg");
 
     bool PushCompleteOnFailure => true;
     int PushDegreeOfParallelism => 5;
+
+    Target Publish => _ => _
+        .DependsOn(Test, Pack)
+        .Executes(() =>
+        {
+#pragma warning disable FALLOUT001 // configuring the experimental multi-channel surface is the point of this target
+            var configured = PublishTargets.ToList();
+            var selection = PublishTo;
+#pragma warning restore FALLOUT001
+
+            var targets = selection.Length == 0
+                ? configured
+                : configured.Where(x => selection.Contains(x.Name, StringComparer.OrdinalIgnoreCase)).ToList();
+
+            Assert.True(targets.Count > 0,
+                selection.Length == 0
+                    ? "No publish targets are configured — override IPublish.PublishTargets."
+                    : $"--publish-to [{selection.JoinComma()}] matched none of the configured targets [{configured.Select(x => x.Name).JoinComma()}].");
+
+            var candidates = PushPackageFiles.ToList();
+
+            foreach (var target in targets)
+            {
+                Assert.True(!target.ApiKey.IsNullOrWhiteSpace(), $"Publish target '{target.Name}' has no API key.");
+
+                var routed = candidates.Where(x => target.Accepts(x.NameWithoutExtension)).ToList();
+                if (routed.Count == 0)
+                {
+                    Serilog.Log.Warning("Publish target {Target}: no packaged files matched its routing rules — skipping.", target.Name);
+                    continue;
+                }
+
+                Serilog.Log.Information("Publish target {Target}: pushing {Count} package(s) → {Source}.", target.Name, routed.Count, target.Source);
+                DotNetNuGetPush(_ => _
+                        .SetSource(target.Source)
+                        .SetApiKey(target.ApiKey!)
+                        .When(target.SkipDuplicate, _ => _.EnableSkipDuplicate())
+                        .Apply(PushSettings)
+                        .CombineWith(routed, (_, v) => _
+                            .SetTargetPath(v)),
+                    PushDegreeOfParallelism,
+                    PushCompleteOnFailure);
+            }
+        });
 }

--- a/src/Fallout.Components/IPublish.cs
+++ b/src/Fallout.Components/IPublish.cs
@@ -39,6 +39,18 @@ public interface IPublish : IPack, ITest
     /// <summary>Extra per-push configuration applied to every target's <c>dotnet nuget push</c>.</summary>
     Configure<DotNetNuGetPushSettings> PushSettings => _ => _;
 
+    /// <summary>Per-package push configuration applied (with <see cref="PushSettings"/>) to every target.</summary>
+    Configure<DotNetNuGetPushSettings> PackagePushSettings => _ => _;
+
+    /// <summary>
+    /// Legacy single-feed base settings (source + key from <see cref="NuGetSource"/>/<see cref="NuGetApiKey"/>).
+    /// Retained for back-compat; the multi-channel <see cref="Publish"/> path sets source/key per
+    /// <see cref="PublishTarget"/> instead, so it does not apply this.
+    /// </summary>
+    sealed Configure<DotNetNuGetPushSettings> PushSettingsBase => _ => _
+        .SetSource(NuGetSource)
+        .SetApiKey(NuGetApiKey);
+
     /// <summary>Candidate package set routed across the selected targets. Defaults to every packed <c>*.nupkg</c>.</summary>
     IEnumerable<AbsolutePath> PushPackageFiles => PackagesDirectory.GlobFiles("*.nupkg");
 
@@ -83,7 +95,8 @@ public interface IPublish : IPack, ITest
                         .When(target.SkipDuplicate, _ => _.EnableSkipDuplicate())
                         .Apply(PushSettings)
                         .CombineWith(routed, (_, v) => _
-                            .SetTargetPath(v)),
+                            .SetTargetPath(v))
+                        .Apply(PackagePushSettings),
                     PushDegreeOfParallelism,
                     PushCompleteOnFailure);
             }

--- a/src/Fallout.Components/PublishTarget.cs
+++ b/src/Fallout.Components/PublishTarget.cs
@@ -14,7 +14,10 @@ namespace Fallout.Components;
 /// everything, nuget.org for <c>Fallout.*</c> only). Part of the experimental
 /// multi-channel publishing surface (<c>FALLOUT001</c>).
 /// </summary>
-public sealed record PublishTarget
+// A sealed class (not a record) so the transition-shim generator skips it: it can't
+// derive a Nuke.* shim from a sealed type (CS0509), and this is a new type with no
+// pre-rename consumers to bridge. We don't rely on record value-equality / `with`.
+public sealed class PublishTarget
 {
     /// <summary>Logical name, used by the <c>--publish-to</c> selector (e.g. <c>github-packages</c>, <c>nuget.org</c>).</summary>
     public required string Name { get; init; }

--- a/src/Fallout.Components/PublishTarget.cs
+++ b/src/Fallout.Components/PublishTarget.cs
@@ -1,0 +1,80 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Fallout.Components;
+
+/// <summary>
+/// A routable publish destination: a package feed plus the rules deciding which
+/// packages go to it. Consumed by <see cref="IPublish"/> to fan a single
+/// <c>Pack</c> output out across multiple channels (e.g. GitHub Packages for
+/// everything, nuget.org for <c>Fallout.*</c> only). Part of the experimental
+/// multi-channel publishing surface (<c>FALLOUT001</c>).
+/// </summary>
+public sealed record PublishTarget
+{
+    /// <summary>Logical name, used by the <c>--publish-to</c> selector (e.g. <c>github-packages</c>, <c>nuget.org</c>).</summary>
+    public required string Name { get; init; }
+
+    /// <summary>NuGet feed URL packages are pushed to.</summary>
+    public required string Source { get; init; }
+
+    /// <summary>API key for the feed; <see langword="null"/> when the source needs none.</summary>
+    public string? ApiKey { get; init; }
+
+    /// <summary>Package-name globs (<c>*</c>, <c>?</c>) this target accepts. Default: everything.</summary>
+    public IReadOnlyList<string> IncludePackages { get; init; } = new[] { "*" };
+
+    /// <summary>Package-name globs this target rejects. Exclusion wins over inclusion.</summary>
+    public IReadOnlyList<string> ExcludePackages { get; init; } = Array.Empty<string>();
+
+    /// <summary>Pass <c>--skip-duplicate</c> so re-runs are idempotent on already-published versions.</summary>
+    public bool SkipDuplicate { get; init; } = true;
+
+    /// <summary>
+    /// Whether this target accepts the given package name. <paramref name="packageName"/> is matched
+    /// against the include/exclude globs; callers pass the package file name without its
+    /// <c>.nupkg</c> extension, so a pattern like <c>Fallout.*</c> matches <c>Fallout.Common.2026.1.0</c>.
+    /// </summary>
+    public bool Accepts(string packageName)
+        => PublishPackageRouter.MatchesAny(IncludePackages, packageName)
+           && !PublishPackageRouter.MatchesAny(ExcludePackages, packageName);
+}
+
+/// <summary>
+/// Pure routing logic for <see cref="PublishTarget"/> — kept free of any tooling
+/// or filesystem dependency so it is unit-testable in isolation.
+/// </summary>
+public static class PublishPackageRouter
+{
+    /// <summary>Returns the package names accepted by <paramref name="target"/> from the candidate set.</summary>
+    public static IEnumerable<string> Route(PublishTarget target, IEnumerable<string> packageNames)
+        => packageNames.Where(target.Accepts);
+
+    /// <summary>True when <paramref name="value"/> matches at least one glob in <paramref name="patterns"/> (case-insensitive).</summary>
+    public static bool MatchesAny(IEnumerable<string> patterns, string value)
+        => patterns.Any(pattern => GlobMatches(pattern, value));
+
+    /// <summary>Case-insensitive glob match supporting <c>*</c> (any run) and <c>?</c> (one char).</summary>
+    public static bool GlobMatches(string pattern, string value)
+        => Regex.IsMatch(value, GlobToRegex(pattern), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    static string GlobToRegex(string pattern)
+    {
+        var builder = new StringBuilder("^");
+        foreach (var c in pattern)
+        {
+            builder.Append(c switch
+            {
+                '*' => ".*",
+                '?' => ".",
+                _ => Regex.Escape(c.ToString())
+            });
+        }
+
+        return builder.Append('$').ToString();
+    }
+}

--- a/tests/Fallout.Components.Tests/Fallout.Components.Tests.csproj
+++ b/tests/Fallout.Components.Tests/Fallout.Components.Tests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Fallout.Components\Fallout.Components.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Fallout.Components.Tests/PublishPackageRouterTests.cs
+++ b/tests/Fallout.Components.Tests/PublishPackageRouterTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.Components.Tests;
+
+public class PublishPackageRouterTests
+{
+    [Theory]
+    [InlineData("Fallout.*", "Fallout.Common.2026.1.0", true)]
+    [InlineData("Fallout.*", "Nuke.Common.2026.1.0", false)]
+    [InlineData("*", "anything-at-all", true)]
+    [InlineData("Nuke.?ommon*", "Nuke.Common.1.0.0", true)]
+    [InlineData("Nuke.?ommon*", "Nuke.Xommon.1.0.0", true)]
+    [InlineData("Nuke.?", "Nuke.Common", false)]
+    public void GlobMatches_handles_star_and_question(string pattern, string value, bool expected)
+        => PublishPackageRouter.GlobMatches(pattern, value).Should().Be(expected);
+
+    [Fact]
+    public void GlobMatches_is_case_insensitive()
+        => PublishPackageRouter.GlobMatches("fallout.*", "Fallout.Common").Should().BeTrue();
+
+    [Fact]
+    public void Accepts_includes_then_applies_excludes()
+    {
+        // The real nuget.org routing: Fallout.* only, never the Nuke.* shims.
+        var nugetOrg = new PublishTarget
+        {
+            Name = "nuget.org",
+            Source = "https://api.nuget.org/v3/index.json",
+            IncludePackages = new[] { "Fallout.*" },
+            ExcludePackages = new[] { "Nuke.*" },
+        };
+
+        nugetOrg.Accepts("Fallout.Common.2026.1.0").Should().BeTrue();
+        nugetOrg.Accepts("Nuke.Common.2026.1.0").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Accepts_exclusion_wins_over_inclusion()
+    {
+        var target = new PublishTarget
+        {
+            Name = "t",
+            Source = "s",
+            IncludePackages = new[] { "*" },
+            ExcludePackages = new[] { "Nuke.*" },
+        };
+
+        target.Accepts("Fallout.Common").Should().BeTrue();
+        target.Accepts("Nuke.Common").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Default_target_accepts_everything()
+    {
+        // The real github-packages routing: everything, including the Nuke.* shims.
+        var ghPackages = new PublishTarget { Name = "github-packages", Source = "s" };
+        var all = new[] { "Fallout.Common.1.0.0", "Nuke.Common.1.0.0" };
+
+        PublishPackageRouter.Route(ghPackages, all).Should().BeEquivalentTo(all);
+    }
+}

--- a/tests/Fallout.SourceGenerators.Tests/StronglyTypedSolutionGeneratorTest.Test#Solution.g.verified.cs
+++ b/tests/Fallout.SourceGenerators.Tests/StronglyTypedSolutionGeneratorTest.Test#Solution.g.verified.cs
@@ -17,6 +17,7 @@ internal class Solution(SolutionModel model, AbsolutePath path) : Fallout.Soluti
     public Fallout.Solutions.Project Fallout_Common => this.GetProject("Fallout.Common");
     public Fallout.Solutions.Project Fallout_Common_Tests => this.GetProject("Fallout.Common.Tests");
     public Fallout.Solutions.Project Fallout_Components => this.GetProject("Fallout.Components");
+    public Fallout.Solutions.Project Fallout_Components_Tests => this.GetProject("Fallout.Components.Tests");
     public Fallout.Solutions.Project Fallout_Consumer_Local => this.GetProject("Fallout.Consumer.Local");
     public Fallout.Solutions.Project Fallout_Consumer_NuGet => this.GetProject("Fallout.Consumer.NuGet");
     public Fallout.Solutions.Project Fallout_Core => this.GetProject("Fallout.Core");


### PR DESCRIPTION
Implements the framework half of [epic #332](https://github.com/ChrisonSimtian/Fallout/issues/332)'s first step (#333), on the `experimental` lane (it touches the shipped `Fallout.Components` public surface, gated behind `[Experimental("FALLOUT001")]`).

## What

- **`PublishTarget` + `PublishPackageRouter`** (`Fallout.Components`) — a routable feed (name, source, key, include/exclude package-name globs, skip-duplicate) and pure, dependency-free glob routing. **10 unit tests** in the new `tests/Fallout.Components.Tests`.
- **`IPublish` gains `[Experimental("FALLOUT001")]` `PublishTargets` + `--publish-to`** — `Publish` fans one `Pack` output across the selected feeds via the router. Existing single-feed members (`NuGetSource`/`NuGetApiKey`/`PushSettings`/`PackagePushSettings`/`PushSettingsBase`) retained → the change is **additive**, not breaking.
- **`Build.cs` wires the two real channels:** `github-packages` (every package incl. `Nuke.*`, GitHub-token keyed) and `nuget.org` (`Fallout.*` only, never `Nuke.*`, `NUGET_API_KEY` keyed).
- **Dogfood:** `experimental.yml` / `preview.yml` now `dotnet fallout Publish --publish-to github-packages` instead of hand-rolled `dotnet nuget push`. One invocation = Test → Pack → Publish (NUKE stages); nothing publishes if tests fail.
- `FALLOUT001` registered in `docs/experimental-apis.md`.

## Verified
- `Fallout.Components` + `build/_build` compile **0 errors**; router tests **10/10**; all workflow YAML valid; no generated-workflow drift.

## Scope / deferred
- **release.yml** publish jobs still use raw `dotnet nuget push` — they're coupled to the cross-job artifact handoff + the `nuget-org` approval gate, so dogfooding them is folded into **#336** (generator emits CD pipelines).
- Branch hygiene: built on `experimental` after forward-porting `main` (#338). Worked in an isolated worktree to stay clear of the parallel `spike/ci-ports-gha` work; the two land separately and reconcile in a later session.

Substantially closes #333 (release.yml lane → #336).

🤖 Generated with [Claude Code](https://claude.com/claude-code)