### PR TITLE
Rebrand the global-tool startup banner from NUKE to Fallout

### DIFF
--- a/src/Fallout.Cli/Program.cs
+++ b/src/Fallout.Cli/Program.cs
@@ -39,7 +39,7 @@ public partial class Program
 
     private static void PrintInfo()
     {
-        Host.Information($"NUKE Global Tool 🌐 {typeof(Program).Assembly.GetInformationalText()}");
+        Host.Information($"Fallout Global Tool 🌐 {typeof(Program).Assembly.GetInformationalText()}");
     }
 
     private static AbsolutePath TryGetRootDirectory()


### PR DESCRIPTION
## What

The CLI's startup banner still printed **`NUKE Global Tool 🌐`**:

```
src/Fallout.Cli/Program.cs:42
    Host.Information($"NUKE Global Tool 🌐 {typeof(Program).Assembly.GetInformationalText()}");
```

Changed to `Fallout Global Tool 🌐`.

## Why

A leftover the command/package rebrand missed — #66 renamed the command (`nuke`→`fallout`) and #371 publishes the package as `Fallout.GlobalTools`, but this runtime banner literal was never updated. It's the first line a user sees on every `dotnet fallout` invocation.

## Note for the in-flight CLI refactors

The same literal is currently carried forward (unchanged) by the open refactor PRs:
- #404 (`cli-cmd-collapse`) moves it into `CliConventions.cs` as `ToolBanner`
- #403 (`cli-cmd-navigation`) leaves it in `Program.cs`

Whichever lands first, the string should end up as `Fallout Global Tool 🌐`. Trivial conflict either way — flagging so it isn't silently re-introduced.