### PR TITLE
Convert :cake-convert and :cake-clean to command types (#392)

### DIFF
--- a/src/Fallout.Cli/Commands/CakeCleanCommand.cs
+++ b/src/Fallout.Cli/Commands/CakeCleanCommand.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using Fallout.Cli.Prompts;
+using Fallout.Common;
+using Fallout.Common.IO;
+
+namespace Fallout.Cli.Commands;
+
+/// <summary>
+/// <c>fallout :cake-clean</c>: lists and optionally deletes the <c>*.cake</c> scripts.
+/// </summary>
+public sealed class CakeCleanCommand : IFalloutCommand
+{
+    private readonly IConsolePrompts _prompts;
+
+    public CakeCleanCommand(IConsolePrompts prompts) => _prompts = prompts;
+
+    public string Name => "cake-clean";
+
+    public int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    {
+        var cakeFiles = Program.GetCakeFiles().ToList();
+        Host.Information("Found .cake files:");
+        cakeFiles.ForEach(x => Host.Debug($"  - {x}"));
+
+        if (_prompts.PromptForConfirmation("Delete?"))
+            cakeFiles.ForEach(x => x.DeleteFile());
+
+        return 0;
+    }
+}

--- a/src/Fallout.Cli/Commands/CakeConvertCommand.cs
+++ b/src/Fallout.Cli/Commands/CakeConvertCommand.cs
@@ -51,7 +51,7 @@ public sealed class CakeConvertCommand : IFalloutCommand
         Host.Debug();
 
         if (buildScript == null &&
-            _prompts.PromptForConfirmation("Should a NUKE project be created for better results?"))
+            _prompts.PromptForConfirmation("Should a Fallout project be created for better results?"))
         {
             Program.Setup(args, rootDirectory: null, buildScript: null);
         }

--- a/src/Fallout.Cli/Commands/CakeConvertCommand.cs
+++ b/src/Fallout.Cli/Commands/CakeConvertCommand.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using Fallout.Cli.Prompts;
+using Fallout.Common;
+using Fallout.Common.Execution;
+using Fallout.Common.IO;
+using Fallout.Solutions;
+using Fallout.Common.Utilities;
+using static Fallout.Common.EnvironmentInfo;
+
+namespace Fallout.Cli.Commands;
+
+/// <summary>
+/// <c>fallout :cake-convert</c>: best-effort conversion of <c>*.cake</c> scripts to Fallout C#.
+/// </summary>
+public sealed class CakeConvertCommand : IFalloutCommand
+{
+    private readonly IConsolePrompts _prompts;
+
+    public CakeConvertCommand(IConsolePrompts prompts) => _prompts = prompts;
+
+    public string Name => "cake-convert";
+
+    // The .cake syntax-rewriting helpers (GetCakeFiles/GetCakeConvertedContent/GetCakePackages) and
+    // the shared GetConfiguration/AddOrReplacePackage helpers remain on Program until the #392
+    // collapse PR; GetCakeConvertedContent/GetCakePackages are also exercised directly by tests.
+    public int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    {
+        Program.PrintInfo();
+        Logging.Configure();
+        Telemetry.ConvertCake();
+        ProjectModelTasks.Initialize();
+
+        Host.Warning(
+            new[]
+            {
+                "Converting .cake files is a best effort approach using syntax rewriting.",
+                "Compile errors are to be expected, however, the following elements are currently covered:",
+                "  - Target definitions",
+                "  - Default targets",
+                "  - Parameter declarations",
+                "  - Absolute paths",
+                "  - Globbing patterns",
+                "  - Tool invocations (dotnet CLI, SignTool)",
+                "  - Addin and tool references",
+            }.JoinNewLine());
+
+        Host.Debug();
+        if (!_prompts.PromptForConfirmation("Continue?"))
+            return 0;
+        Host.Debug();
+
+        if (buildScript == null &&
+            _prompts.PromptForConfirmation("Should a NUKE project be created for better results?"))
+        {
+            Program.Setup(args, rootDirectory: null, buildScript: null);
+        }
+
+        var buildScriptFile = WorkingDirectory / Program.CurrentBuildScriptName;
+        var buildProjectFile = buildScriptFile.Exists()
+            ? Program.GetConfiguration(buildScriptFile, evaluate: true)
+                .GetValueOrDefault(Program.BUILD_PROJECT_FILE, defaultValue: null)
+            : null;
+
+        foreach (var cakeFile in Program.GetCakeFiles())
+        {
+            var outputFile = cakeFile.Parent / cakeFile.NameWithoutExtension.Capitalize() + ".cs";
+            var content = Program.GetCakeConvertedContent(cakeFile.ReadAllText());
+            outputFile.WriteAllText(content);
+        }
+
+        if (buildProjectFile != null)
+        {
+            var packages = Program.GetCakeFiles().SelectMany(x => Program.GetCakePackages(x.ReadAllText()));
+            foreach (var package in packages)
+                Program.AddOrReplacePackage(package.Id, package.Version, package.Type, buildProjectFile);
+        }
+
+        return 0;
+    }
+}

--- a/src/Fallout.Cli/Program.Cake.cs
+++ b/src/Fallout.Cli/Program.Cake.cs
@@ -19,74 +19,10 @@ partial class Program
 {
     public const string CAKE_FILE_PATTERN = "*.cake";
 
-    public static int CakeConvert(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-    {
-        PrintInfo();
-        Logging.Configure();
-        Telemetry.ConvertCake();
-        ProjectModelTasks.Initialize();
-
-        Host.Warning(
-            new[]
-            {
-                "Converting .cake files is a best effort approach using syntax rewriting.",
-                "Compile errors are to be expected, however, the following elements are currently covered:",
-                "  - Target definitions",
-                "  - Default targets",
-                "  - Parameter declarations",
-                "  - Absolute paths",
-                "  - Globbing patterns",
-                "  - Tool invocations (dotnet CLI, SignTool)",
-                "  - Addin and tool references",
-            }.JoinNewLine());
-
-        Host.Debug();
-        if (!PromptForConfirmation("Continue?"))
-            return 0;
-        Host.Debug();
-
-        if (buildScript == null &&
-            PromptForConfirmation("Should a NUKE project be created for better results?"))
-        {
-            Setup(args, rootDirectory: null, buildScript: null);
-        }
-
-        var buildScriptFile = WorkingDirectory / CurrentBuildScriptName;
-        var buildProjectFile = buildScriptFile.Exists()
-            ? GetConfiguration(buildScriptFile, evaluate: true)
-                .GetValueOrDefault(BUILD_PROJECT_FILE, defaultValue: null)
-            : null;
-
-        foreach (var cakeFile in GetCakeFiles())
-        {
-            var outputFile = cakeFile.Parent / cakeFile.NameWithoutExtension.Capitalize() + ".cs";
-            var content = GetCakeConvertedContent(cakeFile.ReadAllText());
-            outputFile.WriteAllText(content);
-        }
-
-        if (buildProjectFile != null)
-        {
-            var packages = GetCakeFiles().SelectMany(x => GetCakePackages(x.ReadAllText()));
-            foreach (var package in packages)
-                AddOrReplacePackage(package.Id, package.Version, package.Type, buildProjectFile);
-        }
-
-        return 0;
-    }
-
-    public static int CakeClean(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-    {
-        var cakeFiles = GetCakeFiles().ToList();
-        Host.Information("Found .cake files:");
-        cakeFiles.ForEach(x => Host.Debug($"  - {x}"));
-
-        if (PromptForConfirmation("Delete?"))
-            cakeFiles.ForEach(x => x.DeleteFile());
-
-        return 0;
-    }
-
-    private static IEnumerable<AbsolutePath> GetCakeFiles()
+    // Residual after the :cake-convert/:cake-clean commands moved to CakeConvertCommand/
+    // CakeCleanCommand: these .cake syntax-rewriting helpers stay on Program until the #392 collapse
+    // PR (GetCakeConvertedContent/GetCakePackages are exercised directly by tests).
+    internal static IEnumerable<AbsolutePath> GetCakeFiles()
     {
         return (TryGetRootDirectoryFrom(WorkingDirectory) ?? WorkingDirectory).GlobFiles($"**/{CAKE_FILE_PATTERN}");
     }

--- a/src/Fallout.Cli/Program.cs
+++ b/src/Fallout.Cli/Program.cs
@@ -66,8 +66,11 @@ public partial class Program
 
         // Legacy handlers still living on Program, adapted until they are extracted into command
         // types. Each conversion deletes one line here plus its Program.X.cs partial.
-        services.AddSingleton<IFalloutCommand>(new DelegateCommand("cake-convert", CakeConvert));
-        services.AddSingleton<IFalloutCommand>(new DelegateCommand("cake-clean", CakeClean));
+        services.AddSingleton<IFalloutCommand, CakeConvertCommand>();
+        services.AddSingleton<IFalloutCommand, CakeCleanCommand>();
+
+        // Legacy handlers still living on Program, adapted until they are extracted into command
+        // types. Each conversion deletes one line here plus its Program.X.cs partial.
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("GetNextDirectory", GetNextDirectory));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("PopDirectory", PopDirectory));
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("PushWithCurrentRootDirectory", PushWithCurrentRootDirectory));

--- a/tests/Fallout.Cli.Tests/Commands/CakeCleanCommandTests.cs
+++ b/tests/Fallout.Cli.Tests/Commands/CakeCleanCommandTests.cs
@@ -1,0 +1,21 @@
+using Fallout.Cli.Commands;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.Cli.Tests.Commands;
+
+public class CakeCleanCommandTests
+{
+    [Fact]
+    public void Name_IsCakeClean()
+        => new CakeCleanCommand(new FakeConsolePrompts()).Name.Should().Be("cake-clean");
+
+    [Fact]
+    public void Execute_WhenDeletionDeclined_ReturnsZeroAndDeletesNothing()
+    {
+        // ConfirmationResult = false → the "Delete?" prompt is declined, so no .cake files are removed.
+        var prompts = new FakeConsolePrompts { ConfirmationResult = false };
+
+        new CakeCleanCommand(prompts).Execute([], rootDirectory: null, buildScript: null).Should().Be(0);
+    }
+}


### PR DESCRIPTION
Part of #392. Stacked on #394 — merge after it lands.

Per the locked decision, cake's two verbs become discrete commands with names preserved: `CakeConvertCommand` (`cake-convert`) and `CakeCleanCommand` (`cake-clean`), both taking `IConsolePrompts` via the constructor. The `.cake` rewriting helpers (`GetCakeFiles`/`GetCakeConvertedContent`/`GetCakePackages`) stay on `Program` as `internal` residual (exercised by the Cake tests) until the collapse PR (#404). Replaces both `DelegateCommand` adapters.

### Verification
`Fallout.Cli.Tests` 30 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
