### PR TITLE
Fix CS1734 warning in TransitionShimGenerator attribute XML doc

### DIFF
--- a/src/Fallout.SourceGenerators/TransitionShimGenerator.cs
+++ b/src/Fallout.SourceGenerators/TransitionShimGenerator.cs
@@ -670,8 +670,8 @@ public sealed class TransitionShimGenerator : IIncrementalGenerator
         /// <summary>
         /// Marks the consuming assembly as a transition-shim project. The
         /// TransitionShimGenerator walks referenced Fallout.* assemblies and emits
-        /// shim types under <paramref name="toNamespacePrefix"/> mirroring the
-        /// public types whose namespace begins with <paramref name="fromNamespacePrefix"/>.
+        /// shim types under <c>toNamespacePrefix</c> mirroring the
+        /// public types whose namespace begins with <c>fromNamespacePrefix</c>.
         /// </summary>
         [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = true)]
         internal sealed class ShimAllPublicTypesUnderAttribute : System.Attribute

--- a/tests/Fallout.SourceGenerators.Tests/TransitionShimGeneratorTest.EmitsShimsForEachKindAndSkipsHardTier#ShimAllPublicTypesUnderAttribute.g.verified.cs
+++ b/tests/Fallout.SourceGenerators.Tests/TransitionShimGeneratorTest.EmitsShimsForEachKindAndSkipsHardTier#ShimAllPublicTypesUnderAttribute.g.verified.cs
@@ -6,8 +6,8 @@ namespace Fallout.Migrate.Shims;
 /// <summary>
 /// Marks the consuming assembly as a transition-shim project. The
 /// TransitionShimGenerator walks referenced Fallout.* assemblies and emits
-/// shim types under <paramref name="toNamespacePrefix"/> mirroring the
-/// public types whose namespace begins with <paramref name="fromNamespacePrefix"/>.
+/// shim types under <c>toNamespacePrefix</c> mirroring the
+/// public types whose namespace begins with <c>fromNamespacePrefix</c>.
 /// </summary>
 [System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = true)]
 internal sealed class ShimAllPublicTypesUnderAttribute : System.Attribute


### PR DESCRIPTION
Fixes #414.

## Problem

The generated `ShimAllPublicTypesUnderAttribute` class uses `<paramref>` tags in its class-level XML doc comment to reference constructor parameters. At the type level, `<paramref>` can only reference type parameters (generic params), not constructor params — causing CS1734.

## Fix

Replace `<paramref name="toNamespacePrefix"/>` and `<paramref name="fromNamespacePrefix"/>` with `<c>toNamespacePrefix</c>` and `<c>fromNamespacePrefix</c>` respectively in the attribute's XML doc comment (raw string in `TransitionShimGenerator.cs`).