### PR TITLE
docs: fix doc-site links that 404 (repo-root files)

### DIFF
--- a/docs/agents/conventions.md
+++ b/docs/agents/conventions.md
@@ -4,12 +4,12 @@ Three groups: conventions to respect, things never to do, and the tool-wrapper r
 
 ## Conventions worth respecting
 
-- **Centralized package versions** — add new packages to `Directory.Packages.props`, never inline. Adding a *meaningful* library (not a tiny transitive helper)? Add a row to [docs/dependencies.md](../dependencies.md) in the same PR — reviewers will ask.
+- **Centralized package versions** — add new packages to `Directory.Packages.props`, never inline. Adding a *meaningful* library (not a tiny transitive helper)? Add a row to [docs/dependencies.md](https://github.com/Fallout-build/Fallout/blob/main/docs/dependencies.md) in the same PR — reviewers will ask.
 - **Tool wrappers**: copy/paste from neighbours; cover full commands; use `<c>`, `<a>`, `<ul>`/`<ol>`, `<em>`, `<para/>` in `help`; don't write `secret: false` or `default: xxx`. See [Tool wrapper recipe](#tool-wrapper-recipe) below.
 - **Tests next to code, separate folder**: every `Foo` project under `src/` has a sibling `Foo.Tests` project under `tests/`. Mirror the namespace.
 - **No IDE-specific style files committed.** `.editorconfig` and `*.DotSettings` were removed during the takeover — relying on `dotnet format` defaults and review.
 - **Telemetry opt-out is set in test runs** (`FALLOUT_TELEMETRY_OPTOUT=true`). Keep it that way.
-- **No per-file license headers.** The MIT notice lives in [`LICENSE`](../../LICENSE) at the repo root, and NuGet packages declare MIT via `PackageLicenseExpression`. Per-file headers were stripped in v11 (one source of truth + the header URL would have rotted on the repo-org transfer). Vendored third-party code keeps its own copyright headers — don't touch those (e.g. files under `src/Persistence/Fallout.Persistence.Solution/` retain Microsoft's MIT notice).
+- **No per-file license headers.** The MIT notice lives in [`LICENSE`](https://github.com/Fallout-build/Fallout/blob/main/LICENSE) at the repo root, and NuGet packages declare MIT via `PackageLicenseExpression`. Per-file headers were stripped in v11 (one source of truth + the header URL would have rotted on the repo-org transfer). Vendored third-party code keeps its own copyright headers — don't touch those (e.g. files under `src/Persistence/Fallout.Persistence.Solution/` retain Microsoft's MIT notice).
 - **`[Experimental]` for opt-in unstable public APIs.** Not-yet-stable public surface is marked with `[Experimental("FALLOUT0xx")]` rather than held back or shipped silently. See [the `[Experimental]` convention](#experimental-for-opt-in-unstable-apis) below and the [diagnostic-ID registry](../experimental-apis.md).
 
 ## Writing style for issues, PRs, and commits

--- a/docs/agents/release-and-versioning.md
+++ b/docs/agents/release-and-versioning.md
@@ -38,7 +38,7 @@ Apply by mirroring `main`'s protection JSON to the new branch via the GitHub API
 
 **Validation workflows.** `ubuntu-latest` runs on every PR targeting `experimental`, `main`, `release/*`, or `support/*` (with `paths-ignore` for `docs/**`, `.assets/**`, `**/*.md`). `windows-latest` and `macos-latest` run on push to those branches — they're post-merge / release validation, not PR gates. This is a deliberate cost trade-off. (These three workflows are **generated** from `build/Build.CI.GitHubActions.cs` — change the branch lists in the `MainBranch`/`ExperimentalBranch`/`*BranchPattern` constants there and regenerate, don't hand-edit the `.yml`.)
 
-**Merging.** Both squash and rebase merge are enabled (plain merge commits are disabled by repo setting and would fail linear-history protection anyway). Squash is the default; rebase is opt-in for curated commit sequences. See [CONTRIBUTING.md → Merging](../../CONTRIBUTING.md#merging) for the convention.
+**Merging.** Both squash and rebase merge are enabled (plain merge commits are disabled by repo setting and would fail linear-history protection anyway). Squash is the default; rebase is opt-in for curated commit sequences. See [CONTRIBUTING.md → Merging](https://github.com/Fallout-build/Fallout/blob/main/CONTRIBUTING.md#merging) for the convention.
 
 ## Versioning
 
@@ -52,7 +52,7 @@ GitVersion is still installed as a transitional helper for `MajorMinorPatchVersi
 
 ## Versioning policy
 
-This project ships calendar versions that are valid [Semantic Versioning](https://semver.org/spec/v2.0.0.html) per [CHANGELOG.md](../../CHANGELOG.md). The rule is: **breaking changes are batched to the yearly major cut.**
+This project ships calendar versions that are valid [Semantic Versioning](https://semver.org/spec/v2.0.0.html) per [CHANGELOG.md](https://github.com/Fallout-build/Fallout/blob/main/CHANGELOG.md). The rule is: **breaking changes are batched to the yearly major cut.**
 
 - A breaking change may land on **`experimental` only**, is held for the next yearly major (it does **not** bump `version.json`'s major mid-year), and is recorded in `CHANGELOG.md` under the next-major `[Unreleased]` heading with a migration path.
 - **Neither `main` nor a `release/YYYY` production line takes a breaking change** mid-year — both are strictly non-breaking (minor = features, patch = fixes). A PR that breaks may target `experimental` only.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,7 @@ Every project under `src/` has a sibling under `tests/` (e.g. `src/Fallout.Commo
 - **Central package versions.** All `PackageReference` versions live in `Directory.Packages.props`. Never inline `Version=` on a `PackageReference` — the build will error.
 - **Smart `PackageReference`.** `Directory.Build.targets` rewrites `PackageReference`s that match a project in the current solution into `ProjectReference`s. Lets us reference our own packages by ID across the dev/release boundary.
 - **`AssemblyInfo.cs` at root.** Shared `InternalsVisibleTo` declarations. Included automatically via `Directory.Build.props`.
-- **No per-file license headers.** The MIT notice lives in [`LICENSE`](../LICENSE) at the repo root. NuGet packages declare MIT via `PackageLicenseExpression` in `Directory.Build.props`. Vendored Microsoft code under `src/Persistence/Fallout.Persistence.Solution/` keeps its own headers — leave those alone.
+- **No per-file license headers.** The MIT notice lives in [`LICENSE`](https://github.com/Fallout-build/Fallout/blob/main/LICENSE) at the repo root. NuGet packages declare MIT via `PackageLicenseExpression` in `Directory.Build.props`. Vendored Microsoft code under `src/Persistence/Fallout.Persistence.Solution/` keeps its own headers — leave those alone.
 
 ## CI layout
 

--- a/docs/branching-and-release.md
+++ b/docs/branching-and-release.md
@@ -2,7 +2,7 @@
 
 Maintainer reference for how Fallout branches, ships releases, hotfixes older lines, and uses GitHub Environments to gate publishes. Model defined by [ADR-0004](adr/0004-calendar-versioning-and-dual-pace-channels.md) (calendar versioning + dual-pace channels), amending [ADR-0001](adr/0001-release-branch-model.md) / [milestone #13](https://github.com/ChrisonSimtian/Fallout/milestone/13) / [RFC #267](https://github.com/ChrisonSimtian/Fallout/issues/267).
 
-> **Audience.** Repository maintainers cutting releases or hotfixing older lines. Contributors filing PRs against `main` don't need to read this — see [CONTRIBUTING.md](../CONTRIBUTING.md) instead. AI coding tools should read both this file and [docs/agents/release-and-versioning.md](agents/release-and-versioning.md).
+> **Audience.** Repository maintainers cutting releases or hotfixing older lines. Contributors filing PRs against `main` don't need to read this — see [CONTRIBUTING.md](https://github.com/Fallout-build/Fallout/blob/main/CONTRIBUTING.md) instead. AI coding tools should read both this file and [docs/agents/release-and-versioning.md](agents/release-and-versioning.md).
 
 ## Branches at a glance
 
@@ -215,4 +215,4 @@ A repository ruleset blocks creation/deletion/update of tags matching `v*` for n
 - [docs/adr/0001-release-branch-model.md](adr/0001-release-branch-model.md) — the release-branch + multi-channel CD model (versioning amended by 0004).
 - [milestone #13](https://github.com/ChrisonSimtian/Fallout/milestone/13) — full work-breakdown of how this shape was implemented.
 - [RFC #267](https://github.com/ChrisonSimtian/Fallout/issues/267) — original design discussion.
-- [CONTRIBUTING.md](../CONTRIBUTING.md) — contributor-facing flow.
+- [CONTRIBUTING.md](https://github.com/Fallout-build/Fallout/blob/main/CONTRIBUTING.md) — contributor-facing flow.


### PR DESCRIPTION
While building the docs site locally, the broken-link checker flagged **6 links across 4 files** that point at repo files which aren't published as doc pages — `LICENSE`, `CONTRIBUTING.md`, `CHANGELOG.md`, and the build-excluded `dependencies.md`. Relative links to these render fine on GitHub but **404 on docs.fallout.build**.

Fix: point them at absolute `https://github.com/Fallout-build/Fallout/blob/main/...` URLs, which resolve correctly in **both** contexts (docs site + GitHub markdown).

## Files
- `docs/agents/conventions.md` — `dependencies.md`, `LICENSE`
- `docs/agents/release-and-versioning.md` — `CONTRIBUTING.md#merging`, `CHANGELOG.md`
- `docs/architecture.md` — `LICENSE`
- `docs/branching-and-release.md` — `CONTRIBUTING.md` (×2)

Verified: rebuilt the docs site against these edits → **0 broken-link warnings** (was 6), build green.

Non-breaking, docs-only. `target/2026`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)