### PR TITLE
Replace remaining nuke command text with fallout

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -124,7 +124,7 @@
       "properties": {
         "CodecovToken": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+          "default": "Secrets must be entered via 'fallout :secrets [profile]'"
         },
         "Configuration": {
           "type": "string",
@@ -135,7 +135,7 @@
         },
         "GitHubReleaseGitHubToken": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+          "default": "Secrets must be entered via 'fallout :secrets [profile]'"
         },
         "IgnoreFailedSources": {
           "type": "boolean",
@@ -146,7 +146,7 @@
         },
         "NuGetApiKey": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+          "default": "Secrets must be entered via 'fallout :secrets [profile]'"
         },
         "Solution": {
           "type": "string",

--- a/src/Fallout.Build/Execution/Extensions/HandleShellCompletionAttribute.cs
+++ b/src/Fallout.Build/Execution/Extensions/HandleShellCompletionAttribute.cs
@@ -22,7 +22,7 @@ internal class HandleShellCompletionAttribute : BuildExtensionAttributeBase, IOn
                 {
                     "The old-style .nuke configuration is no longer supported.",
                     "You can convert to the new-style .nuke directory by calling:",
-                    "   nuke :update"
+                    "   fallout :update"
                 }.JoinNewLine());
             Environment.Exit(exitCode: -1);
         }

--- a/src/Fallout.Build/Utilities/SchemaUtility.cs
+++ b/src/Fallout.Build/Utilities/SchemaUtility.cs
@@ -201,7 +201,7 @@ public static class SchemaUtility
         }
 
         if (member.HasCustomAttribute<SecretAttribute>())
-            schema["default"] = "Secrets must be entered via 'nuke :secrets [profile]'";
+            schema["default"] = "Secrets must be entered via 'fallout :secrets [profile]'";
 
         // Override-with-enumeration: parameters with a value set become string enums (or array-of-string-enums).
         var valueSet = ParameterService.GetParameterValueSet(member, build)?.Select(x => x.Text).ToList();

--- a/src/Fallout.Cli/Program.Navigation.cs
+++ b/src/Fallout.Cli/Program.Navigation.cs
@@ -10,10 +10,10 @@ namespace Fallout.Cli;
 
 partial class Program
 {
-    // function nuke- { nuke :PopDirectory; cd $(nuke :GetNextDirectory) }
-    // function nuke/ { nuke :PushWithChosenRootDirectory; cd $(nuke :GetNextDirectory) }
-    // function nuke. { nuke :PushWithCurrentRootDirectory; cd $(nuke :GetNextDirectory) }
-    // function nuke.. { nuke :PushWithParentRootDirectory; cd $(nuke :GetNextDirectory) }
+    // function fallout- { fallout :PopDirectory; cd $(fallout :GetNextDirectory) }
+    // function fallout/ { fallout :PushWithChosenRootDirectory; cd $(fallout :GetNextDirectory) }
+    // function fallout. { fallout :PushWithCurrentRootDirectory; cd $(fallout :GetNextDirectory) }
+    // function fallout.. { fallout :PushWithParentRootDirectory; cd $(fallout :GetNextDirectory) }
 
     private static string SessionId
         => EnvironmentInfo.Platform switch

--- a/src/Fallout.Cli/Program.Secrets.cs
+++ b/src/Fallout.Cli/Program.Secrets.cs
@@ -14,7 +14,7 @@ namespace Fallout.Cli;
 // TODO: unlock prompt
 // TODO: environment variable name
 // TODO: profile vs. environment
-// TODO: nuke :profile <name>
+// TODO: fallout :profile <name>
 partial class Program
 {
     private const string SaveAndExit = "<Save & Exit>";

--- a/src/Fallout.Tooling/NuGetToolPathResolver.cs
+++ b/src/Fallout.Tooling/NuGetToolPathResolver.cs
@@ -141,7 +141,7 @@ public static class NuGetToolPathResolver
                     {
                         "Missing package reference/download.",
                         "Run one of the following commands:"
-                    }.Concat(packageCombinations.Distinct().Select(x => $"  - nuke :add-package {x.Id} --version {x.Version}"))
+                    }.Concat(packageCombinations.Distinct().Select(x => $"  - fallout :add-package {x.Id} --version {x.Version}"))
                     .JoinNewLine(),
                 exception);
             throw new Exception("Not reachable");

--- a/tests/Fallout.Build.Tests/SchemaUtilityTest.TestGetBuildSchema.verified.json
+++ b/tests/Fallout.Build.Tests/SchemaUtilityTest.TestGetBuildSchema.verified.json
@@ -87,7 +87,7 @@
         },
         "SecretParam": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+          "default": "Secrets must be entered via 'fallout :secrets [profile]'"
         },
         "Skip": {
           "type": "array",

--- a/tests/Fallout.Build.Tests/SchemaUtilityTest.TestParameterBuild.verified.json
+++ b/tests/Fallout.Build.Tests/SchemaUtilityTest.TestParameterBuild.verified.json
@@ -186,7 +186,7 @@
         },
         "SecretParam": {
           "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+          "default": "Secrets must be entered via 'fallout :secrets [profile]'"
         },
         "StringArrayParam": {
           "type": "array",


### PR DESCRIPTION
## Summary
- replace user-facing `nuke :...` command hints with `fallout :...`
- update command guidance in runtime messages and schema defaults
- update matching Verify snapshots and CLI comments/TODO text

## Files updated
- `src/Fallout.Tooling/NuGetToolPathResolver.cs`
- `src/Fallout.Build/Utilities/SchemaUtility.cs`
- `src/Fallout.Build/Execution/Extensions/HandleShellCompletionAttribute.cs`
- `src/Fallout.Cli/Program.Navigation.cs`
- `src/Fallout.Cli/Program.Secrets.cs`
- `.fallout/build.schema.json`
- `tests/Fallout.Build.Tests/SchemaUtilityTest.TestParameterBuild.verified.json`
- `tests/Fallout.Build.Tests/SchemaUtilityTest.TestGetBuildSchema.verified.json`