### PR TITLE
Convert :get-configuration to GetConfigurationCommand (#392)

### DIFF
--- a/src/Fallout.Cli/Commands/GetConfigurationCommand.cs
+++ b/src/Fallout.Cli/Commands/GetConfigurationCommand.cs
@@ -1,0 +1,27 @@
+using System;
+using Fallout.Common;
+using Fallout.Common.IO;
+using Fallout.Common.Utilities;
+using Fallout.Common.Utilities.Collections;
+
+namespace Fallout.Cli.Commands;
+
+/// <summary>
+/// <c>fallout :get-configuration</c>: prints the build configuration parsed from the build script.
+/// </summary>
+public sealed class GetConfigurationCommand : IFalloutCommand
+{
+    public string Name => "get-configuration";
+
+    public int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    {
+        // Program.GetConfiguration(buildScript, evaluate) is shared with add-package/update/cake;
+        // it moves into a configuration service in the final #392 collapse PR.
+        var configuration = Program.GetConfiguration(buildScript.NotNull(), evaluate: false);
+
+        Host.Information($"Configuration from {buildScript}:");
+        configuration.ForEach(x => Console.WriteLine($"{x.Key} = {x.Value}"));
+
+        return 0;
+    }
+}

--- a/src/Fallout.Cli/Program.GetConfiguration.cs
+++ b/src/Fallout.Cli/Program.GetConfiguration.cs
@@ -19,16 +19,8 @@ partial class Program
     private const string DOTNET_INSTALL_URL = nameof(DOTNET_INSTALL_URL);
     private const string DOTNET_CHANNEL = nameof(DOTNET_CHANNEL);
 
-    public static int GetConfiguration(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-    {
-        var configuration = GetConfiguration(buildScript.NotNull(), evaluate: false);
-
-        Host.Information($"Configuration from {buildScript}:");
-        configuration.ForEach(x => Console.WriteLine($"{x.Key} = {x.Value}"));
-
-        return 0;
-    }
-
+    // Residual after the :get-configuration command moved to GetConfigurationCommand: this helper is
+    // shared with add-package/update/cake and moves into a configuration service in the #392 collapse PR.
     internal static Dictionary<string, string> GetConfiguration(AbsolutePath buildScript, bool evaluate)
     {
         string ReplaceScriptDirectory(string value)

--- a/src/Fallout.Cli/Program.cs
+++ b/src/Fallout.Cli/Program.cs
@@ -55,6 +55,7 @@ public partial class Program
         services.AddSingleton<IFalloutCommand, RunCommand>();
         services.AddSingleton<IFalloutCommand, TriggerCommand>();
         services.AddSingleton<IFalloutCommand, CompleteCommand>();
+        services.AddSingleton<IFalloutCommand, GetConfigurationCommand>();
 
         // Legacy handlers still living on Program, adapted until they are extracted into command
         // types. Each conversion deletes one line here plus its Program.X.cs partial.
@@ -63,7 +64,6 @@ public partial class Program
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("add-package", AddPackage));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("cake-convert", CakeConvert));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("cake-clean", CakeClean));
-        services.AddSingleton<IFalloutCommand>(new DelegateCommand("get-configuration", GetConfiguration));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("secrets", Secrets));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("GetNextDirectory", GetNextDirectory));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("PopDirectory", PopDirectory));

--- a/tests/Fallout.Cli.Tests/Commands/GetConfigurationCommandTests.cs
+++ b/tests/Fallout.Cli.Tests/Commands/GetConfigurationCommandTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using Fallout.Cli.Commands;
+using Fallout.Common.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.Cli.Tests.Commands;
+
+public class GetConfigurationCommandTests
+{
+    [Fact]
+    public void Name_IsGetConfiguration()
+        => new GetConfigurationCommand().Name.Should().Be("get-configuration");
+
+    [Fact]
+    public void Execute_ParsesConfigurationBlock_ReturnsZero()
+    {
+        var dir = (AbsolutePath)Path.Combine(Path.GetTempPath(), "fallout-getcfg-" + Guid.NewGuid().ToString("N"));
+        dir.CreateDirectory();
+        var buildScript = dir / "build.sh";
+        try
+        {
+            File.WriteAllText(buildScript, string.Join("\n",
+                "# CONFIGURATION",
+                "##############",
+                "",
+                "BUILD_PROJECT_FILE=\"build/_build.csproj\"",
+                "TEMP_DIRECTORY=\"$SCRIPT_DIR/.fallout/temp\"",
+                "",
+                "# EXECUTION",
+                "dotnet run"));
+
+            new GetConfigurationCommand().Execute([], dir, buildScript).Should().Be(0);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Part of #392 (one command per PR). Stacked on #394 — merge after it lands.

Lifts `:get-configuration` into `GetConfigurationCommand : IFalloutCommand`. The shared `GetConfiguration(buildScript, evaluate)` helper (also used by add-package/update/cake) stays on `Program` as `internal` residual until the collapse PR (#404) moves it into a configuration service. Replaces the `DelegateCommand` adapter. Name/behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
