### PR TITLE
Skip convention-less Host subclasses in host auto-detection

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -90,12 +90,16 @@ Still on Matt's personal NuGet account; supply-chain SPOF, high-priority to repl
 |---|---|
 | `xunit` (+ `runner.visualstudio`) | Test framework |
 | `Microsoft.NET.Test.Sdk` | Test host wiring |
-| `FluentAssertions` | Readable assertion DSL |
+| `FluentAssertions` | Readable assertion DSL — see [licensing note](#fluentassertions-licensing) below |
 | `Verify.Xunit` (+ `.DiffPlex`, `.SourceGenerators`) | Snapshot-based testing (the `*.verified.txt` / `*.received.txt` pattern) |
 | `coverlet.msbuild` | Code coverage |
 | `GitHubActionsTestLogger` | Format test output for GitHub Actions annotations |
 | `Basic.Reference.Assemblies.NetStandard20` | Reference assemblies for source-generator compile tests |
 | `NetArchTest.Rules` | Architecture-fitness tests (e.g. `Fallout.Core` purity); broader suite tracked in #95 |
+
+### FluentAssertions licensing
+
+As of **v8.0** (Jan 2025) FluentAssertions dropped Apache 2.0 for the proprietary **Xceed Community License**: free for open-source / non-commercial use, paid (per-seat) for commercial use. v7.x remains Apache 2.0. We pin **8.x** (`Directory.Packages.props`) and stay current — this is fine for Fallout because it's (a) an OSS project covered by the free community license, and (b) a **test-only / dev-time** dependency that is never redistributed to consumers of the framework. The standard assertion convention (xUnit + FluentAssertions + Verify) is unchanged — see [conventions.md](agents/conventions.md).
 
 ## Build-time CLI tools (`PackageDownload`)
 

--- a/src/Fallout.Build/Host.Activation.cs
+++ b/src/Fallout.Build/Host.Activation.cs
@@ -29,9 +29,15 @@ public partial class Host
     private static bool IsRunning(Type hostType)
     {
         var propertyName = $"IsRunning{hostType.Name}";
-        var member = hostType.GetProperty(propertyName, ReflectionUtility.Static)
-            .NotNull($"Host type '{hostType.Name}' defines no property '{propertyName}'");
-        return member.GetValue<bool>();
+        var member = hostType.GetProperty(propertyName, ReflectionUtility.Static);
+
+        // A public Host subclass that doesn't follow the `IsRunning{Name}` convention is
+        // not a runnable host — treat it as not-running rather than throwing. Host
+        // auto-detection runs in FalloutBuild's static ctor, so an exception here crashes
+        // every build that merely references such an assembly. The Nuke.* transition shim
+        // emits exactly such a subclass (`Nuke.Common.Host`), which made any shim-referencing
+        // build abort on startup. See Fallout.Canary#3.
+        return member is not null && member.GetValue<bool>();
     }
 
     private static Host CreateHost(Type hostType)

--- a/tests/Nuke.Common.Shim.Tests/HostDetectionTests.cs
+++ b/tests/Nuke.Common.Shim.Tests/HostDetectionTests.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Nuke.Common.Shim.Tests;
+
+// Runtime counterpart to the compile-only SampleConsumerBuild: actually exercises host
+// auto-detection with the shim loaded. The shim emits a public Host subclass
+// (`Nuke.Common.Host`) that doesn't follow the `IsRunning{Name}` convention; detection
+// used to assert-throw on it inside FalloutBuild's static ctor, aborting every build that
+// referenced the shim. Compile-only tests never caught it because they never run a build.
+// See Fallout.Canary#3.
+public class HostDetectionTests
+{
+    [Fact]
+    public void FalloutBuildHost_Resolves_DespiteConventionLessShimHostSubclass()
+    {
+        // Force the Nuke.Common shim assembly to load so detection sees its types.
+        var shimAssembly = typeof(global::Nuke.Common.NukeBuild).Assembly;
+
+        // Precondition: the shim really does emit a public, convention-less Host subclass.
+        // Without one, this regression test has no teeth.
+        var offenders = shimAssembly.GetTypes()
+            .Where(t => t.IsPublic && t.IsSubclassOf(typeof(global::Fallout.Common.Host)))
+            .Where(t => t.GetProperty($"IsRunning{t.Name}", BindingFlags.Public | BindingFlags.Static) is null)
+            .ToList();
+        Assert.NotEmpty(offenders);
+
+        // Touching FalloutBuild runs its static ctor -> Host.Default, scanning every public
+        // Host subclass. Resolving the property (not throwing) is the assertion.
+        var host = global::Fallout.Common.FalloutBuild.Host;
+        Assert.NotNull(host);
+    }
+}

--- a/tests/Nuke.Common.Shim.Tests/HostDetectionTests.cs
+++ b/tests/Nuke.Common.Shim.Tests/HostDetectionTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Reflection;
+using FluentAssertions;
 using Xunit;
 
 namespace Nuke.Common.Shim.Tests;
@@ -24,11 +25,11 @@ public class HostDetectionTests
             .Where(t => t.IsPublic && t.IsSubclassOf(typeof(global::Fallout.Common.Host)))
             .Where(t => t.GetProperty($"IsRunning{t.Name}", BindingFlags.Public | BindingFlags.Static) is null)
             .ToList();
-        Assert.NotEmpty(offenders);
+        offenders.Should().NotBeEmpty();
 
         // Touching FalloutBuild runs its static ctor -> Host.Default, scanning every public
         // Host subclass. Resolving the property (not throwing) is the assertion.
         var host = global::Fallout.Common.FalloutBuild.Host;
-        Assert.NotNull(host);
+        host.Should().NotBeNull();
     }
 }


### PR DESCRIPTION
## Problem

`Host.Default` scans every public subclass of `Host` and **asserted** each defines a static `IsRunning{Name}` property. The `Nuke.*` transition shim emits `Nuke.Common.Host` (a public `Host` subclass with no `IsRunningHost`), so detection threw `ArgumentException: Host type 'Host' defines no property 'IsRunningHost'` — inside `FalloutBuild`'s **static constructor**. Net effect: **any build that merely references the shim crashes at startup, before a single target runs.**

## Fix

Treat a `Host` subclass that doesn't follow the `IsRunning{Name}` convention as *not running* instead of throwing. Defensive against any third-party `Host` subclass, not just the shim. Non-breaking, additive behavior.

## Test

Adds a **runtime** regression in `Nuke.Common.Shim.Tests` — the existing `SampleConsumerBuild` shim test is compile-only, which is exactly why this slipped through (it never runs a build). The new test reproduces the precise error without the fix and passes with it.

## How it was found

By the new `fallout.canary` acceptance suite, which consumes the published `-preview` packages and *runs* real consumer builds. See Fallout-build/Fallout.Canary#3.