### PR TITLE
Fix errors/warnings for pre-existing code smells after reintroducing editorconfig et al

### DIFF
--- a/src/Fallout.Build/ControlFlow.cs
+++ b/src/Fallout.Build/ControlFlow.cs
@@ -17,12 +17,12 @@ public static class ControlFlow
 {
     public static void SuppressErrors(Action action, bool includeStackTrace = false, bool logWarning = true)
     {
-        SuppressErrorsIf(condition: true, action, includeStackTrace: includeStackTrace, logWarning: logWarning);
+        SuppressErrorsIf(condition: true, action, logWarning: logWarning);
     }
 
     public static T SuppressErrors<T>(Func<T> action, T defaultValue = default, bool includeStackTrace = false, bool logWarning = true)
     {
-        return (T)SuppressErrorsIf(condition: true, action, defaultValue, includeStackTrace, logWarning);
+        return (T)SuppressErrorsIf(condition: true, action, defaultValue, logWarning);
     }
 
     public static IEnumerable<T> SuppressErrors<T>(Func<IEnumerable<T>> action, bool includeStackTrace = false)
@@ -34,7 +34,6 @@ public static class ControlFlow
         bool condition,
         Delegate action,
         object defaultValue = null,
-        bool includeStackTrace = false,
         bool logWarning = true)
     {
         if (!condition)

--- a/src/Fallout.Build/Utilities/SchemaUtility.cs
+++ b/src/Fallout.Build/Utilities/SchemaUtility.cs
@@ -244,7 +244,7 @@ public static class SchemaUtility
             return new JsonObject { ["type"] = "string" };
 
         if (typeof(Enumeration).IsAssignableFrom(type))
-            return BuildEnumerationSchema(type, ctx);
+            return BuildEnumerationSchema(type);
 
         if (type.IsEnum)
             return StringEnumSchema(Enum.GetNames(type));
@@ -266,7 +266,7 @@ public static class SchemaUtility
         return BuildComplexTypeReference(type, ctx);
     }
 
-    private static JsonObject BuildEnumerationSchema(Type enumerationType, SchemaContext ctx)
+    private static JsonObject BuildEnumerationSchema(Type enumerationType)
     {
         var values = enumerationType
             .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)

--- a/src/Fallout.Cli/Program.Navigation.cs
+++ b/src/Fallout.Cli/Program.Navigation.cs
@@ -25,7 +25,7 @@ partial class Program
 
     private static AbsolutePath SessionFile => GlobalTemporaryDirectory / $"nuke-{SessionId}.dat";
 
-    private static int GetNextDirectory(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private static int GetNextDirectory()
     {
         var content = SessionFile.Existing()?.ReadAllLines();
         if (content == null || string.IsNullOrWhiteSpace(content[0]))
@@ -41,7 +41,7 @@ partial class Program
         return 0;
     }
 
-    private static int PopDirectory(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private static int PopDirectory()
     {
         var content = SessionFile.Existing()?.ReadAllLines().ToList();
         if (content == null || content.Count <= 1)
@@ -56,18 +56,18 @@ partial class Program
         return 0;
     }
 
-    private static int PushWithCurrentRootDirectory(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private static int PushWithCurrentRootDirectory(AbsolutePath rootDirectory)
     {
         return PushAndSetNext(() => rootDirectory.NotNull("No root directory"));
     }
 
-    private static int PushWithParentRootDirectory(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private static int PushWithParentRootDirectory(AbsolutePath rootDirectory)
     {
         return PushAndSetNext(() => TryGetRootDirectoryFrom(Path.GetDirectoryName(rootDirectory.NotNull("No root directory")))
             .NotNull("No parent root directory"));
     }
 
-    private static int PushWithChosenRootDirectory(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private static int PushWithChosenRootDirectory()
     {
         return PushAndSetNext(() =>
         {

--- a/src/Fallout.Cli/Program.Setup.cs
+++ b/src/Fallout.Cli/Program.Setup.cs
@@ -96,9 +96,7 @@ partial class Program
 
         WriteBuildScripts(
             scriptDirectory: WorkingDirectory,
-            rootDirectory,
-            buildDirectory,
-            buildProjectName);
+            rootDirectory);
 
         WriteConfigurationFile(rootDirectory, solutionFile);
 
@@ -186,9 +184,7 @@ partial class Program
 
     private static void WriteBuildScripts(
         AbsolutePath scriptDirectory,
-        AbsolutePath rootDirectory,
-        AbsolutePath buildDirectory,
-        string buildProjectName)
+        AbsolutePath rootDirectory)
     {
         (scriptDirectory / "build.sh").WriteAllLines(
             FillTemplate(

--- a/src/Fallout.Cli/Program.Update.cs
+++ b/src/Fallout.Cli/Program.Update.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using System.Text.Json.Nodes;
 using Fallout.Common;
@@ -42,9 +41,7 @@ partial class Program
 
         WriteBuildScripts(
             scriptDirectory: buildScript.Parent,
-            rootDirectory,
-            buildDirectory: buildProjectFile.NotNull().Parent,
-            buildProjectName: Path.GetFileNameWithoutExtension(buildProjectFile));
+            rootDirectory);
     }
 
     private static void UpdateBuildProject(AbsolutePath buildScript)

--- a/src/Fallout.Common/CI/GitHubActions/GitHubActionsAttribute.cs
+++ b/src/Fallout.Common/CI/GitHubActions/GitHubActionsAttribute.cs
@@ -71,7 +71,7 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
     public string PublishCondition { get; set; }
 
     public int TimeoutMinutes { get; set; }
-    
+
     public string EnvironmentName { get; set; }
     public string EnvironmentUrl { get; set; }
 
@@ -163,7 +163,7 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
                    Name = image.GetValue().Replace(".", "_"),
                    EnvironmentName = EnvironmentName,
                    EnvironmentUrl = EnvironmentUrl,
-                   Steps = GetSteps(image, relevantTargets).ToArray(),
+                   Steps = GetSteps(relevantTargets).ToArray(),
                    Image = image,
                    TimeoutMinutes = TimeoutMinutes,
                    ConcurrencyGroup = JobConcurrencyGroup,
@@ -171,7 +171,7 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
                };
     }
 
-    private IEnumerable<GitHubActionsStep> GetSteps(GitHubActionsImage image, IReadOnlyCollection<ExecutableTarget> relevantTargets)
+    private IEnumerable<GitHubActionsStep> GetSteps(IReadOnlyCollection<ExecutableTarget> relevantTargets)
     {
         yield return new GitHubActionsCheckoutStep
                      {

--- a/src/Fallout.Common/Tools/CorFlags/CorFlagsSettings.cs
+++ b/src/Fallout.Common/Tools/CorFlags/CorFlagsSettings.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.Reflection;
 
 namespace Fallout.Common.Tools.CorFlags;
 
 partial class CorFlagsSettings
 {
-    string FormatBoolean(bool? value, PropertyInfo property)
+    private static string FormatBoolean(bool? value)
         => value switch
         {
             true => "+",

--- a/src/Fallout.Tooling.Generator/CodeGenerator.cs
+++ b/src/Fallout.Tooling.Generator/CodeGenerator.cs
@@ -38,7 +38,7 @@ public static class CodeGenerator
         tool.SpecificationFile = specificationFile;
         tool.SourceFile = sourceFileProvider?.Invoke(tool);
         tool.Namespace = namespaceProvider?.Invoke(tool);
-        ApplyRuntimeInformation(tool, specificationFile, sourceFileProvider, namespaceProvider);
+        ApplyRuntimeInformation(tool);
 
         GenerateCode(tool, outputFileProvider?.Invoke(tool) ?? tool.DefaultOutputFile);
     }
@@ -58,10 +58,7 @@ public static class CodeGenerator
 
     // ReSharper disable once CognitiveComplexity
     private static void ApplyRuntimeInformation(
-        Tool tool,
-        string specificationFile,
-        Func<Tool, string> sourceFileProvider,
-        Func<Tool, string> namespaceProvider)
+        Tool tool)
     {
         foreach (var task in tool.Tasks)
         {

--- a/src/Fallout.Tooling/ProcessTasks.cs
+++ b/src/Fallout.Tooling/ProcessTasks.cs
@@ -156,7 +156,7 @@ public static class ProcessTasks
         }
 
         if (logInvocation)
-            LogInvocation(startInfo, outputFilter, environmentVariables != null);
+            LogInvocation(startInfo, outputFilter);
 
         var process = Process.Start(startInfo);
         if (process == null)
@@ -166,7 +166,7 @@ public static class ProcessTasks
         return new Process2(process, outputFilter, timeout, output);
     }
 
-    private static void LogInvocation(ProcessStartInfo startInfo, Func<string, string> outputFilter, bool hasEnvironmentVariables)
+    private static void LogInvocation(ProcessStartInfo startInfo, Func<string, string> outputFilter)
     {
         lock (s_lock)
         {

--- a/src/Fallout.Tooling/ToolOptions.Arguments.cs
+++ b/src/Fallout.Tooling/ToolOptions.Arguments.cs
@@ -115,7 +115,7 @@ partial class ToolOptions
                 // The PropertyInfo is an optional second argument: formatters that don't need it
                 // can declare just the value parameter. Pass args matching the method's arity so
                 // both `Format(value)` and `Format(value, PropertyInfo)` shapes are supported.
-                object[] formatterArgs = formatterMethod.GetParameters().Length <= 1
+                object[] formatterArgs = formatterMethod.GetParameters().Length == 1
                     ? [objValue]
                     : [objValue, property];
                 value = formatterMethod.GetValue<string>(obj: this, args: formatterArgs);

--- a/src/Fallout.Tooling/ToolOptions.Arguments.cs
+++ b/src/Fallout.Tooling/ToolOptions.Arguments.cs
@@ -112,7 +112,13 @@ partial class ToolOptions
                 var formatterType = attribute.FormatterType ?? GetType();
                 var formatterMethod = formatterType.GetMethod(attribute.FormatterMethod, ReflectionUtility.All);
                 var objValue = type != typeof(object) ? DeserializeWithCoercion(token, type) : NodeToString(token);
-                value = formatterMethod.GetValue<string>(obj: this, args: [objValue, property]);
+                // The PropertyInfo is an optional second argument: formatters that don't need it
+                // can declare just the value parameter. Pass args matching the method's arity so
+                // both `Format(value)` and `Format(value, PropertyInfo)` shapes are supported.
+                object[] formatterArgs = formatterMethod.GetParameters().Length <= 1
+                    ? [objValue]
+                    : [objValue, property];
+                value = formatterMethod.GetValue<string>(obj: this, args: formatterArgs);
             }
             else
             {

--- a/src/Persistence/Fallout.Persistence.Solution/Model/ISerializerModelExtension.cs
+++ b/src/Persistence/Fallout.Persistence.Solution/Model/ISerializerModelExtension.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Fallout.Persistence.Solution.Serializer;
+
 namespace Fallout.Persistence.Solution.Model;
 
 /// <summary>

--- a/src/Persistence/Fallout.Persistence.Solution/Model/ISerializerModelExtension.cs
+++ b/src/Persistence/Fallout.Persistence.Solution/Model/ISerializerModelExtension.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Fallout.Persistence.Solution.Serializer;
-
 namespace Fallout.Persistence.Solution.Model;
 
 /// <summary>

--- a/src/Persistence/Fallout.Persistence.Solution/Serializer/ISolutionSerializer.cs
+++ b/src/Persistence/Fallout.Persistence.Solution/Serializer/ISolutionSerializer.cs
@@ -3,7 +3,7 @@
 
 using Fallout.Persistence.Solution.Model;
 
-namespace Fallout.Persistence.Solution;
+namespace Fallout.Persistence.Solution.Serializer;
 
 /// <summary>
 /// Represents a solution serializer.
@@ -45,7 +45,7 @@ public interface ISolutionSerializer
     /// For single file serializers, this checks the file extension.
     /// </summary>
     /// <param name="moniker">The moniker that represents the solution location.</param>
-    /// <returns>If this serilizer can open the solution.</returns>
+    /// <returns>If this serializer can open the solution.</returns>
     bool IsSupported(string moniker);
 }
 
@@ -86,7 +86,7 @@ public interface ISolutionSingleFileSerializer<TSettings> : ISolutionSerializer<
     /// <summary>
     /// Saves a solution model to a stream.
     /// </summary>
-    /// <param name="stream">The stream to save the file..</param>
+    /// <param name="stream">The stream to save the file.</param>
     /// <param name="model">The model to save.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Task to track the asynchronous call status.</returns>

--- a/src/Persistence/Fallout.Persistence.Solution/Serializer/ISolutionSerializer.cs
+++ b/src/Persistence/Fallout.Persistence.Solution/Serializer/ISolutionSerializer.cs
@@ -3,7 +3,7 @@
 
 using Fallout.Persistence.Solution.Model;
 
-namespace Fallout.Persistence.Solution.Serializer;
+namespace Fallout.Persistence.Solution;
 
 /// <summary>
 /// Represents a solution serializer.

--- a/src/Persistence/Fallout.Persistence.Solution/Serializer/SingleFileSerializerBase.cs
+++ b/src/Persistence/Fallout.Persistence.Solution/Serializer/SingleFileSerializerBase.cs
@@ -36,10 +36,11 @@ internal abstract class SingleFileSerializerBase<TSettings> : ISolutionSingleFil
 
     async Task<SolutionModel> ISolutionSerializer.OpenAsync(string moniker, CancellationToken cancellationToken)
     {
-        using (FileStream reader = File.OpenRead(moniker))
-        {
-            return await this.ReadModelAsync(moniker, reader, cancellationToken);
-        }
+        // Plain `using` (not `await using`): FileStream does not implement IAsyncDisposable on
+        // netstandard2.0, so `await using` fails to compile there (CS8417). Synchronous disposal
+        // of a local read stream is fine across all target frameworks.
+        using FileStream reader = File.OpenRead(moniker);
+        return await this.ReadModelAsync(moniker, reader, cancellationToken);
     }
 
     async Task ISolutionSerializer.SaveAsync(string moniker, SolutionModel model, CancellationToken cancellationToken)
@@ -50,10 +51,10 @@ internal abstract class SingleFileSerializerBase<TSettings> : ISolutionSingleFil
             _ = Directory.CreateDirectory(directory);
         }
 
-        using (FileStream writer = File.OpenWrite(moniker))
-        {
-            await this.WriteModelAsync(moniker, model, writer, cancellationToken);
-        }
+        // Plain `using` (not `await using`): see OpenAsync — FileStream is not IAsyncDisposable
+        // on netstandard2.0 (CS8417). Synchronous disposal of a local write stream is fine here.
+        using FileStream writer = File.OpenWrite(moniker);
+        await this.WriteModelAsync(moniker, model, writer, cancellationToken);
     }
 
     private protected abstract Task<SolutionModel> ReadModelAsync(string? fullPath, Stream reader, CancellationToken cancellationToken);

--- a/src/Persistence/Fallout.Persistence.Solution/Serializer/Xml/XmlDecorators/XmlFolder.cs
+++ b/src/Persistence/Fallout.Persistence.Solution/Serializer/Xml/XmlDecorators/XmlFolder.cs
@@ -129,8 +129,8 @@ internal sealed class XmlFolder(SlnxFile root, XmlSolution xmlSolution, XmlEleme
 
         // Projects
         List<(string ItemRef, SolutionProjectModel Item)> projectsInFolder = modelSolution.SolutionProjects.WhereToList(
-            (project, modelFolder) => ReferenceEquals(project.Parent, modelFolder),
-            (project, modelFolder) => (ItemRef: this.Root.ConvertToUserPath(project.ItemRef), Item: project),
+            (project, solutionFolderModel) => ReferenceEquals(project.Parent, solutionFolderModel),
+            (project, _) => (ItemRef: this.Root.ConvertToUserPath(project.ItemRef), Item: project),
             modelFolder);
         modified |= this.ApplyModelItemsToXml(
             modelItems: projectsInFolder,

--- a/tests/Fallout.Tooling.Tests/ToolOptionsArgumentsTest.cs
+++ b/tests/Fallout.Tooling.Tests/ToolOptionsArgumentsTest.cs
@@ -99,8 +99,8 @@ public class ToolOptionsArgumentsTest
         [Argument(Format = "{value}", FormatterType = typeof(Formatter), FormatterMethod = nameof(Formatter.FormatMinutes))]
         public TimeSpan Minutes => Get<TimeSpan>(() => Minutes);
 
-        private string FormatTime(DateTime datetime, PropertyInfo property) => datetime.ToString("t", CultureInfo.InvariantCulture);
-        private string FormatDate(DateTime datetime, PropertyInfo property) => datetime.ToString("d", CultureInfo.InvariantCulture);
+        private string FormatTime(DateTime datetime) => datetime.ToString("t", CultureInfo.InvariantCulture);
+        private string FormatDate(DateTime datetime) => datetime.ToString("d", CultureInfo.InvariantCulture);
     }
 
     private static class Formatter
@@ -124,7 +124,7 @@ public class ToolOptionsArgumentsTest
         [Argument(Format = "--param:{value}", Separator = " ", QuoteMultiple = true)] public IReadOnlyList<string> QuotedList => Get<List<string>>(() => QuotedList);
         [Argument(Format = "--param={value}", FormatterMethod = nameof(Format))] public IReadOnlyList<bool> FormattedList => Get<List<bool>>(() => FormattedList);
 
-        private string Format(bool value, PropertyInfo property) => value.ToString().ToUpperInvariant();
+        private string Format(bool value) => value.ToString().ToUpperInvariant();
     }
 
     private readonly Dictionary<string, object> _simpleDictionary = new() { ["key1"] = 1, ["key2"] = "foobar" };
@@ -143,7 +143,7 @@ public class ToolOptionsArgumentsTest
         [Argument(Format = "-- {key}={value}", Separator = " ")] public IReadOnlyDictionary<string, object> WhitespaceDictionary => Get<Dictionary<string, object>>(() => WhitespaceDictionary);
         [Argument(Format = "/p:{key}={value}", FormatterMethod = nameof(Format))] public IReadOnlyDictionary<string, object> FormattedDictionary => Get<Dictionary<string, object>>(() => FormattedDictionary);
 
-        private string Format(object value, PropertyInfo property) => value?.ToString()?.ToUpperInvariant();
+        private string Format(object value) => value?.ToString()?.ToUpperInvariant();
     }
 
     private readonly LookupTable<string, object> _simpleLookupTable = new() { ["key1"] = [1, 2], ["key2"] = [true, false] };
@@ -160,7 +160,7 @@ public class ToolOptionsArgumentsTest
         [Argument(Format = "--param:{key}={value}", Separator = ";", InnerSeparator = ",")] public ILookup<string, object> SeparatorLookup => Get<LookupTable<string, object>>(() => SeparatorLookup);
         [Argument(Format = "--param {key} {value}", InnerSeparator = "+", FormatterMethod = nameof(Format))] public ILookup<string, object> FormattedLookup => Get<LookupTable<string, object>>(() => FormattedLookup);
 
-        private string Format(object value, PropertyInfo property) => value?.ToString()?.ToUpperInvariant();
+        private string Format(object value) => value?.ToString()?.ToUpperInvariant();
     }
 
     [Fact]


### PR DESCRIPTION
Fixes pre-existing C# warnings / code smells surfaced after reintroducing `.editorconfig` (#388).

**Scope narrowed per @dennisdoomen's review** — the two larger, opinion-dependent changes were split out so this PR stays focused and reviewable:
- Member visibility / encapsulation → #405
- `MSBuildSettings` → `MsBuildSettings` rename → separate PR (pending, breaking-change handling TBD)

## What remains here

**Remove unused method parameters and usings across utilities and CLI**
`ControlFlow`, `SchemaUtility`, `CodeGenerator`, `ProcessTasks`, `GitHubActionsAttribute`, and the CLI navigation/setup/update commands all had method signatures declaring parameters that were never read. Removed the dead parameters and one unused `using` import. A stale splash-screen comment is also corrected.

**Introduce `SingleFileSerializerBase` and clean up the persistence serializer**
The generic arity suffix on the base class name was noise (there is only one concrete base), so it is renamed to `SingleFileSerializerBase`. The `await using FileStream` pattern is replaced with synchronous `using` to fix a `netstandard2.0` compile break (`FileStream` is not `IAsyncDisposable` there — CS8417). Also fixed: a namespace mismatch on `ISerializerModelExtension`, two doc-comment typos in `ISolutionSerializer`, and redundant lambda parameter names in `XmlFolder`.

**Make `PropertyInfo` argument optional for tool-option formatters**
Formatter methods were always invoked with two arguments (`value`, `PropertyInfo`), forcing every formatter to declare the `PropertyInfo` parameter even when unused. Removing it in `CorFlagsSettings` (as part of the unused-parameter cleanup above) caused a parameter-count mismatch at runtime. The invoker now matches arguments to the formatter's declared arity, making the `PropertyInfo` parameter genuinely optional without breaking existing two-parameter formatters.

## Verification
Full `dotnet build fallout.slnx` succeeds (0 errors).