### PR TITLE
Convert :complete to CompleteCommand (#392)

### DIFF
--- a/src/Fallout.Cli/Commands/CompleteCommand.cs
+++ b/src/Fallout.Cli/Commands/CompleteCommand.cs
@@ -7,13 +7,18 @@ using Fallout.Common.Utilities;
 using Fallout.Utilities.Text.Yaml;
 using static Fallout.Common.Constants;
 
-namespace Fallout.Cli;
+namespace Fallout.Cli.Commands;
 
-partial class Program
+/// <summary>
+/// <c>fallout :complete</c>: emits shell-completion candidates for the partially typed command line.
+/// </summary>
+public sealed class CompleteCommand : IFalloutCommand
 {
     private const string CommandName = "fallout";
 
-    public static int Complete(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    public string Name => "complete";
+
+    public int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
     {
         if (rootDirectory == null)
             return 0;

--- a/src/Fallout.Cli/Program.cs
+++ b/src/Fallout.Cli/Program.cs
@@ -54,6 +54,7 @@ public partial class Program
         // Real command types — issue #392 converts one legacy handler per PR.
         services.AddSingleton<IFalloutCommand, RunCommand>();
         services.AddSingleton<IFalloutCommand, TriggerCommand>();
+        services.AddSingleton<IFalloutCommand, CompleteCommand>();
 
         // Legacy handlers still living on Program, adapted until they are extracted into command
         // types. Each conversion deletes one line here plus its Program.X.cs partial.
@@ -62,7 +63,6 @@ public partial class Program
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("add-package", AddPackage));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("cake-convert", CakeConvert));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("cake-clean", CakeClean));
-        services.AddSingleton<IFalloutCommand>(new DelegateCommand("complete", Complete));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("get-configuration", GetConfiguration));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("secrets", Secrets));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("GetNextDirectory", GetNextDirectory));

--- a/tests/Fallout.Cli.Tests/Commands/CompleteCommandTests.cs
+++ b/tests/Fallout.Cli.Tests/Commands/CompleteCommandTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.IO;
+using Fallout.Cli.Commands;
+using Fallout.Common.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.Cli.Tests.Commands;
+
+public class CompleteCommandTests
+{
+    [Fact]
+    public void Name_IsComplete()
+        => new CompleteCommand().Name.Should().Be("complete");
+
+    [Fact]
+    public void Execute_WithoutRootDirectory_ReturnsZero()
+        => new CompleteCommand().Execute(["fallout "], rootDirectory: null, buildScript: null).Should().Be(0);
+
+    [Fact]
+    public void Execute_WordNotStartingWithCommandName_ReturnsZero()
+    {
+        var dir = (AbsolutePath)Path.Combine(Path.GetTempPath(), "fallout-complete-" + Guid.NewGuid().ToString("N"));
+        dir.CreateDirectory();
+        try
+        {
+            // Completion only fires for the `fallout` command line; anything else short-circuits to 0.
+            new CompleteCommand().Execute(["notfallout foo"], dir, buildScript: null).Should().Be(0);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Part of #392 (one command per PR). Stacked on #394 — merge after it lands.

Lifts `:complete` (shell-completion) into `CompleteCommand : IFalloutCommand`, registered directly; removes its `DelegateCommand` adapter and deletes `Program.Complete.cs`. Self-contained. Name/behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
