### PR TITLE
Fix MSBuild tool resolve for VS2026

### DIFF
--- a/src/Fallout.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
+++ b/src/Fallout.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
@@ -64,7 +64,6 @@ public static class MSBuildToolPathResolver
         VisualStudioEdition edition,
         SpecialFolders specialFolder)
     {
-        var versionDirectoryName = version.ToString().TrimStart("VS");
         var basePath = Path.Combine(
             EnvironmentInfo.SpecialFolder(specialFolder).NotNull(),
             $@"Microsoft Visual Studio\{GetVisualStudioFolder(version)}\{edition}\MSBuild\{GetVersionFolder(version)}\Bin");

--- a/src/Fallout.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
+++ b/src/Fallout.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
@@ -35,12 +35,10 @@ public static class MSBuildToolPathResolver
         var instances = new List<Instance>();
 
         instances.AddRange(
-            from version in new[] { MSBuildVersion.VS2022, MSBuildVersion.VS2019, MSBuildVersion.VS2017 }
+            from version in new[] { MSBuildVersion.VS2026, MSBuildVersion.VS2022, MSBuildVersion.VS2019, MSBuildVersion.VS2017 }
             from platform in s_platforms
             from edition in typeof(VisualStudioEdition).GetEnumValues<VisualStudioEdition>()
-            let folder = version == MSBuildVersion.VS2022 && edition != VisualStudioEdition.BuildTools
-                ? SpecialFolders.ProgramFiles
-                : SpecialFolders.ProgramFilesX86
+            let folder = GetProgramFilesFolder(version, edition)
             select GetFromVs2017Instance(version, platform, edition, folder));
 
         instances.AddRange(
@@ -69,7 +67,7 @@ public static class MSBuildToolPathResolver
         var versionDirectoryName = version.ToString().TrimStart("VS");
         var basePath = Path.Combine(
             EnvironmentInfo.SpecialFolder(specialFolder).NotNull(),
-            $@"Microsoft Visual Studio\{versionDirectoryName}\{edition}\MSBuild\{GetVersionFolder(version)}\Bin");
+            $@"Microsoft Visual Studio\{GetVisualStudioFolder(version)}\{edition}\MSBuild\{GetVersionFolder(version)}\Bin");
 
         return new Instance(
             version,
@@ -92,6 +90,34 @@ public static class MSBuildToolPathResolver
                 ? Path.Combine(basePath, "amd64")
                 : basePath);
     }
+
+    private static SpecialFolders GetProgramFilesFolder(MSBuildVersion version, VisualStudioEdition edition)
+    {
+        if (edition == VisualStudioEdition.BuildTools)
+        {
+            return SpecialFolders.ProgramFilesX86;
+        }
+
+        return version switch
+        {
+            MSBuildVersion.VS2013 => SpecialFolders.ProgramFilesX86,
+            MSBuildVersion.VS2015 => SpecialFolders.ProgramFilesX86,
+            MSBuildVersion.VS2017 => SpecialFolders.ProgramFilesX86,
+            MSBuildVersion.VS2019 => SpecialFolders.ProgramFilesX86,
+            // Versions VS2022+ are 64-bit
+            _ => SpecialFolders.ProgramFiles
+        };
+    }
+
+    private static string GetVisualStudioFolder(MSBuildVersion version)
+    {
+        return version switch
+        {
+            MSBuildVersion.VS2026 => "18",
+            _ => version.ToString().TrimStart("VS")
+        };
+    }
+
 
     private static string GetVersionFolder(MSBuildVersion version)
     {

--- a/src/Fallout.Common/Tools/MSBuild/MSBuildVersion.cs
+++ b/src/Fallout.Common/Tools/MSBuild/MSBuildVersion.cs
@@ -9,6 +9,7 @@ namespace Fallout.Common.Tools.MSBuild;
 /// </summary>
 public enum MSBuildVersion
 {
+    VS2026,
     VS2022,
     VS2019,
     VS2017,


### PR DESCRIPTION
This originates from: https://github.com/nuke-build/nuke/pull/1583

Thanks @Kielek

<!-- Keep it terse: one-line summary, then short "what changed" bullets. -->
<!-- Link the issue and summarize it — don't recite it. See docs/agents/issue-and-pr-style.md. -->
<!-- Or let Copilot draft one, then trim it. -->

<!-- This repo merges via rebase only (linear history). Curate your commits into a -->
<!-- clean sequence before final approval — see CONTRIBUTING.md → Merging. -->
