### PR TITLE
Handle missing changelog (sections) during pack

### DIFF
--- a/fallout.slnx
+++ b/fallout.slnx
@@ -9,6 +9,7 @@
   <Project Path="build\_build.csproj">
     <Configuration Solution="Debug|Any CPU" Project="Debug|Any CPU|NoBuild" />
     <Configuration Solution="Release|Any CPU" Project="Debug|Any CPU|NoBuild" />
+    <Build Project="false" />
   </Project>
   <Project Path="src\Fallout.Build.Shared\Fallout.Build.Shared.csproj" />
   <Project Path="src\Fallout.Build\Fallout.Build.csproj" />

--- a/src/Fallout.Common/ChangeLog/ChangeLogTasks.cs
+++ b/src/Fallout.Common/ChangeLog/ChangeLogTasks.cs
@@ -12,6 +12,11 @@ using Serilog;
 // ReSharper disable ArgumentsStyleLiteral
 namespace Fallout.Common.ChangeLog;
 
+/// <summary>
+/// Provides a set of tasks and utility methods for working with changelogs in a software repository.
+/// This class includes methods for reading, extracting, and finalizing changelog entries, as well as
+/// preparing release notes for publishing on platforms such as NuGet.
+/// </summary>
 public static class ChangelogTasks
 {
     public static string GetNuGetReleaseNotes(string changelogFile, GitRepository repository = null)
@@ -150,18 +155,47 @@ public static class ChangelogTasks
     }
 
     /// <summary>
-    /// Extracts the notes of the specified changelog section.
+    /// Extracts the notes from a specific section of the given changelog file, optionally filtered by a section tag.
     /// </summary>
     /// <param name="changelogFile">The path to the changelog file.</param>
-    /// <param name="tag">The tag which release notes should get extracted.</param>
-    /// <returns>A collection of the release notes.</returns>
+    /// <param name="tag">The optional tag to identify the specific section to extract notes from. If null, the first valid section is used.</param>
+    /// <returns>An enumerable collection of strings representing the notes in the specified section. If the file does not exist or the section is not found, an empty collection is returned.</returns>
     public static IEnumerable<string> ExtractChangelogSectionNotes(AbsolutePath changelogFile, string tag = null)
     {
-        var content = changelogFile.ReadAllLines().Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
-        var sections = GetReleaseSections(content);
-        var section = tag == null
-            ? sections.First(x => x.StartIndex < x.EndIndex)
-            : sections.FirstOrDefault(x => x.Caption.EqualsOrdinalIgnoreCase(tag)).NotNull($"Could not find release section for '{tag}'.");
+        if (!changelogFile.FileExists())
+        {
+            // We treat a non-existing changelog file as empty.
+            Log.Information("Changelog file {File} does not exist, so skipping section extraction", changelogFile);
+            return Array.Empty<string>();
+        }
+
+        List<string> content = changelogFile.ReadAllLines().Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+        List<ReleaseSection> sections = GetReleaseSections(content).ToList();
+        if (!sections.Any())
+        {
+            // We treat an empty changelog as if the section does not exist.
+            Log.Information("Changelog file {File} doesn't contain any sections, so skipping section extraction", changelogFile);
+
+            return Array.Empty<string>();
+        }
+
+        ReleaseSection section;
+        if (tag == null)
+        {
+            section = sections.FirstOrDefault(x => x.StartIndex < x.EndIndex);
+            if (section == null)
+            {
+                return Array.Empty<string>();
+            }
+        }
+        else
+        {
+            section = sections.FirstOrDefault(x => x.Caption.EqualsOrdinalIgnoreCase(tag));
+            if (section == null)
+            {
+                throw new Exception($"Could not find release section for '{tag}'.");
+            }
+        }
 
         return content
             .Skip(section.StartIndex + 1)

--- a/tests/Fallout.Common.Tests/ChangelogTasksTest.cs
+++ b/tests/Fallout.Common.Tests/ChangelogTasksTest.cs
@@ -29,6 +29,16 @@ public class ChangelogTasksTest
     }
 
     [Fact]
+    public void Extracting_a_changelog_from_a_non_existing_file_returns_an_empty_collection()
+    {
+        // Arrange
+        var file = RootDirectory / "does-not-exist.md";
+
+        // Act / Assert
+        ChangelogTasks.ExtractChangelogSectionNotes(file).Should().BeEmpty();
+    }
+
+    [Fact]
     public void GetReleaseSections_ChangelogReferenceFileWithoutReleaseHead_ReturnsEmpty()
     {
         var file = PathToChangelogReferenceFiles / "changelog_reference_invalid_variant_1.md";


### PR DESCRIPTION
Summary
- Make pack resilient when no changelog release sections are available.
- Add regression coverage for a missing changelog file.
- Clarify that the build entrypoint project is intentionally excluded from solution builds.

Changes
- Handle missing changelog sections during pack
  - Return empty release notes when the changelog file is missing or contains no release sections, avoiding the pack-time exception.
- Adjust solution build settings
  - Keep the solution file aligned with the current build configuration for this PR branch.
  - The build entrypoint project (`build/_build.csproj`) is intentionally marked as not built in the solution so it is exercised via the build entrypoint (`./build.ps1` / `./build.sh`) rather than as a normal solution build target.

Combined effect
- Pack no longer fails just because the changelog is absent or empty, and the PR history is split into focused commits.

Validation
- `dotnet test tests/Fallout.Common.Tests/Fallout.Common.Tests.csproj --filter ChangelogTasksTest`

**Note** The failing build was caused by #375, but wasn't caught by GHA as that one skips changes to doc files. 