### PR TITLE
Allow UTF-8 console input

### DIFF
--- a/src/Fallout.Build/Utilities/ConsoleUtility.cs
+++ b/src/Fallout.Build/Utilities/ConsoleUtility.cs
@@ -47,15 +47,13 @@ public class ConsoleUtility
             }
 
             key = Console.ReadKey(intercept: true);
-            if (ConsoleKey.A <= key.Key && key.Key <= ConsoleKey.Z
-                || ConsoleKey.D0 <= key.Key && key.Key <= ConsoleKey.D9
-                || new[] { '.', '/', '\\', '_', '-' }.Any(x => x == key.KeyChar))
+            if (key.IsValidInputKey())
                 input.Append(key.KeyChar);
             else if (key.Key == ConsoleKey.Backspace && input.Length > 0)
                 input.Remove(input.Length - 1, length: 1);
             else if (key.Key == InterruptKey)
                 s_interrupted = true;
-        } while (!(key.Key == ConfirmationKey || key.Key == InterruptKey));
+        } while (key.Key is not (ConfirmationKey or InterruptKey));
 
         var result = input.Length > 0 ? input.ToString() : defaultValue;
         Console.CursorLeft = 0;

--- a/src/Fallout.Build/Utilities/ConsoleUtilityExtensions.cs
+++ b/src/Fallout.Build/Utilities/ConsoleUtilityExtensions.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Linq;
+
+namespace Fallout.Common.Utilities;
+
+public static class ConsoleUtilityExtensions
+{
+    private static readonly char[] AllowedSpecialCharacters = ['.', '/', '\\', '_', '-'];
+
+    public static bool IsValidInputKey(this ConsoleKeyInfo key)
+    {
+        return key.Key is >= ConsoleKey.A and <= ConsoleKey.Z
+               || key.Key is >= ConsoleKey.D0 and <= ConsoleKey.D9
+               || AllowedSpecialCharacters.Any(x => x == key.KeyChar)
+               || char.IsLetterOrDigit(key.KeyChar);
+    }
+}

--- a/tests/Fallout.Build.Tests/Utilities/ConsoleUtilityExtensionsSpecs.cs
+++ b/tests/Fallout.Build.Tests/Utilities/ConsoleUtilityExtensionsSpecs.cs
@@ -1,0 +1,33 @@
+using Fallout.Common.Utilities;
+using Xunit;
+using System;
+using FluentAssertions;
+
+namespace Fallout.Build.Tests.Utilities;
+
+public class ConsoleUtilityExtensionsSpecs
+{
+    [Theory]
+    [InlineData(ConsoleKey.A, 'a', true)]
+    [InlineData(ConsoleKey.Z, 'z', true)]
+    [InlineData(ConsoleKey.D0, '0', true)]
+    [InlineData(ConsoleKey.D9, '9', true)]
+    [InlineData(ConsoleKey.Enter, '\r', false)]
+    [InlineData(ConsoleKey.Backspace, '\b', false)]
+    [InlineData(ConsoleKey.F8, '\0', false)]
+    [InlineData(ConsoleKey.Spacebar, ' ', false)]
+    [InlineData(ConsoleKey.OemPeriod, '.', true)]
+    [InlineData(ConsoleKey.Divide, '/', true)]
+    [InlineData(ConsoleKey.OemMinus, '-', true)]
+    [InlineData(ConsoleKey.NoName, 'ä', true)]
+    [InlineData(ConsoleKey.NoName, 'ö', true)]
+    [InlineData(ConsoleKey.NoName, '中', true)]
+    [InlineData(ConsoleKey.NoName, 'д', true)]
+    [InlineData(ConsoleKey.NoName, 'α', true)]
+    public void Valid_characters_are_accepted_as_input(ConsoleKey key, char keyChar, bool expected)
+    {
+        var keyInfo = new ConsoleKeyInfo(keyChar, key, false, false, false);
+        var result = keyInfo.IsValidInputKey();
+        result.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
_Original description_
> There is a problem for user wanting to input non-ascii characters (ex. cyrillic) during parameter prompt

All credits going to: @rus-art Thank you!

Taken from here: https://github.com/nuke-build/nuke/pull/1321

<!-- Keep it terse: one-line summary, then short "what changed" bullets. -->
<!-- Link the issue and summarize it — don't recite it. See docs/agents/issue-and-pr-style.md. -->
<!-- Or let Copilot draft one, then trim it. -->

<!-- This repo merges via rebase only (linear history). Curate your commits into a -->
<!-- clean sequence before final approval — see CONTRIBUTING.md → Merging. -->
