### PR TITLE
fix(ci): publish token env var GitHubToken → GITHUB_TOKEN (#333)

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -73,4 +73,4 @@ jobs:
       - name: 'Publish: alpha → GitHub Packages'
         run: dotnet fallout Publish --publish-to github-packages
         env:
-          GitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -73,4 +73,4 @@ jobs:
       - name: 'Publish: preview → GitHub Packages'
         run: dotnet fallout Publish --publish-to github-packages
         env:
-          GitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The dogfood `dotnet fallout Publish` run on `experimental` failed: **'Publish target github-packages has no API key'**.

`Build.cs`'s `github-packages` target keys off `From<ICreateGitHubRelease>().GitHubToken` → `GitHubActions.Token`, which reads **`GITHUB_TOKEN`** (`EnvironmentInfo.GetVariable("GITHUB_TOKEN")`). The lane workflows set `GitHubToken` — wrong name (and `ICreateGitHubRelease` is `[ParameterPrefix]`-ed, so the unprefixed param wouldn't bind regardless). Fixed in `experimental.yml` + `preview.yml`.

Caught by letting the post-merge experimental publish run for real — the validation paid off. Follows #339.