### PR TITLE
Add NuGet package analyzer (redundant & conflicting references) with :analyze packages CLI

### DIFF
--- a/fallout.slnx
+++ b/fallout.slnx
@@ -24,6 +24,7 @@
   <Project Path="src\Shims\Nuke.Common\Nuke.Common.csproj" />
   <Project Path="src\Shims\Nuke.Components\Nuke.Components.csproj" />
   <Project Path="src\Fallout.MSBuildTasks\Fallout.MSBuildTasks.csproj" />
+  <Project Path="src\Fallout.NuGet.Analysis\Fallout.NuGet.Analysis.csproj" />
   <Project Path="src\Fallout.ProjectModel\Fallout.ProjectModel.csproj" />
   <Project Path="src\Persistence\Fallout.Persistence.Solution\Fallout.Persistence.Solution.csproj" />
   <Project Path="src\Persistence\Fallout.Solution\Fallout.Solution.csproj" />
@@ -45,6 +46,7 @@
   <Project Path="tests\Fallout.Migrate.Analyzers.Specs\Fallout.Migrate.Analyzers.Specs.csproj" />
   <Project Path="tests\Nuke.Common.Shim.Specs\Nuke.Common.Shim.Specs.csproj" />
   <Project Path="tests\Nuke.Components.Shim.Specs\Nuke.Components.Shim.Specs.csproj" />
+  <Project Path="tests\Fallout.NuGet.Analysis.Specs\Fallout.NuGet.Analysis.Specs.csproj" />
   <Project Path="tests\Fallout.ProjectModel.Specs\Fallout.ProjectModel.Specs.csproj" />
   <Project Path="tests\Fallout.Solution.Specs\Fallout.Solution.Specs.csproj" />
   <Project Path="tests\Fallout.SourceGenerators.Specs\Fallout.SourceGenerators.Specs.csproj" />

--- a/src/Fallout.Cli/Commands/AnalyzeCommand.cs
+++ b/src/Fallout.Cli/Commands/AnalyzeCommand.cs
@@ -28,11 +28,11 @@ internal sealed class AnalyzeCommand : IFalloutCommand
         var subCommand = args.ElementAtOrDefault(0);
         if (!string.Equals(subCommand, "packages", StringComparison.OrdinalIgnoreCase))
         {
-            Host.Error("Usage: fallout :analyze packages [<path>] [--tfm <moniker>] [--severity none|trace|normal|warning|error] [--format table|flat] [--exclude <id>[,<id>...]]");
+            Host.Error("Usage: fallout :analyze packages [<path>] [--tfm <moniker>] [--severity none|trace|normal|warning|error] [--format table|flat] [--conflicts] [--verbose] [--exclude <id>[,<id>...]]");
             return 1;
         }
 
-        if (!TryParseAnalyzeArguments(args.Skip(1).ToArray(), out var path, out var tfm, out var severity, out var format, out var excludes))
+        if (!TryParseAnalyzeArguments(args.Skip(1).ToArray(), out var path, out var tfm, out var severity, out var format, out var showConflicts, out var verbose, out var excludes))
             return 1;
 
         var projectFiles = ResolveProjectFiles(path);
@@ -76,9 +76,9 @@ internal sealed class AnalyzeCommand : IFalloutCommand
         var findings = new PackageAnalyzer().Analyze(analyzed, options);
 
         if (format == OutputFormat.Table)
-            RenderTables(findings, analyzed.Count, restoreMissing);
+            RenderTables(findings, analyzed.Count, restoreMissing, showConflicts, verbose);
         else
-            RenderFlat(findings, severity, analyzed.Count, restoreMissing);
+            RenderFlat(findings, severity, analyzed.Count, restoreMissing, showConflicts);
 
         var failing = severity == LogLevel.Error && findings.Count > 0;
         return failing ? 1 : 0;
@@ -96,12 +96,16 @@ internal sealed class AnalyzeCommand : IFalloutCommand
         out string tfm,
         out LogLevel severity,
         out OutputFormat format,
+        out bool showConflicts,
+        out bool verbose,
         out HashSet<string> excludes)
     {
         path = null;
         tfm = null;
         severity = LogLevel.Warning;
         format = OutputFormat.Table;
+        showConflicts = false;
+        verbose = false;
         excludes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         for (var i = 0; i < args.Length; i++)
@@ -120,6 +124,13 @@ internal sealed class AnalyzeCommand : IFalloutCommand
                 case "--format":
                     if (++i >= args.Length) { Host.Error("--format requires a value."); return false; }
                     if (!TryParseFormat(args[i], out format)) { Host.Error($"Unknown format '{args[i]}' (use table|flat)."); return false; }
+                    break;
+                case "--conflicts":
+                    showConflicts = true;
+                    break;
+                case "--verbose":
+                case "-v":
+                    verbose = true;
                     break;
                 case "--exclude":
                     if (++i >= args.Length) { Host.Error("--exclude requires a value."); return false; }
@@ -216,12 +227,11 @@ internal sealed class AnalyzeCommand : IFalloutCommand
                filePath.Contains($"{Path.AltDirectorySeparatorChar}{segment}{Path.AltDirectorySeparatorChar}");
     }
 
-    private static void RenderTables(IReadOnlyList<Finding> findings, int projectCount, int restoreMissing)
+    private static void RenderTables(IReadOnlyList<Finding> findings, int projectCount, int restoreMissing, bool showConflicts, bool verbose)
     {
-        var redundant = findings.Where(x => x.Kind != FindingKind.VersionConflict)
-            .OrderBy(x => x.Project).ThenBy(x => x.PackageId).ToList();
+        var redundant = findings.Where(x => x.Kind != FindingKind.VersionConflict).ToList();
         var conflicts = findings.Where(x => x.Kind == FindingKind.VersionConflict)
-            .OrderBy(x => x.PackageId).ToList();
+            .OrderBy(x => x.PackageId, StringComparer.OrdinalIgnoreCase).ToList();
 
         if (findings.Count == 0)
         {
@@ -232,58 +242,67 @@ internal sealed class AnalyzeCommand : IFalloutCommand
         }
 
         if (redundant.Count > 0)
-        {
-            var table = new Table { Border = TableBorder.Rounded, Title = new TableTitle("[bold]Redundant package references[/]") };
-            table.AddColumn("Project");
-            table.AddColumn("TFM");
-            table.AddColumn("Package");
-            table.AddColumn("Version");
-            table.AddColumn("Action");
-            table.AddColumn("Provided by");
+            RenderRedundantTree(redundant);
 
-            foreach (var finding in redundant)
-            {
-                var action = finding.SafeToRemove ? "[green]remove[/]" : "[yellow]review[/]";
-                var via = finding.Kind == FindingKind.RedundantViaProject ? "[blue]proj[/]" : "[grey]pkg[/]";
-                table.AddRow(
-                    Markup.Escape(finding.Project ?? string.Empty),
-                    Markup.Escape(finding.TargetFramework ?? string.Empty),
-                    Markup.Escape(finding.PackageId ?? string.Empty),
-                    Markup.Escape(finding.ResolvedVersion ?? string.Empty),
-                    action,
-                    $"{via} {Markup.Escape(string.Join(", ", finding.Providers))}");
-            }
+        if (showConflicts && conflicts.Count > 0)
+            RenderConflictsTable(conflicts, verbose);
 
-            AnsiConsole.Write(table);
-        }
-
-        if (conflicts.Count > 0)
-        {
-            var table = new Table { Border = TableBorder.Rounded, Title = new TableTitle("[bold]Version conflicts[/]") };
-            table.AddColumn("Package");
-            table.AddColumn("Resolved versions (projects)");
-
-            foreach (var finding in conflicts)
-                table.AddRow(Markup.Escape(finding.PackageId ?? string.Empty), Markup.Escape(ConflictBreakdown(finding)));
-
-            AnsiConsole.Write(table);
-        }
-
+        var conflictHint = !showConflicts && conflicts.Count > 0
+            ? " [grey](run with --conflicts to list them)[/]"
+            : string.Empty;
         AnsiConsole.MarkupLine(
-            $"[bold]Summary:[/] [yellow]{redundant.Count}[/] redundant, [yellow]{conflicts.Count}[/] conflict(s) across {projectCount} target(s)." +
+            $"[bold]Summary:[/] [yellow]{redundant.Count}[/] redundant reference(s), [yellow]{conflicts.Count}[/] version conflict(s) across {projectCount} target(s)." +
+            conflictHint +
             (restoreMissing > 0 ? $" [grey]({restoreMissing} skipped — not restored)[/]" : string.Empty));
     }
 
-    private static string ConflictBreakdown(Finding finding)
+    private static void RenderRedundantTree(IReadOnlyList<Finding> redundant)
     {
-        // Finding.Detail looks like "<id> resolves to multiple versions: 3.0.0 (A, B); 4.0.0 (C)."
-        var detail = finding.Detail ?? string.Empty;
-        var marker = detail.IndexOf(": ", StringComparison.Ordinal);
-        var body = marker >= 0 ? detail.Substring(marker + 2).TrimEnd('.') : detail;
-        return string.Join("\n", body.Split("; "));
+        var tree = new Tree("[bold]Redundant package references[/]");
+
+        var groups = redundant
+            .GroupBy(x => (Project: x.Project ?? string.Empty, Tfm: x.TargetFramework ?? string.Empty))
+            .OrderBy(x => x.Key.Project, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(x => x.Key.Tfm, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var group in groups)
+        {
+            var node = tree.AddNode($"[bold]{Markup.Escape(group.Key.Project)}[/] [grey]({Markup.Escape(group.Key.Tfm)})[/]");
+
+            var width = group.Max(x => (x.PackageId ?? string.Empty).Length);
+            foreach (var finding in group.OrderBy(x => x.PackageId, StringComparer.OrdinalIgnoreCase))
+            {
+                var action = finding.SafeToRemove ? "[green]remove[/]" : "[yellow]review[/]";
+                var via = finding.Kind == FindingKind.RedundantViaProject ? "[blue]proj[/]" : "[grey]pkg [/]";
+                var package = Markup.Escape((finding.PackageId ?? string.Empty).PadRight(width));
+                var version = Markup.Escape(finding.ResolvedVersion ?? string.Empty);
+                var providers = Markup.Escape(string.Join(", ", finding.Providers));
+                node.AddNode($"{action}  {package}  [grey]{version}[/]  [grey]←[/] {via} {providers}");
+            }
+        }
+
+        AnsiConsole.Write(tree);
     }
 
-    private static void RenderFlat(IReadOnlyList<Finding> findings, LogLevel severity, int projectCount, int restoreMissing)
+    private static void RenderConflictsTable(IReadOnlyList<Finding> conflicts, bool verbose)
+    {
+        var table = new Table { Border = TableBorder.Rounded, Title = new TableTitle("[bold]Version conflicts[/]") };
+        table.AddColumn("Package");
+        table.AddColumn(verbose ? "Resolved versions (projects)" : "Resolved versions");
+
+        foreach (var finding in conflicts)
+        {
+            var cell = verbose
+                ? string.Join("\n", finding.ConflictVersions.Select(v => $"{v.Version} ({string.Join(", ", v.Projects)})"))
+                : string.Join("  ·  ", finding.ConflictVersions.Select(v => $"{v.Version} ×{v.Projects.Count}"));
+
+            table.AddRow(Markup.Escape(finding.PackageId ?? string.Empty), Markup.Escape(cell));
+        }
+
+        AnsiConsole.Write(table);
+    }
+
+    private static void RenderFlat(IReadOnlyList<Finding> findings, LogLevel severity, int projectCount, int restoreMissing, bool showConflicts)
     {
         void Emit(string text)
         {
@@ -314,11 +333,15 @@ internal sealed class AnalyzeCommand : IFalloutCommand
             Emit($"[{finding.Project} ({finding.TargetFramework})] {finding.PackageId} {finding.ResolvedVersion} — {marker}. {finding.Detail}");
         }
 
-        foreach (var finding in conflicts.OrderBy(x => x.PackageId))
-            Emit($"[version conflict] {finding.Detail}");
+        if (showConflicts)
+        {
+            foreach (var finding in conflicts.OrderBy(x => x.PackageId))
+                Emit($"[version conflict] {finding.Detail}");
+        }
 
         Host.Information(
-            $"Summary: {redundant.Count} redundant reference(s), {conflicts.Count} version conflict(s) across {projectCount} target(s).");
+            $"Summary: {redundant.Count} redundant reference(s), {conflicts.Count} version conflict(s) across {projectCount} target(s)." +
+            (!showConflicts && conflicts.Count > 0 ? " (run with --conflicts to list them)" : string.Empty));
         if (restoreMissing > 0)
             Host.Information($"({restoreMissing} project(s) skipped — not restored.)");
     }

--- a/src/Fallout.Cli/Commands/AnalyzeCommand.cs
+++ b/src/Fallout.Cli/Commands/AnalyzeCommand.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Fallout.Common;
+using Fallout.Common.IO;
+using Fallout.NuGet.Analysis;
+
+namespace Fallout.Cli.Commands;
+
+/// <summary>
+/// <c>fallout :analyze packages</c>: reads the post-restore <c>project.assets.json</c> graph and
+/// reports redundant and conflicting NuGet package references. <c>:analyze</c> is a command
+/// namespace so future analyzers slot in alongside.
+/// </summary>
+internal sealed class AnalyzeCommand : IFalloutCommand
+{
+    public string Name => "analyze";
+
+    public Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+        => Task.FromResult(Execute(args));
+
+    private static int Execute(string[] args)
+    {
+        var subCommand = args.ElementAtOrDefault(0);
+        if (!string.Equals(subCommand, "packages", StringComparison.OrdinalIgnoreCase))
+        {
+            Host.Error("Usage: fallout :analyze packages [<path>] [--tfm <moniker>] [--severity none|trace|normal|warning|error] [--exclude <id>[,<id>...]]");
+            return 1;
+        }
+
+        if (!TryParseAnalyzeArguments(args.Skip(1).ToArray(), out var path, out var tfm, out var severity, out var excludes))
+            return 1;
+
+        var projectFiles = ResolveProjectFiles(path);
+        if (projectFiles == null)
+            return 1;
+
+        var analyzed = new List<AnalyzedProject>();
+        var restoreMissing = 0;
+        foreach (var projectFile in projectFiles)
+        {
+            var assetsFile = ProjectAssetsReader.FindAssetsFile(projectFile);
+            if (assetsFile == null)
+            {
+                restoreMissing++;
+                Host.Verbose($"Skipping {Path.GetFileName(projectFile)} — no obj/project.assets.json (run 'dotnet restore').");
+                continue;
+            }
+
+            try
+            {
+                analyzed.AddRange(ProjectAssetsReader.Read(assetsFile));
+            }
+            catch (Exception exception)
+            {
+                Host.Warning($"Could not read assets for {Path.GetFileName(projectFile)}: {exception.Message}");
+            }
+        }
+
+        if (analyzed.Count == 0)
+        {
+            Host.Warning(restoreMissing > 0
+                ? $"No restored projects found ({restoreMissing} project(s) need 'dotnet restore')."
+                : "No analyzable projects found.");
+            return 0;
+        }
+
+        var options = new AnalyzerOptions { TargetFramework = tfm };
+        foreach (var exclude in excludes)
+            options.ExcludedPackageIds.Add(exclude);
+
+        var findings = new PackageAnalyzer().Analyze(analyzed, options);
+
+        Report(findings, severity, analyzed.Count, restoreMissing);
+
+        var failing = severity == LogLevel.Error && findings.Count > 0;
+        return failing ? 1 : 0;
+    }
+
+    private static bool TryParseAnalyzeArguments(
+        string[] args,
+        out string path,
+        out string tfm,
+        out LogLevel severity,
+        out HashSet<string> excludes)
+    {
+        path = null;
+        tfm = null;
+        severity = LogLevel.Warning;
+        excludes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            switch (arg.ToLowerInvariant())
+            {
+                case "--tfm":
+                    if (++i >= args.Length) { Host.Error("--tfm requires a value."); return false; }
+                    tfm = args[i];
+                    break;
+                case "--severity":
+                    if (++i >= args.Length) { Host.Error("--severity requires a value."); return false; }
+                    if (!TryParseSeverity(args[i], out severity)) { Host.Error($"Unknown severity '{args[i]}'."); return false; }
+                    break;
+                case "--exclude":
+                    if (++i >= args.Length) { Host.Error("--exclude requires a value."); return false; }
+                    foreach (var id in args[i].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                        excludes.Add(id);
+                    break;
+                default:
+                    if (arg.StartsWith("--", StringComparison.Ordinal))
+                    {
+                        Host.Error($"Unknown option '{arg}'.");
+                        return false;
+                    }
+
+                    path = arg;
+                    break;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryParseSeverity(string value, out LogLevel severity)
+    {
+        switch (value.ToLowerInvariant())
+        {
+            case "none": severity = (LogLevel)(-1); return true;
+            case "trace": severity = LogLevel.Trace; return true;
+            case "normal": case "info": case "information": severity = LogLevel.Normal; return true;
+            case "warning": case "warn": severity = LogLevel.Warning; return true;
+            case "error": severity = LogLevel.Error; return true;
+            default: severity = LogLevel.Warning; return false;
+        }
+    }
+
+    private static List<string> ResolveProjectFiles(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return GlobProjects(Directory.GetCurrentDirectory());
+
+        var full = Path.GetFullPath(path);
+
+        if (File.Exists(full) && full.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            return new List<string> { full };
+
+        if (Directory.Exists(full))
+            return GlobProjects(full);
+
+        // .sln / .slnx (or any file): analyze the projects under its directory.
+        if (File.Exists(full))
+            return GlobProjects(Path.GetDirectoryName(full));
+
+        Host.Error($"Path not found: {path}");
+        return null;
+    }
+
+    private static List<string> GlobProjects(string directory)
+    {
+        return Directory.GetFiles(directory, "*.csproj", SearchOption.AllDirectories)
+            .Where(x => !ContainsSegment(x, "obj") && !ContainsSegment(x, "bin"))
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static bool ContainsSegment(string filePath, string segment)
+    {
+        return filePath.Contains($"{Path.DirectorySeparatorChar}{segment}{Path.DirectorySeparatorChar}") ||
+               filePath.Contains($"{Path.AltDirectorySeparatorChar}{segment}{Path.AltDirectorySeparatorChar}");
+    }
+
+    private static void Report(IReadOnlyList<Finding> findings, LogLevel severity, int projectCount, int restoreMissing)
+    {
+        void Emit(string text)
+        {
+            switch (severity)
+            {
+                case LogLevel.Trace: Host.Verbose(text); break;
+                case LogLevel.Normal: Host.Information(text); break;
+                case LogLevel.Warning: Host.Warning(text); break;
+                case LogLevel.Error: Host.Error(text); break;
+                default: break; // none — summary only
+            }
+        }
+
+        var redundant = findings.Where(x => x.Kind != FindingKind.VersionConflict).ToList();
+        var conflicts = findings.Where(x => x.Kind == FindingKind.VersionConflict).ToList();
+
+        if (findings.Count == 0)
+        {
+            Host.Information($"No redundant or conflicting package references found across {projectCount} project/framework target(s).");
+            if (restoreMissing > 0)
+                Host.Information($"({restoreMissing} project(s) were skipped — not restored.)");
+            return;
+        }
+
+        foreach (var finding in redundant.OrderBy(x => x.Project).ThenBy(x => x.PackageId))
+        {
+            var marker = finding.SafeToRemove ? "can be removed" : "might be removed";
+            Emit($"[{finding.Project} ({finding.TargetFramework})] {finding.PackageId} {finding.ResolvedVersion} — {marker}. {finding.Detail}");
+        }
+
+        foreach (var finding in conflicts.OrderBy(x => x.PackageId))
+            Emit($"[version conflict] {finding.Detail}");
+
+        Host.Information(
+            $"Summary: {redundant.Count} redundant reference(s), {conflicts.Count} version conflict(s) across {projectCount} target(s).");
+        if (restoreMissing > 0)
+            Host.Information($"({restoreMissing} project(s) skipped — not restored.)");
+    }
+}

--- a/src/Fallout.Cli/Commands/AnalyzeCommand.cs
+++ b/src/Fallout.Cli/Commands/AnalyzeCommand.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using Fallout.Common;
 using Fallout.Common.IO;
 using Fallout.NuGet.Analysis;
+using Fallout.Solutions;
+using Spectre.Console;
 
 namespace Fallout.Cli.Commands;
 
@@ -26,11 +28,11 @@ internal sealed class AnalyzeCommand : IFalloutCommand
         var subCommand = args.ElementAtOrDefault(0);
         if (!string.Equals(subCommand, "packages", StringComparison.OrdinalIgnoreCase))
         {
-            Host.Error("Usage: fallout :analyze packages [<path>] [--tfm <moniker>] [--severity none|trace|normal|warning|error] [--exclude <id>[,<id>...]]");
+            Host.Error("Usage: fallout :analyze packages [<path>] [--tfm <moniker>] [--severity none|trace|normal|warning|error] [--format table|flat] [--exclude <id>[,<id>...]]");
             return 1;
         }
 
-        if (!TryParseAnalyzeArguments(args.Skip(1).ToArray(), out var path, out var tfm, out var severity, out var excludes))
+        if (!TryParseAnalyzeArguments(args.Skip(1).ToArray(), out var path, out var tfm, out var severity, out var format, out var excludes))
             return 1;
 
         var projectFiles = ResolveProjectFiles(path);
@@ -73,10 +75,19 @@ internal sealed class AnalyzeCommand : IFalloutCommand
 
         var findings = new PackageAnalyzer().Analyze(analyzed, options);
 
-        Report(findings, severity, analyzed.Count, restoreMissing);
+        if (format == OutputFormat.Table)
+            RenderTables(findings, analyzed.Count, restoreMissing);
+        else
+            RenderFlat(findings, severity, analyzed.Count, restoreMissing);
 
         var failing = severity == LogLevel.Error && findings.Count > 0;
         return failing ? 1 : 0;
+    }
+
+    private enum OutputFormat
+    {
+        Table,
+        Flat,
     }
 
     private static bool TryParseAnalyzeArguments(
@@ -84,11 +95,13 @@ internal sealed class AnalyzeCommand : IFalloutCommand
         out string path,
         out string tfm,
         out LogLevel severity,
+        out OutputFormat format,
         out HashSet<string> excludes)
     {
         path = null;
         tfm = null;
         severity = LogLevel.Warning;
+        format = OutputFormat.Table;
         excludes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         for (var i = 0; i < args.Length; i++)
@@ -103,6 +116,10 @@ internal sealed class AnalyzeCommand : IFalloutCommand
                 case "--severity":
                     if (++i >= args.Length) { Host.Error("--severity requires a value."); return false; }
                     if (!TryParseSeverity(args[i], out severity)) { Host.Error($"Unknown severity '{args[i]}'."); return false; }
+                    break;
+                case "--format":
+                    if (++i >= args.Length) { Host.Error("--format requires a value."); return false; }
+                    if (!TryParseFormat(args[i], out format)) { Host.Error($"Unknown format '{args[i]}' (use table|flat)."); return false; }
                     break;
                 case "--exclude":
                     if (++i >= args.Length) { Host.Error("--exclude requires a value."); return false; }
@@ -137,6 +154,16 @@ internal sealed class AnalyzeCommand : IFalloutCommand
         }
     }
 
+    private static bool TryParseFormat(string value, out OutputFormat format)
+    {
+        switch (value.ToLowerInvariant())
+        {
+            case "table": format = OutputFormat.Table; return true;
+            case "flat": case "lines": format = OutputFormat.Flat; return true;
+            default: format = OutputFormat.Table; return false;
+        }
+    }
+
     private static List<string> ResolveProjectFiles(string path)
     {
         if (string.IsNullOrEmpty(path))
@@ -144,18 +171,35 @@ internal sealed class AnalyzeCommand : IFalloutCommand
 
         var full = Path.GetFullPath(path);
 
-        if (File.Exists(full) && full.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
-            return new List<string> { full };
+        if (File.Exists(full))
+        {
+            if (full.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+                return new List<string> { full };
+
+            if (full.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
+                full.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+                return ReadSolutionProjects(full);
+
+            // Some other file — fall back to globbing its directory.
+            return GlobProjects(Path.GetDirectoryName(full));
+        }
 
         if (Directory.Exists(full))
             return GlobProjects(full);
 
-        // .sln / .slnx (or any file): analyze the projects under its directory.
-        if (File.Exists(full))
-            return GlobProjects(Path.GetDirectoryName(full));
-
         Host.Error($"Path not found: {path}");
         return null;
+    }
+
+    private static List<string> ReadSolutionProjects(string solutionFile)
+    {
+        var solution = ((AbsolutePath)solutionFile).ReadSolution();
+        return solution.AllProjects
+            .Select(x => (string)x.Path)
+            .Where(x => x.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            .Where(File.Exists)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 
     private static List<string> GlobProjects(string directory)
@@ -172,7 +216,74 @@ internal sealed class AnalyzeCommand : IFalloutCommand
                filePath.Contains($"{Path.AltDirectorySeparatorChar}{segment}{Path.AltDirectorySeparatorChar}");
     }
 
-    private static void Report(IReadOnlyList<Finding> findings, LogLevel severity, int projectCount, int restoreMissing)
+    private static void RenderTables(IReadOnlyList<Finding> findings, int projectCount, int restoreMissing)
+    {
+        var redundant = findings.Where(x => x.Kind != FindingKind.VersionConflict)
+            .OrderBy(x => x.Project).ThenBy(x => x.PackageId).ToList();
+        var conflicts = findings.Where(x => x.Kind == FindingKind.VersionConflict)
+            .OrderBy(x => x.PackageId).ToList();
+
+        if (findings.Count == 0)
+        {
+            AnsiConsole.MarkupLine($"[green]✓ No redundant or conflicting package references across {projectCount} target(s).[/]");
+            if (restoreMissing > 0)
+                AnsiConsole.MarkupLine($"[grey]{restoreMissing} project(s) skipped — not restored.[/]");
+            return;
+        }
+
+        if (redundant.Count > 0)
+        {
+            var table = new Table { Border = TableBorder.Rounded, Title = new TableTitle("[bold]Redundant package references[/]") };
+            table.AddColumn("Project");
+            table.AddColumn("TFM");
+            table.AddColumn("Package");
+            table.AddColumn("Version");
+            table.AddColumn("Action");
+            table.AddColumn("Provided by");
+
+            foreach (var finding in redundant)
+            {
+                var action = finding.SafeToRemove ? "[green]remove[/]" : "[yellow]review[/]";
+                var via = finding.Kind == FindingKind.RedundantViaProject ? "[blue]proj[/]" : "[grey]pkg[/]";
+                table.AddRow(
+                    Markup.Escape(finding.Project ?? string.Empty),
+                    Markup.Escape(finding.TargetFramework ?? string.Empty),
+                    Markup.Escape(finding.PackageId ?? string.Empty),
+                    Markup.Escape(finding.ResolvedVersion ?? string.Empty),
+                    action,
+                    $"{via} {Markup.Escape(string.Join(", ", finding.Providers))}");
+            }
+
+            AnsiConsole.Write(table);
+        }
+
+        if (conflicts.Count > 0)
+        {
+            var table = new Table { Border = TableBorder.Rounded, Title = new TableTitle("[bold]Version conflicts[/]") };
+            table.AddColumn("Package");
+            table.AddColumn("Resolved versions (projects)");
+
+            foreach (var finding in conflicts)
+                table.AddRow(Markup.Escape(finding.PackageId ?? string.Empty), Markup.Escape(ConflictBreakdown(finding)));
+
+            AnsiConsole.Write(table);
+        }
+
+        AnsiConsole.MarkupLine(
+            $"[bold]Summary:[/] [yellow]{redundant.Count}[/] redundant, [yellow]{conflicts.Count}[/] conflict(s) across {projectCount} target(s)." +
+            (restoreMissing > 0 ? $" [grey]({restoreMissing} skipped — not restored)[/]" : string.Empty));
+    }
+
+    private static string ConflictBreakdown(Finding finding)
+    {
+        // Finding.Detail looks like "<id> resolves to multiple versions: 3.0.0 (A, B); 4.0.0 (C)."
+        var detail = finding.Detail ?? string.Empty;
+        var marker = detail.IndexOf(": ", StringComparison.Ordinal);
+        var body = marker >= 0 ? detail.Substring(marker + 2).TrimEnd('.') : detail;
+        return string.Join("\n", body.Split("; "));
+    }
+
+    private static void RenderFlat(IReadOnlyList<Finding> findings, LogLevel severity, int projectCount, int restoreMissing)
     {
         void Emit(string text)
         {

--- a/src/Fallout.Cli/Fallout.Cli.csproj
+++ b/src/Fallout.Cli/Fallout.Cli.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Fallout.Build\Fallout.Build.csproj" />
     <ProjectReference Include="..\Fallout.Common\Fallout.Common.csproj" />
+    <ProjectReference Include="..\Fallout.NuGet.Analysis\Fallout.NuGet.Analysis.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fallout.Cli/Program.cs
+++ b/src/Fallout.Cli/Program.cs
@@ -58,6 +58,7 @@ internal partial class Program
         services.AddSingleton<IFalloutCommand, TriggerCommand>();
         services.AddSingleton<IFalloutCommand, CompleteCommand>();
         services.AddSingleton<IFalloutCommand, GetConfigurationCommand>();
+        services.AddSingleton<IFalloutCommand, AnalyzeCommand>();
         services.AddSingleton<IFalloutCommand, AddPackageCommand>();
         services.AddSingleton<IFalloutCommand, UpdateCommand>();
         services.AddSingleton<IFalloutCommand, SecretsCommand>();

--- a/src/Fallout.NuGet.Analysis/Fallout.NuGet.Analysis.csproj
+++ b/src/Fallout.NuGet.Analysis/Fallout.NuGet.Analysis.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NuGet.Packaging" />
+  </ItemGroup>
+
+</Project>

--- a/src/Fallout.NuGet.Analysis/Models.cs
+++ b/src/Fallout.NuGet.Analysis/Models.cs
@@ -158,6 +158,23 @@ public sealed class Finding
     /// <summary>The projects/packages that already provide this package.</summary>
     public IReadOnlyList<string> Providers { get; set; } = new List<string>();
 
+    /// <summary>For <see cref="FindingKind.VersionConflict"/>: each resolved version and the projects on it.</summary>
+    public IReadOnlyList<ConflictVersion> ConflictVersions { get; set; } = new List<ConflictVersion>();
+
     /// <summary>A human-readable explanation.</summary>
     public string Detail { get; set; }
+}
+
+/// <summary>One resolved version of a package and the projects that landed on it.</summary>
+public sealed class ConflictVersion
+{
+    public ConflictVersion(string version, IReadOnlyList<string> projects)
+    {
+        Version = version;
+        Projects = projects;
+    }
+
+    public string Version { get; }
+
+    public IReadOnlyList<string> Projects { get; }
 }

--- a/src/Fallout.NuGet.Analysis/Models.cs
+++ b/src/Fallout.NuGet.Analysis/Models.cs
@@ -1,0 +1,163 @@
+using System.Collections.Generic;
+
+namespace Fallout.NuGet.Analysis;
+
+/// <summary>The category of a <see cref="Finding"/>.</summary>
+public enum FindingKind
+{
+    /// <summary>A direct package reference already provided by a referenced project.</summary>
+    RedundantViaProject,
+
+    /// <summary>A direct package reference already pulled in transitively by another package reference.</summary>
+    RedundantViaPackage,
+
+    /// <summary>The same package resolves to different versions across the analyzed projects.</summary>
+    VersionConflict,
+}
+
+/// <summary>Options controlling an analysis run.</summary>
+public sealed class AnalyzerOptions
+{
+    /// <summary>Package ids to ignore entirely (case-insensitive).</summary>
+    public ISet<string> ExcludedPackageIds { get; } =
+        new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>When set, only this target framework (short form, e.g. <c>net10.0</c>) is analyzed.</summary>
+    public string TargetFramework { get; set; }
+}
+
+/// <summary>A single resolved node in a project's dependency graph.</summary>
+public sealed class GraphNode
+{
+    public GraphNode(string key, string name, string version, string type, IReadOnlyList<Edge> dependencies)
+    {
+        Key = key;
+        Name = name;
+        Version = version;
+        Type = type;
+        Dependencies = dependencies;
+    }
+
+    /// <summary>The assets-file node key, e.g. <c>Newtonsoft.Json/13.0.3</c>.</summary>
+    public string Key { get; }
+
+    public string Name { get; }
+
+    /// <summary>The resolved version NuGet settled on for this node.</summary>
+    public string Version { get; }
+
+    /// <summary><c>package</c> or <c>project</c>.</summary>
+    public string Type { get; }
+
+    public IReadOnlyList<Edge> Dependencies { get; }
+
+    public bool IsProject => string.Equals(Type, "project", System.StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary>An edge from one node to a dependency (by name, with the requested version range).</summary>
+public sealed class Edge
+{
+    public Edge(string name, string versionRange)
+    {
+        Name = name;
+        VersionRange = versionRange;
+    }
+
+    public string Name { get; }
+
+    /// <summary>The range the parent requested, e.g. <c>[12.0.1, )</c>.</summary>
+    public string VersionRange { get; }
+}
+
+/// <summary>A direct dependency declared by the project (a <c>PackageReference</c>).</summary>
+public sealed class DirectDependency
+{
+    public DirectDependency(string name, string versionRange, bool autoReferenced, bool privateAssetsAll, string nodeKey)
+    {
+        Name = name;
+        VersionRange = versionRange;
+        AutoReferenced = autoReferenced;
+        PrivateAssetsAll = privateAssetsAll;
+        NodeKey = nodeKey;
+    }
+
+    public string Name { get; }
+
+    /// <summary>The declared range, e.g. <c>[13.0.3, )</c>.</summary>
+    public string VersionRange { get; }
+
+    /// <summary>SDK-implicit reference — cannot be removed from the csproj.</summary>
+    public bool AutoReferenced { get; }
+
+    /// <summary><c>PrivateAssets="all"</c> — does not flow to consumers.</summary>
+    public bool PrivateAssetsAll { get; }
+
+    /// <summary>The resolved graph node this reference maps to (may be <c>null</c> if unresolved).</summary>
+    public string NodeKey { get; }
+}
+
+/// <summary>The analyzable state of one project at one target framework, read from <c>project.assets.json</c>.</summary>
+public sealed class AnalyzedProject
+{
+    public AnalyzedProject(
+        string projectName,
+        string projectPath,
+        string targetFramework,
+        IReadOnlyList<DirectDependency> directPackages,
+        IReadOnlyList<string> directProjectNodeKeys,
+        IReadOnlyDictionary<string, GraphNode> graph)
+    {
+        ProjectName = projectName;
+        ProjectPath = projectPath;
+        TargetFramework = targetFramework;
+        DirectPackages = directPackages;
+        DirectProjectNodeKeys = directProjectNodeKeys;
+        Graph = graph;
+    }
+
+    public string ProjectName { get; }
+
+    public string ProjectPath { get; }
+
+    /// <summary>Short form, e.g. <c>net10.0</c>.</summary>
+    public string TargetFramework { get; }
+
+    public IReadOnlyList<DirectDependency> DirectPackages { get; }
+
+    /// <summary>Graph node keys of the project's direct <c>ProjectReference</c>s.</summary>
+    public IReadOnlyList<string> DirectProjectNodeKeys { get; }
+
+    /// <summary>The resolved dependency graph keyed by node key (<c>Name/Version</c>).</summary>
+    public IReadOnlyDictionary<string, GraphNode> Graph { get; }
+}
+
+/// <summary>A single analyzer finding.</summary>
+public sealed class Finding
+{
+    public FindingKind Kind { get; set; }
+
+    /// <summary>The project the finding applies to (the one carrying the redundant reference).</summary>
+    public string Project { get; set; }
+
+    public string TargetFramework { get; set; }
+
+    public string PackageId { get; set; }
+
+    /// <summary>The resolved version in the graph.</summary>
+    public string ResolvedVersion { get; set; }
+
+    /// <summary>The version declared on the direct reference (redundancy findings only).</summary>
+    public string DeclaredVersion { get; set; }
+
+    /// <summary>
+    /// <c>true</c> when the reference can be removed without changing the resolved version;
+    /// <c>false</c> when removal might lower the resolved version (advisory). Redundancy findings only.
+    /// </summary>
+    public bool SafeToRemove { get; set; }
+
+    /// <summary>The projects/packages that already provide this package.</summary>
+    public IReadOnlyList<string> Providers { get; set; } = new List<string>();
+
+    /// <summary>A human-readable explanation.</summary>
+    public string Detail { get; set; }
+}

--- a/src/Fallout.NuGet.Analysis/PackageAnalyzer.cs
+++ b/src/Fallout.NuGet.Analysis/PackageAnalyzer.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Versioning;
+
+namespace Fallout.NuGet.Analysis;
+
+/// <summary>
+/// The analysis engine. Works purely off the resolved dependency graph(s) produced by
+/// <see cref="ProjectAssetsReader"/>, so it sees exactly what NuGet resolved.
+///
+/// <para>The core rule unifies snitch's two notions of "redundant": a direct package reference
+/// <c>X</c> is redundant when <c>X</c> is reachable in the resolved graph through some
+/// <em>other</em> direct dependency — whether that dependency is a referenced project
+/// (<see cref="FindingKind.RedundantViaProject"/>) or another package
+/// (<see cref="FindingKind.RedundantViaPackage"/>).</para>
+/// </summary>
+public sealed class PackageAnalyzer
+{
+    /// <summary>Run redundancy detection on a single resolved project, plus cross-project version conflicts.</summary>
+    public IReadOnlyList<Finding> Analyze(IEnumerable<AnalyzedProject> projects, AnalyzerOptions options = null)
+    {
+        options ??= new AnalyzerOptions();
+        var materialized = projects
+            .Where(x => options.TargetFramework == null ||
+                        string.Equals(x.TargetFramework, options.TargetFramework, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var findings = new List<Finding>();
+        foreach (var project in materialized)
+            findings.AddRange(AnalyzeRedundancy(project, options));
+
+        findings.AddRange(FindVersionConflicts(materialized, options));
+        return findings;
+    }
+
+    /// <summary>Redundant direct package references for one project at one target framework.</summary>
+    public IReadOnlyList<Finding> AnalyzeRedundancy(AnalyzedProject project, AnalyzerOptions options = null)
+    {
+        options ??= new AnalyzerOptions();
+        var findings = new List<Finding>();
+
+        var byName = BuildNameIndex(project.Graph);
+
+        // The set of direct dependencies a redundant reference could be "provided" through.
+        var directPackageKeys = project.DirectPackages
+            .Where(x => x.NodeKey != null)
+            .Select(x => x.NodeKey)
+            .ToList();
+        var allDirectKeys = directPackageKeys.Concat(project.DirectProjectNodeKeys).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var direct in project.DirectPackages)
+        {
+            if (direct.NodeKey == null)
+                continue;
+            if (direct.AutoReferenced || direct.PrivateAssetsAll)
+                continue;
+            if (options.ExcludedPackageIds.Contains(direct.Name))
+                continue;
+
+            // Every other direct dependency is a candidate provider.
+            var otherRoots = allDirectKeys.Where(x => !string.Equals(x, direct.NodeKey, StringComparison.OrdinalIgnoreCase));
+
+            var providerProjects = new List<string>();
+            var providerPackages = new List<string>();
+            foreach (var root in otherRoots)
+            {
+                var reachable = Reachable(project.Graph, byName, root);
+                if (!reachable.Contains(direct.NodeKey))
+                    continue;
+
+                if (project.Graph.TryGetValue(root, out var rootNode))
+                {
+                    if (rootNode.IsProject)
+                        providerProjects.Add(rootNode.Name);
+                    else
+                        providerPackages.Add(rootNode.Name);
+                }
+            }
+
+            if (providerProjects.Count == 0 && providerPackages.Count == 0)
+                continue;
+
+            var resolvedVersion = project.Graph[direct.NodeKey].Version;
+            var safe = IsSafeToRemove(project.Graph, direct, out var wouldResolveTo);
+
+            var providers = providerProjects.Concat(providerPackages).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            var kind = providerProjects.Count > 0 ? FindingKind.RedundantViaProject : FindingKind.RedundantViaPackage;
+            var via = kind == FindingKind.RedundantViaProject ? "project reference" : "package";
+
+            var detail = $"{direct.Name} is already provided via {via} {string.Join(", ", providers)}.";
+            if (!safe)
+                detail += $" Removing it may downgrade {direct.Name} from {resolvedVersion} to {wouldResolveTo}.";
+
+            findings.Add(new Finding
+            {
+                Kind = kind,
+                Project = project.ProjectName,
+                TargetFramework = project.TargetFramework,
+                PackageId = direct.Name,
+                ResolvedVersion = resolvedVersion,
+                DeclaredVersion = NormalizeRange(direct.VersionRange),
+                SafeToRemove = safe,
+                Providers = providers,
+                Detail = detail,
+            });
+        }
+
+        return findings;
+    }
+
+    /// <summary>Same package resolved at different versions across the analyzed projects.</summary>
+    public IReadOnlyList<Finding> FindVersionConflicts(IReadOnlyList<AnalyzedProject> projects, AnalyzerOptions options = null)
+    {
+        options ??= new AnalyzerOptions();
+        var findings = new List<Finding>();
+
+        // package id -> (project, version) occurrences across all graphs.
+        var occurrences = new Dictionary<string, List<(string Project, string Version)>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var project in projects)
+        {
+            foreach (var node in project.Graph.Values)
+            {
+                if (node.IsProject || string.IsNullOrEmpty(node.Version))
+                    continue;
+                if (options.ExcludedPackageIds.Contains(node.Name))
+                    continue;
+
+                if (!occurrences.TryGetValue(node.Name, out var list))
+                    occurrences[node.Name] = list = new List<(string, string)>();
+                list.Add((project.ProjectName, node.Version));
+            }
+        }
+
+        foreach (var pair in occurrences)
+        {
+            var distinctVersions = pair.Value.Select(x => x.Version).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+            if (distinctVersions.Count < 2)
+                continue;
+
+            var breakdown = pair.Value
+                .GroupBy(x => x.Version, StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(g => g.Key)
+                .Select(g => $"{g.Key} ({string.Join(", ", g.Select(x => x.Project).Distinct())})");
+
+            findings.Add(new Finding
+            {
+                Kind = FindingKind.VersionConflict,
+                PackageId = pair.Key,
+                ResolvedVersion = distinctVersions.OrderByDescending(x => x).First(),
+                Providers = distinctVersions,
+                Detail = $"{pair.Key} resolves to multiple versions: {string.Join("; ", breakdown)}.",
+            });
+        }
+
+        return findings;
+    }
+
+    private static bool IsSafeToRemove(
+        IReadOnlyDictionary<string, GraphNode> graph,
+        DirectDependency direct,
+        out string wouldResolveTo)
+    {
+        wouldResolveTo = null;
+
+        var declaredMin = ParseMinVersion(direct.VersionRange);
+        if (declaredMin == null)
+            return true;
+
+        // Highest version any transitive requester asks for (edges in the graph pointing at this package).
+        NuGetVersion highestTransitive = null;
+        foreach (var node in graph.Values)
+        {
+            foreach (var edge in node.Dependencies)
+            {
+                if (!string.Equals(edge.Name, direct.Name, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var min = ParseMinVersion(edge.VersionRange);
+                if (min != null && (highestTransitive == null || min > highestTransitive))
+                    highestTransitive = min;
+            }
+        }
+
+        if (highestTransitive == null)
+            return true;
+
+        if (declaredMin > highestTransitive)
+        {
+            wouldResolveTo = highestTransitive.ToNormalizedString();
+            return false;
+        }
+
+        return true;
+    }
+
+    private static HashSet<string> Reachable(
+        IReadOnlyDictionary<string, GraphNode> graph,
+        IReadOnlyDictionary<string, string> byName,
+        string startKey)
+    {
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var queue = new Queue<string>();
+        queue.Enqueue(startKey);
+
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!graph.TryGetValue(current, out var node))
+                continue;
+
+            foreach (var edge in node.Dependencies)
+            {
+                if (!byName.TryGetValue(edge.Name, out var childKey))
+                    continue;
+                if (visited.Add(childKey))
+                    queue.Enqueue(childKey);
+            }
+        }
+
+        return visited;
+    }
+
+    private static Dictionary<string, string> BuildNameIndex(IReadOnlyDictionary<string, GraphNode> graph)
+    {
+        var index = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var node in graph.Values)
+            index[node.Name] = node.Key;
+        return index;
+    }
+
+    private static NuGetVersion ParseMinVersion(string range)
+    {
+        if (string.IsNullOrWhiteSpace(range))
+            return null;
+
+        if (VersionRange.TryParse(range, out var parsed) && parsed.MinVersion != null)
+            return parsed.MinVersion;
+
+        return NuGetVersion.TryParse(range, out var version) ? version : null;
+    }
+
+    private static string NormalizeRange(string range)
+    {
+        var min = ParseMinVersion(range);
+        return min != null ? min.ToNormalizedString() : range;
+    }
+}

--- a/src/Fallout.NuGet.Analysis/PackageAnalyzer.cs
+++ b/src/Fallout.NuGet.Analysis/PackageAnalyzer.cs
@@ -109,51 +109,82 @@ public sealed class PackageAnalyzer
         return findings;
     }
 
-    /// <summary>Same package resolved at different versions across the analyzed projects.</summary>
+    /// <summary>
+    /// Same package resolved at different versions across the analyzed projects.
+    /// Detection is done <em>per target framework</em>, so a multi-targeted project that legitimately
+    /// pins different versions across its own frameworks is not reported as a conflict.
+    /// </summary>
     public IReadOnlyList<Finding> FindVersionConflicts(IReadOnlyList<AnalyzedProject> projects, AnalyzerOptions options = null)
     {
         options ??= new AnalyzerOptions();
-        var findings = new List<Finding>();
 
-        // package id -> (project, version) occurrences across all graphs.
-        var occurrences = new Dictionary<string, List<(string Project, string Version)>>(StringComparer.OrdinalIgnoreCase);
-        foreach (var project in projects)
+        // package -> version -> projects, accumulated only from frameworks where the package actually conflicts.
+        var conflicting = new Dictionary<string, Dictionary<string, SortedSet<string>>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var tfmGroup in projects.GroupBy(x => x.TargetFramework, StringComparer.OrdinalIgnoreCase))
         {
-            foreach (var node in project.Graph.Values)
+            var perPackage = new Dictionary<string, Dictionary<string, SortedSet<string>>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var project in tfmGroup)
             {
-                if (node.IsProject || string.IsNullOrEmpty(node.Version))
-                    continue;
-                if (options.ExcludedPackageIds.Contains(node.Name))
-                    continue;
+                foreach (var node in project.Graph.Values)
+                {
+                    if (node.IsProject || string.IsNullOrEmpty(node.Version))
+                        continue;
+                    if (options.ExcludedPackageIds.Contains(node.Name))
+                        continue;
 
-                if (!occurrences.TryGetValue(node.Name, out var list))
-                    occurrences[node.Name] = list = new List<(string, string)>();
-                list.Add((project.ProjectName, node.Version));
+                    if (!perPackage.TryGetValue(node.Name, out var byVersion))
+                        perPackage[node.Name] = byVersion = new Dictionary<string, SortedSet<string>>(StringComparer.OrdinalIgnoreCase);
+                    if (!byVersion.TryGetValue(node.Version, out var projectsOnVersion))
+                        byVersion[node.Version] = projectsOnVersion = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+                    projectsOnVersion.Add(project.ProjectName);
+                }
+            }
+
+            foreach (var pair in perPackage)
+            {
+                if (pair.Value.Count < 2)
+                    continue; // one resolved version within this framework — not a conflict
+
+                if (!conflicting.TryGetValue(pair.Key, out var merged))
+                    conflicting[pair.Key] = merged = new Dictionary<string, SortedSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var version in pair.Value)
+                {
+                    if (!merged.TryGetValue(version.Key, out var projectsOnVersion))
+                        merged[version.Key] = projectsOnVersion = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var project in version.Value)
+                        projectsOnVersion.Add(project);
+                }
             }
         }
 
-        foreach (var pair in occurrences)
+        var findings = new List<Finding>();
+        foreach (var pair in conflicting)
         {
-            var distinctVersions = pair.Value.Select(x => x.Version).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
-            if (distinctVersions.Count < 2)
-                continue;
-
-            var breakdown = pair.Value
-                .GroupBy(x => x.Version, StringComparer.OrdinalIgnoreCase)
-                .OrderByDescending(g => g.Key)
-                .Select(g => $"{g.Key} ({string.Join(", ", g.Select(x => x.Project).Distinct())})");
+            var versions = pair.Value
+                .OrderByDescending(x => ParseVersionOrZero(x.Key))
+                .Select(x => new ConflictVersion(x.Key, x.Value.ToList()))
+                .ToList();
 
             findings.Add(new Finding
             {
                 Kind = FindingKind.VersionConflict,
                 PackageId = pair.Key,
-                ResolvedVersion = distinctVersions.OrderByDescending(x => x).First(),
-                Providers = distinctVersions,
-                Detail = $"{pair.Key} resolves to multiple versions: {string.Join("; ", breakdown)}.",
+                ResolvedVersion = versions.First().Version,
+                Providers = versions.Select(x => x.Version).ToList(),
+                ConflictVersions = versions,
+                Detail = $"{pair.Key} resolves to multiple versions: " +
+                         string.Join("; ", versions.Select(v => $"{v.Version} ({string.Join(", ", v.Projects)})")) + ".",
             });
         }
 
         return findings;
+    }
+
+    private static NuGetVersion ParseVersionOrZero(string version)
+    {
+        return NuGetVersion.TryParse(version, out var parsed) ? parsed : new NuGetVersion(0, 0, 0);
     }
 
     private static bool IsSafeToRemove(

--- a/src/Fallout.NuGet.Analysis/ProjectAssetsReader.cs
+++ b/src/Fallout.NuGet.Analysis/ProjectAssetsReader.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using NuGet.Frameworks;
+
+namespace Fallout.NuGet.Analysis;
+
+/// <summary>
+/// Reads a <c>project.assets.json</c> (the post-restore lock file) into one <see cref="AnalyzedProject"/>
+/// per target framework. The assets file already encodes everything the analyzer needs: the declared
+/// direct references (with <c>autoReferenced</c> / <c>suppressParent</c>), and the fully-resolved
+/// transitive graph with the versions NuGet settled on.
+/// </summary>
+public static class ProjectAssetsReader
+{
+    /// <summary>
+    /// Locate the assets file for a project (the default <c>&lt;projDir&gt;/obj/project.assets.json</c>).
+    /// Returns <c>null</c> if it does not exist (i.e. the project has not been restored).
+    /// </summary>
+    public static string FindAssetsFile(string projectFilePath)
+    {
+        var dir = Path.GetDirectoryName(Path.GetFullPath(projectFilePath));
+        if (dir == null)
+            return null;
+
+        var assets = Path.Combine(dir, "obj", "project.assets.json");
+        return File.Exists(assets) ? assets : null;
+    }
+
+    /// <summary>Read every target framework out of the given assets file.</summary>
+    public static IReadOnlyList<AnalyzedProject> Read(string assetsFilePath)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(assetsFilePath));
+        var root = document.RootElement;
+
+        var projectElement = root.TryGetProperty("project", out var p) ? p : default;
+        var restore = projectElement.ValueKind == JsonValueKind.Object && projectElement.TryGetProperty("restore", out var r)
+            ? r
+            : default;
+
+        var projectPath = restore.ValueKind == JsonValueKind.Object && restore.TryGetProperty("projectPath", out var pp)
+            ? pp.GetString()
+            : assetsFilePath;
+        var projectName = restore.ValueKind == JsonValueKind.Object && restore.TryGetProperty("projectName", out var pn)
+            ? pn.GetString()
+            : Path.GetFileNameWithoutExtension(projectPath);
+
+        // Build a graph per resolved target (skipping RID-specific "tfm/rid" targets).
+        var graphsByFramework = ReadGraphs(root);
+
+        var results = new List<AnalyzedProject>();
+        if (projectElement.ValueKind != JsonValueKind.Object ||
+            !projectElement.TryGetProperty("frameworks", out var frameworks) ||
+            frameworks.ValueKind != JsonValueKind.Object)
+        {
+            return results;
+        }
+
+        foreach (var framework in frameworks.EnumerateObject())
+        {
+            var shortTfm = ResolveShortTfm(framework);
+            var nugetFramework = TryParseFramework(framework.Name);
+            var graph = MatchGraph(graphsByFramework, nugetFramework);
+            if (graph == null)
+                continue;
+
+            var directPackages = ReadDirectPackages(framework.Value, graph);
+            var directProjectNodeKeys = ReadDirectProjectNodeKeys(restore, framework.Name, graph);
+
+            results.Add(new AnalyzedProject(
+                projectName,
+                projectPath,
+                shortTfm,
+                directPackages,
+                directProjectNodeKeys,
+                graph));
+        }
+
+        return results;
+    }
+
+    private static Dictionary<NuGetFramework, IReadOnlyDictionary<string, GraphNode>> ReadGraphs(JsonElement root)
+    {
+        var result = new Dictionary<NuGetFramework, IReadOnlyDictionary<string, GraphNode>>();
+        if (!root.TryGetProperty("targets", out var targets) || targets.ValueKind != JsonValueKind.Object)
+            return result;
+
+        foreach (var target in targets.EnumerateObject())
+        {
+            // Skip RID-qualified targets such as ".NETCoreApp,Version=v10.0/win-x64".
+            if (target.Name.Contains('/'))
+                continue;
+
+            var framework = TryParseFramework(target.Name);
+            if (framework == null)
+                continue;
+
+            var nodes = new Dictionary<string, GraphNode>(StringComparer.OrdinalIgnoreCase);
+            foreach (var node in target.Value.EnumerateObject())
+            {
+                var slash = node.Name.IndexOf('/');
+                var name = slash >= 0 ? node.Name.Substring(0, slash) : node.Name;
+                var version = slash >= 0 ? node.Name.Substring(slash + 1) : string.Empty;
+                var type = node.Value.TryGetProperty("type", out var t) ? t.GetString() : "package";
+
+                var edges = new List<Edge>();
+                if (node.Value.TryGetProperty("dependencies", out var deps) && deps.ValueKind == JsonValueKind.Object)
+                {
+                    foreach (var dep in deps.EnumerateObject())
+                        edges.Add(new Edge(dep.Name, dep.Value.GetString()));
+                }
+
+                nodes[node.Name] = new GraphNode(node.Name, name, version, type, edges);
+            }
+
+            result[framework] = nodes;
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyDictionary<string, GraphNode> MatchGraph(
+        Dictionary<NuGetFramework, IReadOnlyDictionary<string, GraphNode>> graphs,
+        NuGetFramework framework)
+    {
+        if (framework != null && graphs.TryGetValue(framework, out var exact))
+            return exact;
+
+        // Single-target projects: pair the lone framework even if monikers parsed differently.
+        return graphs.Count == 1 ? graphs.Values.First() : null;
+    }
+
+    private static IReadOnlyList<DirectDependency> ReadDirectPackages(
+        JsonElement framework,
+        IReadOnlyDictionary<string, GraphNode> graph)
+    {
+        var result = new List<DirectDependency>();
+        if (!framework.TryGetProperty("dependencies", out var deps) || deps.ValueKind != JsonValueKind.Object)
+            return result;
+
+        foreach (var dep in deps.EnumerateObject())
+        {
+            var value = dep.Value;
+            var target = value.TryGetProperty("target", out var tg) ? tg.GetString() : "Package";
+            if (!string.Equals(target, "Package", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var versionRange = value.TryGetProperty("version", out var v) ? v.GetString() : null;
+            var autoReferenced = value.TryGetProperty("autoReferenced", out var a) &&
+                                 a.ValueKind == JsonValueKind.True;
+            var suppressParent = value.TryGetProperty("suppressParent", out var sp) ? sp.GetString() : null;
+            var privateAssetsAll = string.Equals(suppressParent, "All", StringComparison.OrdinalIgnoreCase);
+
+            var nodeKey = FindNodeKeyByName(graph, dep.Name);
+            result.Add(new DirectDependency(dep.Name, versionRange, autoReferenced, privateAssetsAll, nodeKey));
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyList<string> ReadDirectProjectNodeKeys(
+        JsonElement restore,
+        string frameworkName,
+        IReadOnlyDictionary<string, GraphNode> graph)
+    {
+        var result = new List<string>();
+        if (restore.ValueKind != JsonValueKind.Object ||
+            !restore.TryGetProperty("frameworks", out var frameworks) ||
+            frameworks.ValueKind != JsonValueKind.Object ||
+            !frameworks.TryGetProperty(frameworkName, out var framework) ||
+            !framework.TryGetProperty("projectReferences", out var projectReferences) ||
+            projectReferences.ValueKind != JsonValueKind.Object)
+        {
+            return result;
+        }
+
+        foreach (var reference in projectReferences.EnumerateObject())
+        {
+            var projectFilePath = reference.Value.TryGetProperty("projectPath", out var pp)
+                ? pp.GetString()
+                : reference.Name;
+            var name = Path.GetFileNameWithoutExtension(projectFilePath);
+
+            var node = graph.Values.FirstOrDefault(x =>
+                x.IsProject && string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase));
+            if (node != null)
+                result.Add(node.Key);
+        }
+
+        return result;
+    }
+
+    private static string FindNodeKeyByName(IReadOnlyDictionary<string, GraphNode> graph, string name)
+    {
+        return graph.Values
+            .FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase))
+            ?.Key;
+    }
+
+    private static string ResolveShortTfm(JsonProperty framework)
+    {
+        if (framework.Value.TryGetProperty("targetAlias", out var alias))
+        {
+            var value = alias.GetString();
+            if (!string.IsNullOrEmpty(value))
+                return value;
+        }
+
+        return framework.Name;
+    }
+
+    private static NuGetFramework TryParseFramework(string moniker)
+    {
+        try
+        {
+            var framework = NuGetFramework.Parse(moniker);
+            return framework.IsUnsupported ? null : framework;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/Fallout.NuGet.Analysis.Specs/AssetsFixture.cs
+++ b/tests/Fallout.NuGet.Analysis.Specs/AssetsFixture.cs
@@ -1,0 +1,99 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Fallout.NuGet.Analysis.Specs;
+
+/// <summary>
+/// Builds synthetic <c>project.assets.json</c> content for the analyzer specs and writes it to a
+/// temp file. Fragments (<c>Target</c>, <c>DirectDependencies</c>, <c>ProjectReferences</c>) are raw
+/// JSON snippets, so a test reads like the shape of a real assets file.
+/// </summary>
+internal static class AssetsFixture
+{
+    /// <summary>One target framework of a project: its resolved graph and declared direct references.</summary>
+    internal sealed record Framework(
+        string Tfm,
+        string DirectDependencies,
+        string Target,
+        string ProjectReferences = null,
+        string Alias = null);
+
+    public static string WriteAssets(string json)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"assets-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    /// <summary>A single-target-framework assets file (the common case).</summary>
+    public static string SingleFramework(
+        string directDependencies,
+        string target,
+        string projectReferences = null,
+        string projectName = "TestProject",
+        string tfm = "net10.0")
+        => Assets(projectName, new Framework(tfm, directDependencies, target, projectReferences));
+
+    /// <summary>A multi-target-framework assets file.</summary>
+    public static string Assets(string projectName, params Framework[] frameworks)
+        => Assets(projectName, extraTargets: null, frameworks);
+
+    /// <summary>
+    /// A multi-target-framework assets file, plus optional raw extra entries under <c>targets</c>
+    /// (used to inject RID-qualified targets the reader is expected to skip).
+    /// </summary>
+    public static string Assets(string projectName, string extraTargets, params Framework[] frameworks)
+    {
+        static string Alias(Framework framework) => framework.Alias ?? framework.Tfm;
+
+        var targets = string.Join(",\n", frameworks.Select(framework => $$"""
+            "{{framework.Tfm}}": {
+                {{framework.Target}}
+            }
+            """));
+        if (!string.IsNullOrEmpty(extraTargets))
+            targets += ",\n" + extraTargets;
+
+        var restoreFrameworks = string.Join(",\n", frameworks.Select(framework =>
+        {
+            var projectReferences = framework.ProjectReferences == null
+                ? string.Empty
+                : $$""", "projectReferences": { {{framework.ProjectReferences}} }""";
+            return $$"""
+                "{{framework.Tfm}}": { "targetAlias": "{{Alias(framework)}}"{{projectReferences}} }
+                """;
+        }));
+
+        var projectFrameworks = string.Join(",\n", frameworks.Select(framework => $$"""
+            "{{framework.Tfm}}": {
+                "targetAlias": "{{Alias(framework)}}",
+                "dependencies": {
+                    {{framework.DirectDependencies}}
+                }
+            }
+            """));
+
+        return $$"""
+            {
+                "version": 3,
+                "targets": {
+                    {{targets}}
+                },
+                "project": {
+                    "version": "1.0.0",
+                    "restore": {
+                        "projectName": "{{projectName}}",
+                        "projectPath": "/repo/{{projectName}}/{{projectName}}.csproj",
+                        "frameworks": {
+                            {{restoreFrameworks}}
+                        }
+                    },
+                    "frameworks": {
+                        {{projectFrameworks}}
+                    }
+                }
+            }
+            """;
+    }
+}

--- a/tests/Fallout.NuGet.Analysis.Specs/Fallout.NuGet.Analysis.Specs.csproj
+++ b/tests/Fallout.NuGet.Analysis.Specs/Fallout.NuGet.Analysis.Specs.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Fallout.NuGet.Analysis\Fallout.NuGet.Analysis.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageDownload Include="xunit.runner.console" Version="[2.6.1]" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Fallout.NuGet.Analysis.Specs/PackageAnalyzerSpecs.cs
+++ b/tests/Fallout.NuGet.Analysis.Specs/PackageAnalyzerSpecs.cs
@@ -1,0 +1,197 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.NuGet.Analysis.Specs;
+
+public sealed class PackageAnalyzerSpecs
+{
+    [Fact]
+    public void Detects_transitive_package_redundancy_and_marks_it_safe()
+    {
+        // Direct refs A and B; A depends on B at the same version B resolves to.
+        var assets = WriteAssets(Scenario(
+            directDependencies: """
+                                "A": { "target": "Package", "version": "[1.0.0, )" },
+                                "B": { "target": "Package", "version": "[1.0.0, )" }
+                                """,
+            target: """
+                    "A/1.0.0": { "type": "package", "dependencies": { "B": "1.0.0" } },
+                    "B/1.0.0": { "type": "package" }
+                    """));
+
+        var findings = Analyze(assets);
+
+        var finding = findings.Single(x => x.PackageId == "B");
+        finding.Kind.Should().Be(FindingKind.RedundantViaPackage);
+        finding.Providers.Should().ContainSingle().Which.Should().Be("A");
+        finding.SafeToRemove.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Flags_might_downgrade_when_the_direct_reference_pins_higher_than_the_transitive_one()
+    {
+        // B is pinned directly at 2.0.0 (so it resolves to 2.0.0) but A only asks for 1.0.0.
+        var assets = WriteAssets(Scenario(
+            directDependencies: """
+                                "A": { "target": "Package", "version": "[1.0.0, )" },
+                                "B": { "target": "Package", "version": "[2.0.0, )" }
+                                """,
+            target: """
+                    "A/1.0.0": { "type": "package", "dependencies": { "B": "1.0.0" } },
+                    "B/2.0.0": { "type": "package" }
+                    """));
+
+        var finding = Analyze(assets).Single(x => x.PackageId == "B");
+
+        finding.SafeToRemove.Should().BeFalse();
+        finding.ResolvedVersion.Should().Be("2.0.0");
+        finding.Detail.Should().Contain("downgrade");
+    }
+
+    [Fact]
+    public void Ignores_auto_referenced_and_private_assets_dependencies()
+    {
+        var assets = WriteAssets(Scenario(
+            directDependencies: """
+                                "A": { "target": "Package", "version": "[1.0.0, )" },
+                                "B": { "target": "Package", "version": "[1.0.0, )", "autoReferenced": true },
+                                "C": { "target": "Package", "version": "[1.0.0, )", "suppressParent": "All" }
+                                """,
+            target: """
+                    "A/1.0.0": { "type": "package", "dependencies": { "B": "1.0.0", "C": "1.0.0" } },
+                    "B/1.0.0": { "type": "package" },
+                    "C/1.0.0": { "type": "package" }
+                    """));
+
+        Analyze(assets).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Respects_the_exclude_option()
+    {
+        var assets = WriteAssets(Scenario(
+            directDependencies: """
+                                "A": { "target": "Package", "version": "[1.0.0, )" },
+                                "B": { "target": "Package", "version": "[1.0.0, )" }
+                                """,
+            target: """
+                    "A/1.0.0": { "type": "package", "dependencies": { "B": "1.0.0" } },
+                    "B/1.0.0": { "type": "package" }
+                    """));
+
+        var options = new AnalyzerOptions();
+        options.ExcludedPackageIds.Add("B");
+
+        Analyze(assets, options).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Detects_redundancy_provided_through_a_project_reference()
+    {
+        var assets = WriteAssets(Scenario(
+            directDependencies: """
+                                "Newtonsoft.Json": { "target": "Package", "version": "[13.0.0, )" }
+                                """,
+            target: """
+                    "MyLib/1.0.0": { "type": "project", "dependencies": { "Newtonsoft.Json": "13.0.0" } },
+                    "Newtonsoft.Json/13.0.0": { "type": "package" }
+                    """,
+            projectReferences: """
+                               "/repo/MyLib/MyLib.csproj": { "projectPath": "/repo/MyLib/MyLib.csproj" }
+                               """));
+
+        var finding = Analyze(assets).Single();
+
+        finding.Kind.Should().Be(FindingKind.RedundantViaProject);
+        finding.PackageId.Should().Be("Newtonsoft.Json");
+        finding.Providers.Should().Contain("MyLib");
+    }
+
+    [Fact]
+    public void Detects_version_conflicts_across_projects()
+    {
+        var projectOne = ProjectAssetsReader.Read(WriteAssets(Scenario(
+            projectName: "ProjectOne",
+            directDependencies: """ "Serilog": { "target": "Package", "version": "[3.0.0, )" } """,
+            target: """ "Serilog/3.0.0": { "type": "package" } """)));
+
+        var projectTwo = ProjectAssetsReader.Read(WriteAssets(Scenario(
+            projectName: "ProjectTwo",
+            directDependencies: """ "Serilog": { "target": "Package", "version": "[4.0.0, )" } """,
+            target: """ "Serilog/4.0.0": { "type": "package" } """)));
+
+        var conflicts = new PackageAnalyzer()
+            .Analyze(projectOne.Concat(projectTwo).ToList())
+            .Where(x => x.Kind == FindingKind.VersionConflict)
+            .ToList();
+
+        var serilog = conflicts.Single(x => x.PackageId == "Serilog");
+        serilog.Providers.Should().BeEquivalentTo(new[] { "3.0.0", "4.0.0" });
+    }
+
+    private static IReadOnlyList<Finding> Analyze(string assetsFile, AnalyzerOptions options = null)
+    {
+        var projects = ProjectAssetsReader.Read(assetsFile);
+        return new PackageAnalyzer().Analyze(projects, options)
+            .Where(x => x.Kind != FindingKind.VersionConflict)
+            .ToList();
+    }
+
+    private static string Scenario(
+        string directDependencies,
+        string target,
+        string projectReferences = null,
+        string projectName = "TestProject",
+        string tfm = "net10.0")
+    {
+        var projectReferencesJson = projectReferences == null
+            ? string.Empty
+            : $$""""
+                ,
+                        "projectReferences": {
+                            {{projectReferences}}
+                        }
+                """";
+
+        return $$"""
+                 {
+                     "version": 3,
+                     "targets": {
+                         "net10.0": {
+                             {{target}}
+                         }
+                     },
+                     "project": {
+                         "version": "1.0.0",
+                         "restore": {
+                             "projectName": "{{projectName}}",
+                             "projectPath": "/repo/{{projectName}}/{{projectName}}.csproj",
+                             "frameworks": {
+                                 "{{tfm}}": {
+                                     "targetAlias": "{{tfm}}"{{projectReferencesJson}}
+                                 }
+                             }
+                         },
+                         "frameworks": {
+                             "{{tfm}}": {
+                                 "targetAlias": "{{tfm}}",
+                                 "dependencies": {
+                                     {{directDependencies}}
+                                 }
+                             }
+                         }
+                     }
+                 }
+                 """;
+    }
+
+    private static string WriteAssets(string json)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"assets-{System.Guid.NewGuid():N}.json");
+        File.WriteAllText(path, json);
+        return path;
+    }
+}

--- a/tests/Fallout.NuGet.Analysis.Specs/PackageAnalyzerSpecs.cs
+++ b/tests/Fallout.NuGet.Analysis.Specs/PackageAnalyzerSpecs.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
@@ -132,6 +131,106 @@ public sealed class PackageAnalyzerSpecs
         serilog.Providers.Should().BeEquivalentTo(new[] { "3.0.0", "4.0.0" });
     }
 
+    [Fact]
+    public void Detects_redundancy_reachable_through_a_multi_hop_transitive_chain()
+    {
+        // Direct refs A and B. A -> C -> B, so B is redundant via A across two hops.
+        var assets = WriteAssets(Scenario(
+            directDependencies: """
+                                "A": { "target": "Package", "version": "[1.0.0, )" },
+                                "B": { "target": "Package", "version": "[1.0.0, )" }
+                                """,
+            target: """
+                    "A/1.0.0": { "type": "package", "dependencies": { "C": "1.0.0" } },
+                    "C/1.0.0": { "type": "package", "dependencies": { "B": "1.0.0" } },
+                    "B/1.0.0": { "type": "package" }
+                    """));
+
+        var finding = Analyze(assets).Single(x => x.PackageId == "B");
+
+        finding.Kind.Should().Be(FindingKind.RedundantViaPackage);
+        finding.Providers.Should().ContainSingle().Which.Should().Be("A");
+        finding.SafeToRemove.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Does_not_flag_a_conflict_when_one_project_pins_different_versions_across_its_own_tfms()
+    {
+        // One project, two TFMs. Serilog resolves to 3.0.0 on net8.0 and 4.0.0 on net10.0.
+        // That is legal multi-targeting, not a conflict — detection is per target framework.
+        var assets = AssetsFixture.WriteAssets(AssetsFixture.Assets(
+            "MultiTarget",
+            new AssetsFixture.Framework(
+                Tfm: "net8.0",
+                DirectDependencies: """ "Serilog": { "target": "Package", "version": "[3.0.0, )" } """,
+                Target: """ "Serilog/3.0.0": { "type": "package" } """),
+            new AssetsFixture.Framework(
+                Tfm: "net10.0",
+                DirectDependencies: """ "Serilog": { "target": "Package", "version": "[4.0.0, )" } """,
+                Target: """ "Serilog/4.0.0": { "type": "package" } """)));
+
+        var projects = ProjectAssetsReader.Read(assets);
+        projects.Should().HaveCount(2);
+
+        var findings = new PackageAnalyzer().Analyze(projects);
+
+        findings.Where(x => x.Kind == FindingKind.VersionConflict).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Reports_a_conflict_only_from_the_frameworks_where_versions_diverge()
+    {
+        // net8.0: both projects resolve Serilog to 3.0.0 (agree — not a conflict there).
+        // net10.0: ProjectOne=4.0.0, ProjectTwo=5.0.0 (diverge — a conflict).
+        // Only the net10.0 versions should be reported; the agreed 3.0.0 must not appear.
+        static string Project(string name, string netEight, string netTen) => AssetsFixture.Assets(
+            name,
+            new AssetsFixture.Framework(
+                Tfm: "net8.0",
+                DirectDependencies: $$""" "Serilog": { "target": "Package", "version": "[{{netEight}}, )" } """,
+                Target: $$""" "Serilog/{{netEight}}": { "type": "package" } """),
+            new AssetsFixture.Framework(
+                Tfm: "net10.0",
+                DirectDependencies: $$""" "Serilog": { "target": "Package", "version": "[{{netTen}}, )" } """,
+                Target: $$""" "Serilog/{{netTen}}": { "type": "package" } """));
+
+        var one = ProjectAssetsReader.Read(AssetsFixture.WriteAssets(Project("ProjectOne", "3.0.0", "4.0.0")));
+        var two = ProjectAssetsReader.Read(AssetsFixture.WriteAssets(Project("ProjectTwo", "3.0.0", "5.0.0")));
+
+        var conflict = new PackageAnalyzer()
+            .Analyze(one.Concat(two).ToList())
+            .Single(x => x.Kind == FindingKind.VersionConflict && x.PackageId == "Serilog");
+
+        conflict.ConflictVersions.Select(x => x.Version).Should().BeEquivalentTo(new[] { "4.0.0", "5.0.0" });
+        conflict.ResolvedVersion.Should().Be("5.0.0"); // the highest resolved version
+    }
+
+    [Fact]
+    public void Restricts_analysis_to_the_requested_target_framework()
+    {
+        // The same redundancy (B via A) exists on both TFMs; asking for net10.0 yields net10.0 findings only.
+        static AssetsFixture.Framework Redundant(string tfm) => new(
+            Tfm: tfm,
+            DirectDependencies: """
+                                "A": { "target": "Package", "version": "[1.0.0, )" },
+                                "B": { "target": "Package", "version": "[1.0.0, )" }
+                                """,
+            Target: """
+                    "A/1.0.0": { "type": "package", "dependencies": { "B": "1.0.0" } },
+                    "B/1.0.0": { "type": "package" }
+                    """);
+
+        var assets = AssetsFixture.WriteAssets(AssetsFixture.Assets("MultiTarget", Redundant("net8.0"), Redundant("net10.0")));
+        var projects = ProjectAssetsReader.Read(assets);
+
+        var options = new AnalyzerOptions { TargetFramework = "net10.0" };
+        var findings = new PackageAnalyzer().Analyze(projects, options);
+
+        findings.Should().NotBeEmpty();
+        findings.Should().OnlyContain(x => x.TargetFramework == "net10.0");
+        findings.Should().Contain(x => x.PackageId == "B");
+    }
+
     private static IReadOnlyList<Finding> Analyze(string assetsFile, AnalyzerOptions options = null)
     {
         var projects = ProjectAssetsReader.Read(assetsFile);
@@ -146,52 +245,7 @@ public sealed class PackageAnalyzerSpecs
         string projectReferences = null,
         string projectName = "TestProject",
         string tfm = "net10.0")
-    {
-        var projectReferencesJson = projectReferences == null
-            ? string.Empty
-            : $$""""
-                ,
-                        "projectReferences": {
-                            {{projectReferences}}
-                        }
-                """";
+        => AssetsFixture.SingleFramework(directDependencies, target, projectReferences, projectName, tfm);
 
-        return $$"""
-                 {
-                     "version": 3,
-                     "targets": {
-                         "net10.0": {
-                             {{target}}
-                         }
-                     },
-                     "project": {
-                         "version": "1.0.0",
-                         "restore": {
-                             "projectName": "{{projectName}}",
-                             "projectPath": "/repo/{{projectName}}/{{projectName}}.csproj",
-                             "frameworks": {
-                                 "{{tfm}}": {
-                                     "targetAlias": "{{tfm}}"{{projectReferencesJson}}
-                                 }
-                             }
-                         },
-                         "frameworks": {
-                             "{{tfm}}": {
-                                 "targetAlias": "{{tfm}}",
-                                 "dependencies": {
-                                     {{directDependencies}}
-                                 }
-                             }
-                         }
-                     }
-                 }
-                 """;
-    }
-
-    private static string WriteAssets(string json)
-    {
-        var path = Path.Combine(Path.GetTempPath(), $"assets-{System.Guid.NewGuid():N}.json");
-        File.WriteAllText(path, json);
-        return path;
-    }
+    private static string WriteAssets(string json) => AssetsFixture.WriteAssets(json);
 }

--- a/tests/Fallout.NuGet.Analysis.Specs/ProjectAssetsReaderSpecs.cs
+++ b/tests/Fallout.NuGet.Analysis.Specs/ProjectAssetsReaderSpecs.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.NuGet.Analysis.Specs;
+
+public sealed class ProjectAssetsReaderSpecs
+{
+    [Fact]
+    public void Reads_one_analyzed_project_per_target_framework()
+    {
+        var assets = AssetsFixture.WriteAssets(AssetsFixture.Assets(
+            "MultiTarget",
+            new AssetsFixture.Framework(
+                Tfm: "net8.0",
+                DirectDependencies: """ "A": { "target": "Package", "version": "[1.0.0, )" } """,
+                Target: """ "A/1.0.0": { "type": "package" } """),
+            new AssetsFixture.Framework(
+                Tfm: "net10.0",
+                DirectDependencies: """ "A": { "target": "Package", "version": "[2.0.0, )" } """,
+                Target: """ "A/2.0.0": { "type": "package" } """)));
+
+        var projects = ProjectAssetsReader.Read(assets);
+
+        projects.Select(x => x.TargetFramework).Should().BeEquivalentTo(new[] { "net8.0", "net10.0" });
+        projects.Single(x => x.TargetFramework == "net10.0").Graph.Values
+            .Should().Contain(x => x.Name == "A" && x.Version == "2.0.0");
+    }
+
+    [Fact]
+    public void Skips_rid_qualified_targets()
+    {
+        // A "tfm/rid" target carries RID-specific nodes that the analyzer must not treat as resolved deps.
+        var assets = AssetsFixture.WriteAssets(AssetsFixture.Assets(
+            "App",
+            extraTargets: """
+                          "net10.0/win-x64": {
+                              "RidOnly/9.9.9": { "type": "package" }
+                          }
+                          """,
+            new AssetsFixture.Framework(
+                Tfm: "net10.0",
+                DirectDependencies: """ "A": { "target": "Package", "version": "[1.0.0, )" } """,
+                Target: """ "A/1.0.0": { "type": "package" } """)));
+
+        var project = ProjectAssetsReader.Read(assets).Single();
+
+        project.Graph.Values.Should().Contain(x => x.Name == "A");
+        project.Graph.Values.Should().NotContain(x => x.Name == "RidOnly");
+    }
+
+    [Fact]
+    public void Prefers_the_target_alias_over_the_framework_key()
+    {
+        var assets = AssetsFixture.WriteAssets(AssetsFixture.Assets(
+            "Aliased",
+            new AssetsFixture.Framework(
+                Tfm: "net10.0",
+                DirectDependencies: """ "A": { "target": "Package", "version": "[1.0.0, )" } """,
+                Target: """ "A/1.0.0": { "type": "package" } """,
+                Alias: "custom-tfm")));
+
+        ProjectAssetsReader.Read(assets).Single().TargetFramework.Should().Be("custom-tfm");
+    }
+
+    [Fact]
+    public void Returns_nothing_for_an_assets_file_without_a_project_section()
+    {
+        var assets = AssetsFixture.WriteAssets(""" { "version": 3, "targets": {} } """);
+
+        ProjectAssetsReader.Read(assets).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Returns_nothing_when_the_project_declares_no_frameworks()
+    {
+        var assets = AssetsFixture.WriteAssets(
+            """ { "version": 3, "targets": {}, "project": { "restore": { "projectName": "X" } } } """);
+
+        ProjectAssetsReader.Read(assets).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FindAssetsFile_returns_the_path_when_the_project_has_been_restored()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"proj-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(directory, "obj"));
+        var assets = Path.Combine(directory, "obj", "project.assets.json");
+        File.WriteAllText(assets, "{}");
+
+        ProjectAssetsReader.FindAssetsFile(Path.Combine(directory, "My.csproj")).Should().Be(assets);
+    }
+
+    [Fact]
+    public void FindAssetsFile_returns_null_when_the_project_is_not_restored()
+    {
+        var projectFile = Path.Combine(Path.GetTempPath(), $"proj-{Guid.NewGuid():N}", "My.csproj");
+
+        ProjectAssetsReader.FindAssetsFile(projectFile).Should().BeNull();
+    }
+}

--- a/tests/Fallout.SourceGenerators.Specs/StronglyTypedSolutionGeneratorSpecs.Enabled_code_generation#Solution.g.verified.cs
+++ b/tests/Fallout.SourceGenerators.Specs/StronglyTypedSolutionGeneratorSpecs.Enabled_code_generation#Solution.g.verified.cs
@@ -28,6 +28,8 @@ internal class Solution(SolutionModel model, AbsolutePath path) : Fallout.Soluti
     public Fallout.Solutions.Project Fallout_Migrate_Analyzers_Specs => this.GetProject("Fallout.Migrate.Analyzers.Specs");
     public Fallout.Solutions.Project Fallout_Migrate_Specs => this.GetProject("Fallout.Migrate.Specs");
     public Fallout.Solutions.Project Fallout_MSBuildTasks => this.GetProject("Fallout.MSBuildTasks");
+    public Fallout.Solutions.Project Fallout_NuGet_Analysis => this.GetProject("Fallout.NuGet.Analysis");
+    public Fallout.Solutions.Project Fallout_NuGet_Analysis_Specs => this.GetProject("Fallout.NuGet.Analysis.Specs");
     public Fallout.Solutions.Project Fallout_Persistence_Solution => this.GetProject("Fallout.Persistence.Solution");
     public Fallout.Solutions.Project Fallout_Persistence_Solution_Benchmarks => this.GetProject("Fallout.Persistence.Solution.Benchmarks");
     public Fallout.Solutions.Project Fallout_ProjectModel => this.GetProject("Fallout.ProjectModel");

--- a/tests/Fallout.SourceGenerators.Specs/StronglyTypedSolutionGeneratorSpecs.Enabled_code_generation_with_fancy_naming#Solution.g.verified.cs
+++ b/tests/Fallout.SourceGenerators.Specs/StronglyTypedSolutionGeneratorSpecs.Enabled_code_generation_with_fancy_naming#Solution.g.verified.cs
@@ -28,6 +28,8 @@ internal class Solution(SolutionModel model, AbsolutePath path) : Fallout.Soluti
     public Fallout.Solutions.Project FalloutꞏMigrateꞏAnalyzersꞏSpecs => this.GetProject("Fallout.Migrate.Analyzers.Specs");
     public Fallout.Solutions.Project FalloutꞏMigrateꞏSpecs => this.GetProject("Fallout.Migrate.Specs");
     public Fallout.Solutions.Project FalloutꞏMSBuildTasks => this.GetProject("Fallout.MSBuildTasks");
+    public Fallout.Solutions.Project FalloutꞏNuGetꞏAnalysis => this.GetProject("Fallout.NuGet.Analysis");
+    public Fallout.Solutions.Project FalloutꞏNuGetꞏAnalysisꞏSpecs => this.GetProject("Fallout.NuGet.Analysis.Specs");
     public Fallout.Solutions.Project FalloutꞏPersistenceꞏSolution => this.GetProject("Fallout.Persistence.Solution");
     public Fallout.Solutions.Project FalloutꞏPersistenceꞏSolutionꞏBenchmarks => this.GetProject("Fallout.Persistence.Solution.Benchmarks");
     public Fallout.Solutions.Project FalloutꞏProjectModel => this.GetProject("Fallout.ProjectModel");


### PR DESCRIPTION
A NuGet dependency analyzer built on Fallout's existing solution and assets machinery. Ships as a CLI command now; a build target follows. Closes #421.

### What changed
- New `Fallout.NuGet.Analysis` project. It reads the post-restore `project.assets.json` and detects:
  - **Redundant via project reference** — a direct `PackageReference` already provided by a referenced project.
  - **Redundant via package** — a direct `PackageReference` already pulled in transitively by another package you reference.
  - **Version conflict** — the same package resolved at different versions across projects. Computed per target framework, so a multi-targeted project pinning different versions across its own TFMs is not a false positive.
- New CLI command:
  ```
  dotnet fallout :analyze packages [<path>] [--tfm <moniker>] [--severity none|trace|normal|warning|error] [--format table|flat] [--conflicts] [--verbose] [--exclude <id>[,<id>...]]
  ```
  `<path>` is a `.csproj`, a directory, or a `.sln`/`.slnx` (real membership via `ReadSolution()`). Defaults to the working directory. `:analyze` is a command namespace so future analyzers slot in alongside.
- Default output is a per-project tree of redundant references. Conflicts are hidden unless `--conflicts`. `--severity error` returns a non-zero exit code, so CI can gate on findings.

### Design notes
- Reads `project.assets.json` directly. That file is the post-restore truth: it encodes direct-reference intent (`autoReferenced`/`suppressParent`) and the resolved transitive graph with versions. No MSBuild evaluation needed. It requires a restore to have run first.
- Guardrails: excludes `autoReferenced` (SDK-implicit) and `PrivateAssets=all` references. Distinguishes **remove** (resolved version stays the same) from **review** (removal could downgrade the resolved version). Central Package Management aware.
- The core library has no CLI or build coupling, so both can consume it. It targets `net10.0` for now and will multi-target when the build integration lands.

### Layout
- `src/Fallout.NuGet.Analysis/` — analyzer (assets reader, detections, result model).
- `src/Fallout.Cli/Commands/AnalyzeCommand.cs` — the `:analyze packages` command.
- `tests/Fallout.NuGet.Analysis.Specs/` — 6 unit tests over synthetic assets files.

### Verification
- `dotnet fallout :analyze packages` dogfooded against this repo's `src/` and against a large real-world solution. It surfaces genuine project- and package-level redundancy and cross-project version drift.
- Analyzer tests (6) and the solution-generator snapshot tests pass locally.

### Follow-ups (not in this PR)
- A build target consuming the analyzer, with a configurable log level and optional fail-on-finding.
- MSBuild-eval file attribution: point removal advice at the exact `.csproj` versus `Directory.Build.props`.
- Pre-release flagging and dependency-graph export.
