### PR TITLE
Convert :trigger to TriggerCommand (#392)

### DIFF
--- a/src/Fallout.Cli/Commands/TriggerCommand.cs
+++ b/src/Fallout.Cli/Commands/TriggerCommand.cs
@@ -1,16 +1,19 @@
-﻿using System;
-using System.Linq;
 using Fallout.Common;
 using Fallout.Common.Git;
 using Fallout.Common.IO;
 using Fallout.Common.Tools.Git;
 using Fallout.Common.Utilities;
 
-namespace Fallout.Cli;
+namespace Fallout.Cli.Commands;
 
-partial class Program
+/// <summary>
+/// <c>fallout :trigger</c>: pushes an empty commit with the given message to trigger a remote build.
+/// </summary>
+public sealed class TriggerCommand : IFalloutCommand
 {
-    public static int Trigger(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    public string Name => "trigger";
+
+    public int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
     {
         var repository = GitRepository.FromLocalDirectory(rootDirectory.NotNull()).NotNull("No Git repository");
         Assert.NotNull(repository.Branch, "Git repository must not be detached");

--- a/src/Fallout.Cli/Program.cs
+++ b/src/Fallout.Cli/Program.cs
@@ -53,6 +53,7 @@ public partial class Program
     {
         // Real command types — issue #392 converts one legacy handler per PR.
         services.AddSingleton<IFalloutCommand, RunCommand>();
+        services.AddSingleton<IFalloutCommand, TriggerCommand>();
 
         // Legacy handlers still living on Program, adapted until they are extracted into command
         // types. Each conversion deletes one line here plus its Program.X.cs partial.
@@ -64,7 +65,6 @@ public partial class Program
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("complete", Complete));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("get-configuration", GetConfiguration));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("secrets", Secrets));
-        services.AddSingleton<IFalloutCommand>(new DelegateCommand("trigger", Trigger));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("GetNextDirectory", GetNextDirectory));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("PopDirectory", PopDirectory));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("PushWithCurrentRootDirectory", PushWithCurrentRootDirectory));

--- a/tests/Fallout.Cli.Tests/Commands/TriggerCommandTests.cs
+++ b/tests/Fallout.Cli.Tests/Commands/TriggerCommandTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using Fallout.Cli.Commands;
+using Fallout.Common.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.Cli.Tests.Commands;
+
+public class TriggerCommandTests
+{
+    [Fact]
+    public void Name_IsTrigger()
+        => new TriggerCommand().Name.Should().Be("trigger");
+
+    [Fact]
+    public void Execute_OutsideGitRepository_Throws()
+    {
+        var dir = (AbsolutePath)Path.Combine(Path.GetTempPath(), "fallout-trigger-" + Guid.NewGuid().ToString("N"));
+        dir.CreateDirectory();
+        try
+        {
+            var action = () => new TriggerCommand().Execute(["a message"], dir, buildScript: null);
+
+            // No resolvable Git repository at a throwaway temp dir → the command fails rather than
+            // pushing anything.
+            action.Should().Throw<Exception>();
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Part of #392 (one command per PR). Stacked on #394 — auto-retargets to `main` once it lands.

Lifts `:trigger` into a standalone `TriggerCommand : IFalloutCommand`, registered directly; removes its transitional `DelegateCommand` adapter and deletes `Program.Trigger.cs`. Self-contained, no shared helpers. Name/behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
