### PR TITLE
chore: publish the global tool as Fallout.GlobalTools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Fallout welcomes contributions. As a community, we want to help each other, prov
 - Branch from your PR's base (`main` for deliberate non-breaking work, `experimental` for fast/breaking work). Name your branch `feature/<slug>`, `bugfix/<slug>`, or `chore/<slug>`.
 - Make sure your employer allows the contribution.
 - Read [AGENTS.md](AGENTS.md) for the codebase conventions — package versions go in `Directory.Packages.props`, tests live next to code, no per-file license headers (the `LICENSE` file at the root is the single source of truth). (AGENTS.md is the canonical brief for both human contributors and AI tools; `CLAUDE.md` and `.github/copilot-instructions.md` point to it.)
-- The bootstrappers are now thin: `./build.ps1` / `./build.sh` provision .NET if needed, then run `dotnet tool restore` + `dotnet fallout "$@"`. The `Fallout.Cli` version is pinned in `.config/dotnet-tools.json`.
+- The bootstrappers are now thin: `./build.ps1` / `./build.sh` provision .NET if needed, then run `dotnet tool restore` + `dotnet fallout "$@"`. The `Fallout.GlobalTools` version is pinned in `.config/dotnet-tools.json`.
 - Run `./build.ps1 Test` (or `./build.sh Test`, or directly `dotnet fallout Test` once your tools are restored) locally first.
 
 ### When writing the PR

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ fallout-migrate
 ## Install
 
 ```sh
-dotnet tool install -g Fallout.Cli
+dotnet tool install -g Fallout.GlobalTools
 ```
 
 The CLI installs as `fallout`. Verify with `fallout --help`.
 
 > [!NOTE]
-> **Upgrading from `Fallout.GlobalTool`?** The package was renamed to `Fallout.Cli` for install ergonomics — same `fallout` command, friendlier ID. Uninstall the old one first so you don't end up with two tools claiming the same command:
+> **Upgrading from `Fallout.GlobalTool`?** The dotnet-tool package is now `Fallout.GlobalTools` — same `fallout` command. Uninstall the old one first so you don't end up with two tools claiming the same command:
 >
 > ```sh
 > dotnet tool uninstall -g Fallout.GlobalTool

--- a/docs/01-getting-started/03-execution.md
+++ b/docs/01-getting-started/03-execution.md
@@ -34,7 +34,7 @@ fallout [arguments]
 </Tabs>
 
 :::info
-The bootstrappers are thin: they provision the .NET SDK if it isn't already installed, run `dotnet tool restore` (to pin the `Fallout.Cli` version from `.config/dotnet-tools.json`), then forward to `dotnet fallout`. Once `dotnet` is on your `PATH` and tools are restored, `fallout [arguments]` and `./build.sh [arguments]` do the same thing.
+The bootstrappers are thin: they provision the .NET SDK if it isn't already installed, run `dotnet tool restore` (to pin the `Fallout.GlobalTools` version from `.config/dotnet-tools.json`), then forward to `dotnet fallout`. Once `dotnet` is on your `PATH` and tools are restored, `fallout [arguments]` and `./build.sh [arguments]` do the same thing.
 :::
 
 :::info

--- a/docs/05-cicd/github-actions.md
+++ b/docs/05-cicd/github-actions.md
@@ -98,7 +98,7 @@ jobs:
 ```
 
 :::info
-The generated workflow uses `actions/setup-dotnet` to install the .NET SDK on the runner, then `dotnet tool restore` to install the `Fallout.Cli` version pinned in `.config/dotnet-tools.json`, then `dotnet fallout <targets>` to run your build. Your repository needs a `.config/dotnet-tools.json` manifest with `Fallout.Cli` pinned — `fallout :setup` creates one automatically.
+The generated workflow uses `actions/setup-dotnet` to install the .NET SDK on the runner, then `dotnet tool restore` to install the `Fallout.GlobalTools` version pinned in `.config/dotnet-tools.json`, then `dotnet fallout <targets>` to run your build. Your repository needs a `.config/dotnet-tools.json` manifest with `Fallout.GlobalTools` pinned — `fallout :setup` creates one automatically.
 :::
 
 </details>

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -18,7 +18,7 @@ description: Fallout is a C#-first build automation framework for .NET — the h
 
 ```powershell
 # terminal-command
-dotnet tool install Fallout.Cli --global
+dotnet tool install Fallout.GlobalTools --global
 ```
 
 **2. Go to a repository of your choice and set up a build:**
@@ -45,7 +45,7 @@ Get a feeling how your Cake scripts would look like in Fallout.
 
 ```powershell
 # terminal-command
-dotnet tool install Fallout.Cli --global
+dotnet tool install Fallout.GlobalTools --global
 ```
 
 **2. Go to a repository built with Cake.**

--- a/docs/migration/from-globaltool-to-cli.md
+++ b/docs/migration/from-globaltool-to-cli.md
@@ -1,7 +1,14 @@
 ---
 title: Fallout.GlobalTool → Fallout.Cli
 description: Migrating from the renamed Fallout CLI NuGet package. Short guide — the command name didn't change, just the package ID.
+draft: true
 ---
+
+<!-- DRAFT / unpublished. The `Fallout.Cli` package id this guide describes was never
+     released to nuget.org and is being superseded by `Fallout.GlobalTools` before first
+     public release, so there is nobody to migrate. Kept out of the published site until
+     the rename settles; do not publish a Fallout.Cli → Fallout.GlobalTools migration. -->
+
 
 In v11, the dotnet-tool NuGet package id was renamed: **`Fallout.GlobalTool` → `Fallout.Cli`**. The **command name stays `fallout`**, so build scripts and shell invocations don't change. The only thing that moves is the install/restore reference.
 

--- a/docs/rebrand-plan.md
+++ b/docs/rebrand-plan.md
@@ -45,7 +45,7 @@ This is locked by the bridge-package design — `[TypeForwardedTo]` requires the
 | `Nuke.Common.Utilities` (+ `.Collections`, `.Net`) | `Fallout.Common.Utilities` | |
 | `Nuke.Common.ValueInjection` | `Fallout.Common.ValueInjection` | |
 | `Nuke.Components` | `Fallout.Components` | |
-| `Nuke.GlobalTool` (+ `.Rewriting.Cake`) | `Fallout.Cli` | Renamed from `Fallout.GlobalTool` post-rebrand for install ergonomics (`dotnet tool install Fallout.Cli`). Command name stays `fallout`. |
+| `Nuke.GlobalTool` (+ `.Rewriting.Cake`) | `Fallout.Cli` | Project/namespace/assembly is `Fallout.Cli`. The **published package id is `Fallout.GlobalTools`** (`dotnet tool install Fallout.GlobalTools`) — decoupled from the assembly name on purpose. Command name stays `fallout`. |
 | `Nuke.MSBuildTasks` | `Fallout.MSBuildTasks` | |
 | `Nuke.SourceGenerators` | `Fallout.SourceGenerators` | |
 | `Nuke.Utilities.Text.Json` | `Fallout.Utilities.Text.Json` | |

--- a/src/Fallout.Build/Execution/Extensions/UpdateNotificationAttribute.cs
+++ b/src/Fallout.Build/Execution/Extensions/UpdateNotificationAttribute.cs
@@ -35,7 +35,7 @@ internal class UpdateNotificationAttribute : BuildExtensionAttributeBase, IOnBui
             {
                 "--- UPDATE RECOMMENDED FROM 5.1.0 ---",
                 "1. Update your global tool",
-                "   dotnet tool update Fallout.Cli -g",
+                "   dotnet tool update Fallout.GlobalTools -g",
                 "2. Update your build",
                 "   fallout :update",
                 "3. Confirm on update for configuration file and build scripts",

--- a/src/Fallout.Cli/Fallout.Cli.csproj
+++ b/src/Fallout.Cli/Fallout.Cli.csproj
@@ -6,6 +6,9 @@
     <RollForward>LatestMajor</RollForward>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>fallout</ToolCommandName>
+    <!-- Published package id. Decoupled from the assembly/namespace (Fallout.Cli) on purpose:
+         the install name users type is Fallout.GlobalTools; the command stays `fallout`. -->
+    <PackageId>Fallout.GlobalTools</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Fallout.Cli/Program.Setup.cs
+++ b/src/Fallout.Cli/Program.Setup.cs
@@ -210,10 +210,10 @@ partial class Program
                     })),
             platformFamily: PlatformFamily.Windows);
 
-        // .config/dotnet-tools.json pins Fallout.Cli as a local tool so the thin shims
+        // .config/dotnet-tools.json pins Fallout.GlobalTools as a local tool so the thin shims
         // (build.sh / build.ps1) can `dotnet tool restore` and `dotnet fallout` deterministically.
         // Skip if the consumer already has a manifest — they may have other tools pinned and we
-        // don't want to clobber. They can add the `fallout.cli` entry manually.
+        // don't want to clobber. They can add the `fallout.globaltools` entry manually.
         var toolManifest = rootDirectory / ".config" / "dotnet-tools.json";
         if (!toolManifest.FileExists())
         {

--- a/src/Fallout.Cli/templates/dotnet-tools.json
+++ b/src/Fallout.Cli/templates/dotnet-tools.json
@@ -2,7 +2,7 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fallout.cli": {
+    "fallout.globaltools": {
       "version": "_FALLOUT_CLI_VERSION_",
       "commands": [
         "fallout"


### PR DESCRIPTION
Follow-up to Dennis's `cc077a6e` ("docs: update global tool name"), which set the install name to **`Fallout.GlobalTools`** in 2 docs but left the rest of the repo on `Fallout.Cli`.

The root cause: `Fallout.Cli.csproj` had **no `<PackageId>`**, so the package defaulted to the assembly name `Fallout.Cli` — i.e. Dennis's docs and the actual published id disagreed. This change makes them agree on `Fallout.GlobalTools`.

**Not a breaking change:** `Fallout.Cli` was never pushed to nuget.org, so this is a pre-publication rename. Targets `main` / `target/2026`.

## What changed
**Package identity (not the code):**
- `Fallout.Cli.csproj` → `<PackageId>Fallout.GlobalTools</PackageId>`. Assembly/namespace stay `Fallout.Cli`; command stays `fallout`. ✅ Verified `dotnet pack` emits `Fallout.GlobalTools.*.nupkg`.
- `templates/dotnet-tools.json` + `Program.Setup.cs` comment — the manifest `fallout :setup` writes into **user** repos now pins `fallout.globaltools`.
- `UpdateNotificationAttribute` — in-tool update prompt → `dotnet tool update Fallout.GlobalTools -g`.

**Docs (match the install name — point a):**
- README (install + upgrade note), `introduction`, `03-execution`, `05-cicd/github-actions`, `CONTRIBUTING` pin ref, `rebrand-plan` mapping.
- `migration/from-globaltool-to-cli.md` → **`draft: true`** (unpublished — point b). It documents the never-released `→ Fallout.Cli` rename, now superseded; no `Fallout.Cli → Fallout.GlobalTools` migration is published since nobody is on `Fallout.Cli`. ✅ Verified the page is excluded from the built site.

✅ Docs site builds clean; install pages render `Fallout.GlobalTools`, no `Fallout.Cli`.

## Deliberately left (flagging for a maintainer call)
- **`.config/dotnet-tools.json`** — the repo's own dogfood pin (`fallout.cli` 10.3.45). Can't flip to `fallout.globaltools` until a version is actually published under the new id, or `dotnet tool restore` breaks the build.
- **`tools/unlist-*.json`, `CHANGELOG.md` #206 narrative** — records of already-published ids; not rewritten.
- **`architecture` / `repository-layout` / `dependencies` component tables** — these name the internal project (`Fallout.Cli`), which is unchanged. Left as-is; happy to switch them to the package name if you'd prefer consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)