### PR TITLE
Use different ansi escape code for yellow on gitlab

### DIFF
--- a/src/Fallout.Build/Host.cs
+++ b/src/Fallout.Build/Host.cs
@@ -33,7 +33,9 @@ public partial class Host
         // True-color ANSI for Fallout yellow (#F5C800). Modern terminals
         // (Windows Terminal, VS Code, macOS Terminal.app, GitHub Actions logs)
         // render this directly; older sinks ignore the escape bytes.
-        const string Y = "[38;2;245;200;0m";
+        string Y = Environment.GetEnvironmentVariable("GITLAB_CI") == "true"
+            ? "[93m"
+            : "[38;2;245;200;0m";
         const string D = "[2m";
         const string R = "[0m";
 

--- a/src/Fallout.Build/Host.cs
+++ b/src/Fallout.Build/Host.cs
@@ -27,48 +27,53 @@ public partial class Host
 
     internal virtual string OutputTemplate => Logging.TimestampOutputTemplate;
 
+    // True-color ANSI for Fallout yellow (#F5C800). Modern terminals
+    // (Windows Terminal, VS Code, macOS Terminal.app, GitHub Actions logs)
+    // render this directly; older sinks ignore the escape bytes.
+
+    protected virtual string LogoYellow { get => "[38;2;245;200;0m"; }
+
+    protected virtual string LogoDark { get => "[2m"; }
+
+    protected virtual string LogoReset { get => "[0m"; }
+
     protected internal void WriteLogo()
     {
         Debug();
-        // True-color ANSI for Fallout yellow (#F5C800). Modern terminals
-        // (Windows Terminal, VS Code, macOS Terminal.app, GitHub Actions logs)
-        // render this directly; older sinks ignore the escape bytes.
-        string Y = Environment.GetEnvironmentVariable("GITLAB_CI") == "true"
-            ? "[93m"
-            : "[38;2;245;200;0m";
-        const string D = "[2m";
-        const string R = "[0m";
 
         new[]
         {
-            $"{Y}███████╗ █████╗ ██╗     ██╗      ██████╗ ██╗   ██╗████████╗{R}",
-            $"{Y}██╔════╝██╔══██╗██║     ██║     ██╔═══██╗██║   ██║╚══██╔══╝{R}",
-            $"{Y}█████╗  ███████║██║     ██║     ██║   ██║██║   ██║   ██║   {R}",
-            $"{Y}██╔══╝  ██╔══██║██║     ██║     ██║   ██║██║   ██║   ██║   {R}",
-            $"{Y}██║     ██║  ██║███████╗███████╗╚██████╔╝╚██████╔╝   ██║   {R}",
-            $"{Y}╚═╝     ╚═╝  ╚═╝╚══════╝╚══════╝ ╚═════╝  ╚═════╝    ╚═╝   {R}",
+            $"{LogoYellow}███████╗ █████╗ ██╗     ██╗      ██████╗ ██╗   ██╗████████╗{LogoReset}",
+            $"{LogoYellow}██╔════╝██╔══██╗██║     ██║     ██╔═══██╗██║   ██║╚══██╔══╝{LogoReset}",
+            $"{LogoYellow}█████╗  ███████║██║     ██║     ██║   ██║██║   ██║   ██║   {LogoReset}",
+            $"{LogoYellow}██╔══╝  ██╔══██║██║     ██║     ██║   ██║██║   ██║   ██║   {LogoReset}",
+            $"{LogoYellow}██║     ██║  ██║███████╗███████╗╚██████╔╝╚██████╔╝   ██║   {LogoReset}",
+            $"{LogoYellow}╚═╝     ╚═╝  ╚═╝╚══════╝╚══════╝ ╚═════╝  ╚═════╝    ╚═╝   {LogoReset}",
             string.Empty,
-            $"                       {D}.NET build system{R}",
-            $"                     {Y}☢{R} {D}survived the NUKE{R}"
+            $"                       {LogoDark}.NET build system{LogoReset}",
+            $"                     {LogoYellow}☢{LogoReset} {LogoDark}survived the NUKE{LogoReset}"
         }.ForEach(x => Debug(x.Replace(" ", " ")));
+
         Debug();
     }
 
     protected internal virtual IDisposable WriteBlock(string text)
     {
-        return DelegateDisposable.CreateBracket(
-            () =>
-            {
-                var formattedBlockText = text
-                    .Split(new[] { EnvironmentInfo.NewLine }, StringSplitOptions.None)
-                    .Select(Theme.FormatInformation);
+        return DelegateDisposable.CreateBracket(() =>
+        {
+            var formattedBlockText = text
+                .Split(new[]
+                {
+                    EnvironmentInfo.NewLine
+                }, StringSplitOptions.None)
+                .Select(Theme.FormatInformation);
 
-                Debug();
-                Debug("╬" + '═'.Repeat(text.Length + 5));
-                formattedBlockText.ForEach(x => Debug($"║ {x}"));
-                Debug("╬" + '═'.Repeat(Math.Max(text.Length - 4, 2)));
-                Debug();
-            });
+            Debug();
+            Debug("╬" + '═'.Repeat(text.Length + 5));
+            formattedBlockText.ForEach(x => Debug($"║ {x}"));
+            Debug("╬" + '═'.Repeat(Math.Max(text.Length - 4, 2)));
+            Debug();
+        });
     }
 
     protected internal virtual void ReportWarning(string text, string details = null)
@@ -146,18 +151,23 @@ public partial class Host
                 case ExecutionStatus.Skipped:
                     Debug(line);
                     break;
+
                 case ExecutionStatus.Succeeded:
                     Success(line);
                     break;
+
                 case ExecutionStatus.Aborted:
                 case ExecutionStatus.NotRun:
                     Warning(line);
                     break;
+
                 case ExecutionStatus.Failed:
                     Error(line);
                     break;
+
                 case ExecutionStatus.Collective:
                     break;
+
                 default:
                     throw new NotSupportedException(target.Status.ToString());
             }

--- a/src/Fallout.Build/Host.cs
+++ b/src/Fallout.Build/Host.cs
@@ -33,7 +33,7 @@ public partial class Host
 
     protected virtual string LogoYellow { get => "[38;2;245;200;0m"; }
 
-    protected virtual string LogoDark { get => "[2m"; }
+    protected virtual string LogoDimmed { get => "[2m"; }
 
     protected virtual string LogoReset { get => "[0m"; }
 
@@ -50,8 +50,8 @@ public partial class Host
             $"{LogoYellow}██║     ██║  ██║███████╗███████╗╚██████╔╝╚██████╔╝   ██║   {LogoReset}",
             $"{LogoYellow}╚═╝     ╚═╝  ╚═╝╚══════╝╚══════╝ ╚═════╝  ╚═════╝    ╚═╝   {LogoReset}",
             string.Empty,
-            $"                       {LogoDark}.NET build system{LogoReset}",
-            $"                     {LogoYellow}☢{LogoReset} {LogoDark}survived the NUKE{LogoReset}"
+            $"                       {LogoDimmed}.NET build system{LogoReset}",
+            $"                     {LogoYellow}☢{LogoReset} {LogoDimmed}survived the NUKE{LogoReset}"
         }.ForEach(x => Debug(x.Replace(" ", " ")));
 
         Debug();

--- a/src/Fallout.Common/CI/GitLab/GitLab.cs
+++ b/src/Fallout.Common/CI/GitLab/GitLab.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Fallout.Common.Utilities;
 
 namespace Fallout.Common.CI.GitLab;
@@ -18,6 +17,10 @@ public partial class GitLab : Host, IBuildServer
 
     private const string SectionStartSequence = "\u001b[0K";
     private const string SectionResetSequence = "\r\u001b[0K";
+
+    protected override string LogoYellow => "[93m";
+
+    protected override string LogoDark => "[90m";
 
     private readonly Action<string> _messageSink;
 

--- a/src/Fallout.Common/CI/GitLab/GitLab.cs
+++ b/src/Fallout.Common/CI/GitLab/GitLab.cs
@@ -20,7 +20,7 @@ public partial class GitLab : Host, IBuildServer
 
     protected override string LogoYellow => "[93m";
 
-    protected override string LogoDark => "[90m";
+    protected override string LogoDimmed => "[90m";
 
     private readonly Action<string> _messageSink;
 


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Gitlab does not support "24-bit true-color ANSI sequence" so the logo appears white instead of yellow.


<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

<!-- Optional: merge preference. Squash is the default; pick rebase only if you've -->
<!-- curated your commits into a logical sequence and interactive-rebased away any -->
<!-- review-fixup noise. See CONTRIBUTING.md → Merging. -->

**Merge preference:** ( ) squash (default)  ( ) rebase
