### PR TITLE
Add draft-first PR creation, test naming, and Specs suffix conventions

### DIFF
--- a/docs/agents/conventions.md
+++ b/docs/agents/conventions.md
@@ -5,6 +5,8 @@ Three groups: conventions to respect, things never to do, and the tool-wrapper r
 ## Conventions worth respecting
 
 - **Centralized package versions** — add new packages to `Directory.Packages.props`, never inline. Adding a *meaningful* library (not a tiny transitive helper)? Add a row to [docs/dependencies.md](https://github.com/Fallout-build/Fallout/blob/main/docs/dependencies.md) in the same PR — reviewers will ask.
+- **Test naming follows AV1600 behavior-focused style.** Write test names as short, present-tense descriptions of observable behavior, not method calls. Example good: `Missing_changelog_does_not_add_a_full_changelog_link_to_release_notes`. Example bad: `GetNuGetReleaseNotes_WithMissingChangelog_AndGitHubRepository_DoesNotThrow`. Focus on "what happens" not "what method is called" (see [AV1600](references/testability.md#AV1620)).
+- **Test files and classes use `Specs` suffix.** Name test projects `Foo.Specs`, test files `FooSpecs.cs`, and test classes `FooSpecs`. Use `Specs` not `Test` or `Tests` — it clarifies that the class describes the expected behavior (specification) of the subject under test.
 - **Tool wrappers**: copy/paste from neighbours; cover full commands; use `<c>`, `<a>`, `<ul>`/`<ol>`, `<em>`, `<para/>` in `help`; don't write `secret: false` or `default: xxx`. See [Tool wrapper recipe](#tool-wrapper-recipe) below.
 - **Tests next to code, separate folder**: every `Foo` project under `src/` has a sibling `Foo.Tests` project under `tests/`. Mirror the namespace.
 - **No IDE-specific style files committed.** `.editorconfig` and `*.DotSettings` were removed during the takeover — relying on `dotnet format` defaults and review.

--- a/docs/agents/issue-and-pr-style.md
+++ b/docs/agents/issue-and-pr-style.md
@@ -75,6 +75,7 @@ Closes #<issue>
   in a series). Summarize the need in a line — don't recite the issue's
   Problem/Outcome/criteria back; the reader can click through. The PR explains
   *the change*; the issue holds *the requirement*.
+- **Create PRs as draft by default.** Use `gh pr create --draft` unless the user explicitly asks for a ready-for-review PR. Convert to ready only when the user explicitly requests it. This keeps incomplete work from accidentally entering review and ensures work stays flexible during early development.
 - Add the `⚠️ Breaking change` callout **only** when the change is breaking —
   see the [PR-creation flow](release-and-versioning.md#pr-creation-flow) for
   what that requires.


### PR DESCRIPTION
Add three focused documentation rules to guide agent and human contributors on testing and PR creation practices.

### What changed
- `docs/agents/issue-and-pr-style.md`: Added draft-by-default rule (PRs created as draft unless explicitly requested otherwise)
- `docs/agents/conventions.md`: Added AV1600 test naming convention (behavior-focused, present-tense test names) and Specs suffix convention (test projects/files/classes use `Specs` suffix instead of `Test`/`Tests`)

### Why
These rules belong in domain-specific docs where they apply. Draft creation is part of PR best practices (issue-and-pr-style), and test naming conventions are code style (conventions). Using `Specs` clarifies behavior-specification semantics in testing.