### PR TITLE
Stop CreateGitHubRelease from firing on preview publishes

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -191,7 +191,12 @@ partial class Build
         .TriggeredBy<IPublish>()
         .ProceedAfterFailure()
         .Requires(() => From<ICreateGitHubRelease>().GitHubToken)
-        .OnlyWhenStatic(() => GitRepository.IsOnMainBranch())
+        // Only cut a GitHub Release in the release workflow — never as a side-effect of a
+        // preview/alpha publish. This target is TriggeredBy<IPublish>, and since #333 the
+        // preview/experimental lanes dogfood `Publish`; gating on IsOnMainBranch alone would
+        // fire it on every preview push to main (it doesn't — GitHub Releases are production-
+        // only, and release.yml hand-rolls them via `gh release create`).
+        .OnlyWhenStatic(() => GitHubActions?.Workflow == ReleaseWorkflow)
         .Executes(async () =>
         {
             var client = GitHubTasks.GitHubClient;


### PR DESCRIPTION
## Problem

The post-merge **preview CD on `main`** (from #342) went red. The target summary tells the real story — the feature works, a *different* target failed:

| Target | Result |
|---|---|
| Test | ✅ Passed: 470, Skipped: 7 |
| Pack | ✅ Packages: 22 |
| **Publish** | ✅ **0:07 — pushed 22 packages to GitHub Packages** |
| CreateGitHubRelease | ❌ `NotFoundException: Not Found` |

So `dotnet fallout Publish --publish-to github-packages` (the #333 dogfooding) did exactly its job. The job failed on `CreateGitHubRelease` getting dragged into the run.

## Root cause

`ICreateGitHubRelease.CreateGitHubRelease` is `.TriggeredBy<IPublish>()` and was gated only on `.OnlyWhenStatic(() => GitRepository.IsOnMainBranch())`.

Before #333, `Publish` ran **only in the release workflow** (its old `.Requires` gated on `Workflow == ReleaseWorkflow`). #333 replaced that with `.Requires(Host is GitHubActions)` so the preview/experimental lanes could dogfood `Publish`. Because **preview pushes to `main`**, the `IsOnMainBranch()` gate now passes and a GitHub Release is attempted on every preview push. (Experimental is unaffected — not on `main`, so the `OnlyWhen` skips it.)

GitHub Releases are **production-only** in the channel model. `release.yml` hand-rolls them via `gh release create` (the `publish-github-releases` job) and doesn't invoke this C# target at all.

## Fix

Gate `CreateGitHubRelease` to the release workflow (`GitHubActions?.Workflow == ReleaseWorkflow`) instead of just `IsOnMainBranch()`, so it stays dormant on preview/experimental publishes.

## Validation

`dotnet build build/_build.csproj` clean. Merging this re-triggers the preview lane on `main`, which should now go green (Publish succeeds, CreateGitHubRelease skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)