### PR TITLE
Fix Pack when CHANGELOG.md is missing

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -148,6 +148,16 @@
           "type": "string",
           "default": "Secrets must be entered via 'fallout :secrets [profile]'"
         },
+        "NuGetSource": {
+          "type": "string"
+        },
+        "PublishTo": {
+          "type": "array",
+          "description": "Publish only to these named targets (default: all configured PublishTargets)",
+          "items": {
+            "type": "string"
+          }
+        },
         "Solution": {
           "type": "string",
           "description": "Path to a solution file that is automatically loaded"

--- a/src/Fallout.Common/ChangeLog/ChangeLogTasks.cs
+++ b/src/Fallout.Common/ChangeLog/ChangeLogTasks.cs
@@ -21,10 +21,12 @@ public static class ChangelogTasks
 {
     public static string GetNuGetReleaseNotes(string changelogFile, GitRepository repository = null)
     {
+        AbsolutePath changelogPath = changelogFile;
+
         // URL-encode characters MSBuild treats as command-line/property metacharacters.
         // Without this, MSBuild's property parser splits on ; (turning a long release note
         // into multiple bogus arguments) and chokes on stray " in the value.
-        var changelogSectionNotes = ExtractChangelogSectionNotes(changelogFile)
+        var changelogSectionNotes = ExtractChangelogSectionNotes(changelogPath)
             .Select(x => x.Replace("- ", "\u2022 ")
                 .Replace("* ", "\u2022 ")
                 .Replace("+ ", "\u2022 ")
@@ -32,10 +34,10 @@ public static class ChangelogTasks
                 .Replace(",", "%2C")
                 .Replace(";", "%3B")).ToList();
 
-        if (repository.IsGitHubRepository())
+        if (repository.IsGitHubRepository() && changelogPath.FileExists())
         {
             changelogSectionNotes.Add(string.Empty);
-            changelogSectionNotes.Add($"Full changelog at {repository.GetGitHubBrowseUrl(changelogFile)}");
+            changelogSectionNotes.Add($"Full changelog at {repository.GetGitHubBrowseUrl(changelogPath, itemType: GitHubItemType.File)}");
         }
 
         return changelogSectionNotes.JoinNewLine();

--- a/tests/Fallout.Common.Tests/ChangelogTasksTest.cs
+++ b/tests/Fallout.Common.Tests/ChangelogTasksTest.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Fallout.Common.ChangeLog;
+using Fallout.Common.Git;
 using Fallout.Common.IO;
+using Fallout.Common.Tools.GitHub;
 using VerifyXunit;
 using Xunit;
 
@@ -36,6 +38,20 @@ public class ChangelogTasksTest
 
         // Act / Assert
         ChangelogTasks.ExtractChangelogSectionNotes(file).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Missing_changelog_does_not_add_a_full_changelog_link_to_release_notes()
+    {
+        // Arrange
+        var changelogFile = RootDirectory / "does-not-exist.md";
+        var repository = GitRepository.FromLocalDirectory(RootDirectory);
+
+        // Act
+        string releaseNotes = ChangelogTasks.GetNuGetReleaseNotes(changelogFile, repository);
+
+        // Assert
+        releaseNotes.Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Problem
- Pack crashed when CHANGELOG.md was missing.
- GetNuGetReleaseNotes appended a GitHub browse URL using automatic item-type detection, which threw when the file did not exist.

## Outcome
- Force changelog browse links to use GitHubItemType.File when building NuGet release notes.
- Add regression test for missing changelog + GitHub repository path.
