### PR TITLE
Convert :add-package to AddPackageCommand (#392)

### DIFF
--- a/src/Fallout.Cli/Commands/AddPackageCommand.cs
+++ b/src/Fallout.Cli/Commands/AddPackageCommand.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using Fallout.Common;
+using Fallout.Common.Execution;
+using Fallout.Common.IO;
+using Fallout.Solutions;
+using Fallout.Common.Tooling;
+using Fallout.Common.Tools.DotNet;
+
+namespace Fallout.Cli.Commands;
+
+/// <summary>
+/// <c>fallout :add-package</c>: adds (or upgrades) a NuGet package reference in the build project.
+/// </summary>
+public sealed class AddPackageCommand : IFalloutCommand
+{
+    public string Name => "add-package";
+
+    public int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    {
+        Program.PrintInfo();
+        Logging.Configure();
+        Telemetry.AddPackage();
+        ProjectModelTasks.Initialize();
+
+        var packageId = args.ElementAt(0);
+        var packageVersion =
+            (EnvironmentInfo.GetNamedArgument<string>("version") ??
+             args.ElementAtOrDefault(1) ??
+             NuGetVersionResolver.GetLatestVersion(packageId, includePrereleases: false).GetAwaiter().GetResult() ??
+             NuGetPackageResolver.GetGlobalInstalledPackage(packageId, version: null, packagesConfigFile: null)?.Version.ToString())
+            .NotNull("packageVersion != null");
+
+        // GetConfiguration / AddOrReplacePackage / BUILD_PROJECT_FILE / PACKAGE_TYPE_* are shared
+        // helpers still on Program; they move into services in the final #392 collapse PR.
+        var configuration = Program.GetConfiguration(buildScript, evaluate: true);
+        var buildProjectFile = configuration[Program.BUILD_PROJECT_FILE];
+        Host.Information($"Installing {packageId}/{packageVersion} to {buildProjectFile} ...");
+        Program.AddOrReplacePackage(packageId, packageVersion, Program.PACKAGE_TYPE_DOWNLOAD, buildProjectFile);
+        DotNetTasks.DotNet($"restore {buildProjectFile}");
+
+        var installedPackage = NuGetPackageResolver.GetGlobalInstalledPackage(packageId, packageVersion, packagesConfigFile: null)
+            .NotNull("installedPackage != null");
+        var hasToolsDirectory = installedPackage.Directory.GlobDirectories("tools").Any();
+        if (!hasToolsDirectory)
+            Program.AddOrReplacePackage(packageId, packageVersion, Program.PACKAGE_TYPE_REFERENCE, buildProjectFile);
+
+        Host.Information($"Done installing {packageId}/{packageVersion} to {buildProjectFile}");
+        return 0;
+    }
+}

--- a/src/Fallout.Cli/Program.AddPackage.cs
+++ b/src/Fallout.Cli/Program.AddPackage.cs
@@ -14,37 +14,8 @@ partial class Program
     public const string PACKAGE_TYPE_DOWNLOAD = "PackageDownload";
     public const string PACKAGE_TYPE_REFERENCE = "PackageReference";
 
-    public static int AddPackage(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-    {
-        PrintInfo();
-        Logging.Configure();
-        Telemetry.AddPackage();
-        ProjectModelTasks.Initialize();
-
-        var packageId = args.ElementAt(0);
-        var packageVersion =
-            (EnvironmentInfo.GetNamedArgument<string>("version") ??
-             args.ElementAtOrDefault(1) ??
-             NuGetVersionResolver.GetLatestVersion(packageId, includePrereleases: false).GetAwaiter().GetResult() ??
-             NuGetPackageResolver.GetGlobalInstalledPackage(packageId, version: null, packagesConfigFile: null)?.Version.ToString())
-            .NotNull("packageVersion != null");
-
-        var configuration = GetConfiguration(buildScript, evaluate: true);
-        var buildProjectFile = configuration[BUILD_PROJECT_FILE];
-        Host.Information($"Installing {packageId}/{packageVersion} to {buildProjectFile} ...");
-        AddOrReplacePackage(packageId, packageVersion, PACKAGE_TYPE_DOWNLOAD, buildProjectFile);
-        DotNetTasks.DotNet($"restore {buildProjectFile}");
-
-        var installedPackage = NuGetPackageResolver.GetGlobalInstalledPackage(packageId, packageVersion, packagesConfigFile: null)
-            .NotNull("installedPackage != null");
-        var hasToolsDirectory = installedPackage.Directory.GlobDirectories("tools").Any();
-        if (!hasToolsDirectory)
-            AddOrReplacePackage(packageId, packageVersion, PACKAGE_TYPE_REFERENCE, buildProjectFile);
-
-        Host.Information($"Done installing {packageId}/{packageVersion} to {buildProjectFile}");
-        return 0;
-    }
-
+    // Residual after the :add-package command moved to AddPackageCommand: this helper is shared with
+    // cake and moves into a package service in the #392 collapse PR.
     internal static void AddOrReplacePackage(string packageId, string packageVersion, string packageType, string buildProjectFile)
     {
         var buildProject = ProjectModelTasks.ParseProject(buildProjectFile).NotNull();

--- a/src/Fallout.Cli/Program.cs
+++ b/src/Fallout.Cli/Program.cs
@@ -56,12 +56,12 @@ public partial class Program
         services.AddSingleton<IFalloutCommand, TriggerCommand>();
         services.AddSingleton<IFalloutCommand, CompleteCommand>();
         services.AddSingleton<IFalloutCommand, GetConfigurationCommand>();
+        services.AddSingleton<IFalloutCommand, AddPackageCommand>();
 
         // Legacy handlers still living on Program, adapted until they are extracted into command
         // types. Each conversion deletes one line here plus its Program.X.cs partial.
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("setup", Setup));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("update", Update));
-        services.AddSingleton<IFalloutCommand>(new DelegateCommand("add-package", AddPackage));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("cake-convert", CakeConvert));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("cake-clean", CakeClean));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("secrets", Secrets));


### PR DESCRIPTION
Part of #392 (one command per PR). Stacked on #394 — merge after it lands.

Lifts `:add-package` into `AddPackageCommand : IFalloutCommand`. The shared `AddOrReplacePackage` helper and `PACKAGE_TYPE_*`/`BUILD_PROJECT_FILE` constants stay on `Program` as residual (still used by cake + the Cake tests) until the collapse PR (#404). Replaces the `DelegateCommand` adapter. Name/behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
