### PR TITLE
Update global tool name in install instructions

### DIFF
--- a/docs/01-getting-started/01-installation.md
+++ b/docs/01-getting-started/01-installation.md
@@ -6,11 +6,11 @@ Before you can set up a build project, you need to install Fallout's dedicated [
 
 ```powershell
 # terminal-command
-dotnet tool install Fallout.Cli --global
+dotnet tool install Fallout.GlobalTools --global
 ```
 
 :::tip
-For repos that already have a `.config/dotnet-tools.json` manifest with `Fallout.Cli` pinned (this is what `fallout :setup` creates), you can skip the global install and run `dotnet tool restore` instead — the local manifest version then takes precedence.
+For repos that already have a `.config/dotnet-tools.json` manifest with `Fallout.GlobalTools` pinned (this is what `fallout :setup` creates), you can skip the global install and run `dotnet tool restore` instead — the local manifest version then takes precedence.
 :::
 
 From now on, you can use the global tool to:

--- a/docs/01-getting-started/02-setup.md
+++ b/docs/01-getting-started/02-setup.md
@@ -34,7 +34,7 @@ The setup will create a number of files in your repository and – if you've cho
 ```bash
 <root-directory>
 ├── .config
-│   └── dotnet-tools.json           # Local tool manifest pinning Fallout.Cli
+│   └── dotnet-tools.json           # Local tool manifest pinning Fallout.GlobalTools
 │
 ├── .fallout                        # Root directory marker
 │   ├── build.schema.json           # Build schema file
@@ -51,7 +51,7 @@ The setup will create a number of files in your repository and – if you've cho
 ```
 
 :::note
-The two thin bootstrappers (`build.ps1` and `build.sh`) provision the .NET SDK locally when it's not on `PATH`, then run `dotnet tool restore` and `dotnet fallout "$@"`. They're optional once you have a global `dotnet` install and have run `dotnet tool restore` at least once — but they're the safest way to run the build in CI and on a freshly-cloned machine. The `.config/dotnet-tools.json` manifest pins the exact `Fallout.Cli` version your build expects.
+The two thin bootstrappers (`build.ps1` and `build.sh`) provision the .NET SDK locally when it's not on `PATH`, then run `dotnet tool restore` and `dotnet fallout "$@"`. They're optional once you have a global `dotnet` install and have run `dotnet tool restore` at least once — but they're the safest way to run the build in CI and on a freshly-cloned machine. The `.config/dotnet-tools.json` manifest pins the exact `Fallout.GlobalTools` version your build expects.
 :::
 
 ## Project Structure
@@ -64,7 +64,7 @@ While you can enjoy writing most build-relevant logic inside your build console 
 ```powershell
 <root-directory>
 ├── .config
-│   └── dotnet-tools.json    # Local tool manifest (Fallout.Cli pin)
+│   └── dotnet-tools.json    # Local tool manifest (Fallout.GlobalTools pin)
 │
 ├── .fallout
 │   ├── parameters.json      # Parameters files


### PR DESCRIPTION
Updates the getting-started installation and setup docs to refer to \Fallout.GlobalTools\ instead of \Fallout.Cli\.