### PR TITLE
Encapsulate build/component members with explicit visibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -149,3 +149,15 @@ resharper_redundant_if_else_block_highlighting = none
 
 # If we use explicit property names in anonymous types, we do that on purpose.
 resharper_redundant_anonymous_type_property_name_highlighting = none
+
+####################################################################
+## Dogfood build scripts (build/)
+####################################################################
+
+# The build project is our own dogfood console app, not shipped API. Favour
+# convenience over ceremony there: explicit accessibility modifiers are optional,
+# so build targets/properties/fields can stay terse. Relax the rule that the
+# global [*.cs] section enforces as an error — both Roslyn (IDE0040) and ReSharper
+# read this key, so a silent severity stops either from flagging build scripts.
+[build/**.cs]
+dotnet_style_require_accessibility_modifiers = omit_if_default:silent

--- a/src/Fallout.Build/IFalloutBuild.cs
+++ b/src/Fallout.Build/IFalloutBuild.cs
@@ -51,7 +51,7 @@ public interface IFalloutBuild
     bool Continue { get; }
     Partition Partition { get; }
 
-    public T TryGetValue<T>(Expression<Func<T>> parameterExpression) where T : class;
+    T TryGetValue<T>(Expression<Func<T>> parameterExpression) where T : class;
 
-    public T TryGetValue<T>(Expression<Func<object>> parameterExpression);
+    T TryGetValue<T>(Expression<Func<object>> parameterExpression);
 }

--- a/src/Fallout.Components/ICreateGitHubRelease.cs
+++ b/src/Fallout.Components/ICreateGitHubRelease.cs
@@ -16,7 +16,7 @@ namespace Fallout.Components;
 [ParameterPrefix(GitHubRelease)]
 public interface ICreateGitHubRelease : IHasGitRepository, IHasChangelog
 {
-    public const string GitHubRelease = nameof(GitHubRelease);
+    const string GitHubRelease = nameof(GitHubRelease);
 
     [Parameter] [Secret] string GitHubToken => TryGetValue(() => GitHubToken) ?? GitHubActions.Instance?.Token;
 

--- a/src/Fallout.Components/IHasTwitterCredentials.cs
+++ b/src/Fallout.Components/IHasTwitterCredentials.cs
@@ -7,7 +7,7 @@ namespace Fallout.Components;
 [ParameterPrefix(Twitter)]
 public interface IHasTwitterCredentials : IFalloutBuild
 {
-    public const string Twitter = nameof(Twitter);
+    const string Twitter = nameof(Twitter);
 
     [Parameter] [Secret] string ConsumerKey => TryGetValue(() => ConsumerKey);
     [Parameter] [Secret] string ConsumerSecret => TryGetValue(() => ConsumerSecret);

--- a/src/Fallout.Components/ISignPackages.cs
+++ b/src/Fallout.Components/ISignPackages.cs
@@ -43,9 +43,9 @@ namespace Fallout.Components;
 [ParameterPrefix(SignPath)]
 public interface ISignPackages : IFalloutBuild
 {
-    public const string SignPath = nameof(SignPath);
+    const string SignPath = nameof(SignPath);
 
-    public record SignPathSettings(
+    record SignPathSettings(
         string OrganizationId,
         string ProjectSlug,
         string PolicySlug);

--- a/src/Fallout.Tooling/ToolTasks.ToolPath.cs
+++ b/src/Fallout.Tooling/ToolTasks.ToolPath.cs
@@ -120,9 +120,9 @@ public class NuGetToolAttribute : ToolAttribute
 public interface IToolOptionsWithFramework
 {
 #if NET6_0_OR_GREATER
-    public string Framework => ((IOptions)this).Get<string>(() => Framework);
+    string Framework => ((IOptions)this).Get<string>(() => Framework);
 #else
-    public string Framework { get; }
+    string Framework { get; }
 #endif
 }
 

--- a/tests/Consumers/Fallout.Consumer.Local/Build.cs
+++ b/tests/Consumers/Fallout.Consumer.Local/Build.cs
@@ -6,13 +6,14 @@ using Fallout.Common;
 using Fallout.Common.IO;
 using Fallout.Solutions;  // was Fallout.Common.ProjectModel; — renamed in #254 (persistence layering + namespace cleanup)
 
-class Build : FalloutBuild
+internal class Build : FalloutBuild
 {
     public static int Main() => Execute<Build>(x => x.Default);
 
-    [Solution] readonly Solution Solution;
+    [Solution]
+    private readonly Solution Solution;
 
-    Target Default => _ => _
+    private Target Default => _ => _
         .Executes(() =>
         {
             Serilog.Log.Information("hello from fallout consumer (local source)");

--- a/tests/Consumers/Fallout.Consumer.NuGet/Build.cs
+++ b/tests/Consumers/Fallout.Consumer.NuGet/Build.cs
@@ -7,13 +7,14 @@ using Fallout.Common;
 using Fallout.Common.IO;
 using Fallout.Common.ProjectModel;
 
-class Build : FalloutBuild
+internal class Build : FalloutBuild
 {
     public static int Main() => Execute<Build>(x => x.Default);
 
-    [Solution] readonly Solution Solution;
+    [Solution]
+    private readonly Solution Solution;
 
-    Target Default => _ => _
+    private Target Default => _ => _
         .Executes(() =>
         {
             Serilog.Log.Information("hello from fallout consumer (pinned nuget 11.0.8)");

--- a/tests/Consumers/Nuke.Consumer/Build.cs
+++ b/tests/Consumers/Nuke.Consumer/Build.cs
@@ -16,13 +16,14 @@ using Nuke.Components;
 // Including it here keeps the rest of the file NUKE-shape.
 using Target = Fallout.Common.Target;
 
-class Build : NukeBuild
+internal class Build : NukeBuild
 {
     public static int Main() => Execute<Build>(x => x.Default);
 
-    [Solution] readonly Solution Solution;
+    [Solution]
+    private readonly Solution Solution;
 
-    Target Default => _ => _
+    private Target Default => _ => _
         .Executes(() =>
         {
             Serilog.Log.Information("hello from nuke consumer (via shim)");

--- a/tests/Fallout.Build.Tests/DefaultInterfaceExecutionTest.cs
+++ b/tests/Fallout.Build.Tests/DefaultInterfaceExecutionTest.cs
@@ -137,7 +137,7 @@ public class DefaultInterfaceExecutionTest
     {
         [Parameter] string StringParameter => TryGetValue(() => StringParameter);
 
-        public Target HelloWorld => _ => _
+        Target HelloWorld => _ => _
             .Requires(() => StringParameter)
             .Executes(() =>
             {
@@ -185,28 +185,32 @@ public class DefaultInterfaceExecutionTest
 
     private interface ITestBuild
     {
-        public string Description => DefaultInterfaceExecutionTest.Description;
-        public Action Action => DefaultInterfaceExecutionTest.Action;
-        public Expression<Func<bool>> Requirement => DefaultInterfaceExecutionTest.Requirement;
-        public Func<bool> StaticCondition => DefaultInterfaceExecutionTest.StaticCondition;
-        public Func<bool> DynamicCondition => DefaultInterfaceExecutionTest.DynamicCondition;
+        string Description => DefaultInterfaceExecutionTest.Description;
 
-        public Target A => _ => _
+        Action Action => DefaultInterfaceExecutionTest.Action;
+
+        Expression<Func<bool>> Requirement => DefaultInterfaceExecutionTest.Requirement;
+
+        Func<bool> StaticCondition => DefaultInterfaceExecutionTest.StaticCondition;
+
+        Func<bool> DynamicCondition => DefaultInterfaceExecutionTest.DynamicCondition;
+
+        Target A => _ => _
             .Description(Description)
             .Requires(Requirement)
             .Executes(Action);
 
-        public Target B => _ => _
+        Target B => _ => _
             .WhenSkipped(DependencyBehavior.Execute)
             .OnlyWhenStatic(StaticCondition)
             .DependsOn(D)
             .DependentFor(C);
 
-        public Target C => _ => _
+        Target C => _ => _
             .Triggers(B)
             .TriggeredBy(D);
 
-        public Target D => _ => _
+        Target D => _ => _
             .WhenSkipped(DependencyBehavior.Skip)
             .OnlyWhenDynamic(DynamicCondition)
             .After(B)
@@ -215,13 +219,13 @@ public class DefaultInterfaceExecutionTest
 
     private interface IInheritedTestBuild : ITestBuild
     {
-        public Target F => _ => _
+        Target F => _ => _
             .Triggers<ITestBuild>(x => x.A);
     }
 
     private interface IDuplicatedTargetBuild
     {
-        public Target D => _ => _
+        Target D => _ => _
             .Executes(() => { });
     }
 

--- a/tests/Nuke.Common.Shim.Tests/SampleConsumerBuild.cs
+++ b/tests/Nuke.Common.Shim.Tests/SampleConsumerBuild.cs
@@ -25,19 +25,25 @@ namespace Nuke.Common.Shim.Tests;
 [GlobbingOptions(Fallout.Common.IO.GlobbingCaseSensitivity.CaseInsensitive)]
 public abstract class SampleConsumerBuild : NukeBuild, INukeBuild
 {
-    [Parameter("Configuration to build")] readonly string Configuration;
-    [Parameter] readonly bool RunTests;
-    [Secret] readonly string NuGetApiKey;
-    [Solution] readonly Fallout.Solutions.Solution Solution;
-    [Solution("path/to/explicit.slnx")] readonly Fallout.Solutions.Solution ExplicitSolution;
-    [GitRepository] readonly Fallout.Common.Git.GitRepository GitRepository;
+    [Parameter("Configuration to build")]
+    private readonly string Configuration;
+    [Parameter]
+    private readonly bool RunTests;
+    [Secret]
+    private readonly string NuGetApiKey;
+    [Solution]
+    private readonly Fallout.Solutions.Solution Solution;
+    [Solution("path/to/explicit.slnx")]
+    private readonly Fallout.Solutions.Solution ExplicitSolution;
+    [GitRepository]
+    private readonly Fallout.Common.Git.GitRepository GitRepository;
 
     // CI-host shims expose only the static `Instance` accessor. Consumers can
     // still chain into instance members because the returned type is canonical.
     // Field-injection patterns like `[CI] readonly GitHubActions GitHubActions`
     // are intentionally NOT supported — those need `fallout-migrate` to flip
     // the type reference to canonical.
-    void TouchCiHostShims()
+    private void TouchCiHostShims()
     {
         _ = GitHubActions.Instance?.Workflow;
         _ = AzurePipelines.Instance?.AgentName;
@@ -49,7 +55,7 @@ public abstract class SampleConsumerBuild : NukeBuild, INukeBuild
     // DelegateDisposable shim re-exposes the static factories. Consumer
     // usage stays canonical-typed at runtime (the factories return
     // canonical IDisposable instances).
-    void TouchDelegateDisposableShim()
+    private void TouchDelegateDisposableShim()
     {
         using var bracket = DelegateDisposable.CreateBracket(
             setup: () => { },


### PR DESCRIPTION
Split out of #393 per @dennisdoomen's review that the combined PR had grown too large.

## What this does
Makes accessibility explicit on **shipped and tested** surface — no behavioural change — while deliberately **exempting the dogfood `build/` folder** instead of encapsulating it:

- **Components** (`IFalloutBuild`, `ICreateGitHubRelease`, `IHasTwitterCredentials`, `ISignPackages`, `IToolOptionsWithFramework`): drop the redundant `public` from interface members (implicitly public — matches `for_non_interface_members`).
- **Consumer/sample builds under `tests/`** + `DefaultInterfaceExecutionTest`: explicit `internal`/`private`.
- **`build/` folder: exempted from the rule.** A new `[build/**.cs]` section in `.editorconfig` relaxes `dotnet_style_require_accessibility_modifiers`, so build scripts stay terse (convenience over ceremony — Dennis's "never bothered with visibility in builds"). The explicit modifiers an earlier revision added under `build/` are dropped to match.

## Why exempt build/ rather than encapsulate it
The build project is our own dogfood console app, not shipped API. Forcing explicit accessibility there fights the convenience that makes build scripts pleasant to write, and those modifiers "often just get dropped" anyway. Exempting the folder once in `.editorconfig` is more durable than re-adding modifiers commit by commit.

## Verification
Rebased onto `main` (was conflicting). `dotnet build build/_build.csproj` succeeds, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)