### PR TITLE
Convert :secrets to SecretsCommand (#392)

### DIFF
--- a/src/Fallout.Cli/Commands/SecretsCommand.cs
+++ b/src/Fallout.Cli/Commands/SecretsCommand.cs
@@ -1,7 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json.Nodes;
+using Fallout.Cli.Prompts;
 using Fallout.Common;
 using Fallout.Common.IO;
 using Fallout.Common.Utilities;
@@ -9,20 +8,31 @@ using Fallout.Common.Utilities.Collections;
 using static Fallout.Common.Constants;
 using static Fallout.Common.Utilities.EncryptionUtility;
 
-namespace Fallout.Cli;
+namespace Fallout.Cli.Commands;
 
 // TODO: unlock prompt
 // TODO: environment variable name
 // TODO: profile vs. environment
 // TODO: nuke :profile <name>
-partial class Program
+
+/// <summary>
+/// <c>fallout :secrets</c>: interactively encrypts secret parameters into the (optionally profile-scoped)
+/// parameters file, managing the keychain password.
+/// </summary>
+public sealed class SecretsCommand : IFalloutCommand
 {
     private const string SaveAndExit = "<Save & Exit>";
     private const string DiscardAndExit = "<Discard & Exit>";
     private const string DeletePasswordAndExit = "<Delete Password & Exit>";
 
+    private readonly IConsolePrompts _prompts;
+
+    public SecretsCommand(IConsolePrompts prompts) => _prompts = prompts;
+
+    public string Name => "secrets";
+
     // ReSharper disable once CognitiveComplexity
-    public static int Secrets(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    public int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
     {
         var secretParameters = CompletionUtility.GetItemsFromSchema(
                 GetBuildSchemaFile(rootDirectory.NotNull("No root directory")),
@@ -62,7 +72,7 @@ partial class Program
 
         if (EnvironmentInfo.IsOsx && existingSecrets.Count == 0 && !fromCredentialStore)
         {
-            if (generatedPassword || PromptForConfirmation($"Save password to keychain? (associated with '{rootDirectory}')"))
+            if (generatedPassword || _prompts.PromptForConfirmation($"Save password to keychain? (associated with '{rootDirectory}')"))
                 CredentialStore.SavePassword(credentialStoreName, password);
         }
         else if (fromLegacyCredentialStore)
@@ -78,13 +88,13 @@ partial class Program
         var addedSecrets = new Dictionary<string, string>();
         while (true)
         {
-            var choice = PromptForChoice(
+            var choice = _prompts.PromptForChoice(
                 "Choose secret parameter to enter value:",
                 options.Select(x => (x, addedSecrets.ContainsKey(x) || existingSecrets.ContainsKey(x) ? $"* {x}" : x)).ToArray());
 
             if (!choice.EqualsAnyOrdinalIgnoreCase(SaveAndExit, DiscardAndExit, DeletePasswordAndExit))
             {
-                addedSecrets[choice] = PromptForSecret(choice);
+                addedSecrets[choice] = _prompts.PromptForSecret(choice);
             }
             else
             {

--- a/src/Fallout.Cli/Program.cs
+++ b/src/Fallout.Cli/Program.cs
@@ -62,12 +62,12 @@ public partial class Program
         // Legacy handlers still living on Program, adapted until they are extracted into command
         // types. Each conversion deletes one line here plus its Program.X.cs partial.
         services.AddSingleton<IFalloutCommand, UpdateCommand>();
+        services.AddSingleton<IFalloutCommand, SecretsCommand>();
 
         // Legacy handlers still living on Program, adapted until they are extracted into command
         // types. Each conversion deletes one line here plus its Program.X.cs partial.
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("cake-convert", CakeConvert));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("cake-clean", CakeClean));
-        services.AddSingleton<IFalloutCommand>(new DelegateCommand("secrets", Secrets));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("GetNextDirectory", GetNextDirectory));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("PopDirectory", PopDirectory));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("PushWithCurrentRootDirectory", PushWithCurrentRootDirectory));

--- a/tests/Fallout.Cli.Tests/Commands/SecretsCommandTests.cs
+++ b/tests/Fallout.Cli.Tests/Commands/SecretsCommandTests.cs
@@ -1,0 +1,22 @@
+using System;
+using Fallout.Cli.Commands;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.Cli.Tests.Commands;
+
+public class SecretsCommandTests
+{
+    [Fact]
+    public void Name_IsSecrets()
+        => new SecretsCommand(new FakeConsolePrompts()).Name.Should().Be("secrets");
+
+    [Fact]
+    public void Execute_WithoutRootDirectory_Throws()
+    {
+        var action = () => new SecretsCommand(new FakeConsolePrompts())
+            .Execute([], rootDirectory: null, buildScript: null);
+
+        action.Should().Throw<Exception>().WithMessage("*No root directory*");
+    }
+}


### PR DESCRIPTION
Part of #392 (one command per PR). Stacked on #394 — merge after it lands.

Lifts `:secrets` (and its `LoadSecrets`/`SaveSecrets` helpers) into `SecretsCommand : IFalloutCommand`, taking `IConsolePrompts` via the constructor. Self-contained. Replaces the `DelegateCommand` adapter; deletes `Program.Secrets.cs`. Name/behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
