### PR TITLE
Introduce IFalloutCommand dispatch with DI for Fallout.Cli (#392, PR 0)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,47 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Prompts you for the command/args each launch, e.g. ":get-configuration" or ":bogus".
+      "name": "fallout (ask for args)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-cli",
+      "program": "${workspaceFolder}/src/Fallout.Cli/bin/Debug/net10.0/Fallout.Cli.dll",
+      "args": "${input:falloutArgs}",
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "stopAtEntry": false
+    },
+    {
+      // Dispatch error path — prints the command manifest, no side effects.
+      "name": "fallout :bogus",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-cli",
+      "program": "${workspaceFolder}/src/Fallout.Cli/bin/Debug/net10.0/Fallout.Cli.dll",
+      "args": [":bogus"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    },
+    {
+      // Real command via the DelegateCommand path — read-only.
+      "name": "fallout :get-configuration",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-cli",
+      "program": "${workspaceFolder}/src/Fallout.Cli/bin/Debug/net10.0/Fallout.Cli.dll",
+      "args": [":get-configuration"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "falloutArgs",
+      "type": "promptString",
+      "description": "Arguments to pass to fallout (space-separated), e.g. ':get-configuration'",
+      "default": ":bogus"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build-cli",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/src/Fallout.Cli/Fallout.Cli.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Glob" Version="1.1.9" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageVersion Include="Humanizer" Version="3.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />

--- a/src/Fallout.Cli/CommandDispatcher.cs
+++ b/src/Fallout.Cli/CommandDispatcher.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Fallout.Cli.Commands;
 using Fallout.Cli.Prompts;
 using Fallout.Common;
@@ -20,50 +21,52 @@ internal sealed class CommandDispatcher
 {
     private const char CommandPrefix = ':';
 
-    private readonly IReadOnlyList<IFalloutCommand> _commands;
-    private readonly IConsolePrompts _prompts;
+    private readonly IReadOnlyList<IFalloutCommand> commands;
+    private readonly IConsolePrompts prompts;
 
     public CommandDispatcher(IEnumerable<IFalloutCommand> commands, IConsolePrompts prompts)
     {
-        _commands = commands.ToList();
-        _prompts = prompts;
+        this.commands = commands.ToList();
+        this.prompts = prompts;
     }
 
-    public int Dispatch(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    public async Task<int> DispatchAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
     {
         var hasCommand = args.FirstOrDefault()?.StartsWithOrdinalIgnoreCase(CommandPrefix.ToString()) ?? false;
         if (hasCommand)
         {
             var token = args.First().Trim(CommandPrefix);
             if (string.IsNullOrWhiteSpace(token))
+            {
                 Assert.Fail($"No command specified. Usage is: fallout {CommandPrefix}<command> [args]");
+            }
 
             var command = Resolve(token);
-            return command.Execute(args.Skip(count: 1).ToArray(), rootDirectory, buildScript);
+            return await command.ExecuteAsync(args.Skip(count: 1).ToArray(), rootDirectory, buildScript);
         }
 
         if (rootDirectory == null)
         {
-            return _prompts.PromptForConfirmation(
+            return prompts.PromptForConfirmation(
                     $"Could not find {Constants.FalloutDirectoryName} directory/file. Do you want to setup a build?")
-                ? GetRequired("setup").Execute(Array.Empty<string>(), rootDirectory: null, buildScript: null)
+                ? await GetRequired("setup").ExecuteAsync(Array.Empty<string>(), rootDirectory: null, buildScript: null)
                 : 0;
         }
 
         // TODO: docker
 
-        return GetRequired("run").Execute(args, rootDirectory, BuildProjectResolver.Resolve(rootDirectory));
+        return await GetRequired("run").ExecuteAsync(args, rootDirectory, BuildProjectResolver.Resolve(rootDirectory));
     }
 
     private IFalloutCommand Resolve(string token)
     {
-        return _commands.SingleOrDefault(x => Normalize(x.Name).EqualsOrdinalIgnoreCase(Normalize(token)))
+        return commands.SingleOrDefault(x => Normalize(x.Name).EqualsOrdinalIgnoreCase(Normalize(token)))
             .NotNull(new[] { $"Command '{token}' is not supported, available commands are:" }
-                .Concat(_commands.Select(x => $"  - {x.Name}").OrderBy(x => x)).JoinNewLine());
+                .Concat(commands.Select(x => $"  - {x.Name}").OrderBy(x => x)).JoinNewLine());
     }
 
     private IFalloutCommand GetRequired(string name)
-        => _commands.Single(x => x.Name.EqualsOrdinalIgnoreCase(name));
+        => commands.Single(x => x.Name.EqualsOrdinalIgnoreCase(name));
 
     private static string Normalize(string value) => value.Replace("-", string.Empty);
 }

--- a/src/Fallout.Cli/CommandDispatcher.cs
+++ b/src/Fallout.Cli/CommandDispatcher.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Fallout.Cli.Commands;
+using Fallout.Cli.Prompts;
+using Fallout.Common;
+using Fallout.Common.IO;
+using Fallout.Common.Utilities;
+using Fallout.Common.Utilities.Collections;
+
+namespace Fallout.Cli;
+
+/// <summary>
+/// Routes a command-line invocation to the matching <see cref="IFalloutCommand"/>. Commands are
+/// resolved by <see cref="IFalloutCommand.Name"/> from the registered set — dash- and
+/// case-insensitively, preserving every spelling the historical reflection dispatch accepted
+/// (e.g. <c>:add-package</c> and <c>:addpackage</c>, <c>:PopDirectory</c> and <c>:popdirectory</c>).
+/// </summary>
+internal sealed class CommandDispatcher
+{
+    private const char CommandPrefix = ':';
+
+    private readonly IReadOnlyList<IFalloutCommand> _commands;
+    private readonly IConsolePrompts _prompts;
+
+    public CommandDispatcher(IEnumerable<IFalloutCommand> commands, IConsolePrompts prompts)
+    {
+        _commands = commands.ToList();
+        _prompts = prompts;
+    }
+
+    public int Dispatch(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    {
+        var hasCommand = args.FirstOrDefault()?.StartsWithOrdinalIgnoreCase(CommandPrefix.ToString()) ?? false;
+        if (hasCommand)
+        {
+            var token = args.First().Trim(CommandPrefix);
+            if (string.IsNullOrWhiteSpace(token))
+                Assert.Fail($"No command specified. Usage is: fallout {CommandPrefix}<command> [args]");
+
+            var command = Resolve(token);
+            return command.Execute(args.Skip(count: 1).ToArray(), rootDirectory, buildScript);
+        }
+
+        if (rootDirectory == null)
+        {
+            return _prompts.PromptForConfirmation(
+                    $"Could not find {Constants.FalloutDirectoryName} directory/file. Do you want to setup a build?")
+                ? GetRequired("setup").Execute(Array.Empty<string>(), rootDirectory: null, buildScript: null)
+                : 0;
+        }
+
+        // TODO: docker
+
+        return GetRequired("run").Execute(args, rootDirectory, BuildProjectResolver.Resolve(rootDirectory));
+    }
+
+    private IFalloutCommand Resolve(string token)
+    {
+        return _commands.SingleOrDefault(x => Normalize(x.Name).EqualsOrdinalIgnoreCase(Normalize(token)))
+            .NotNull(new[] { $"Command '{token}' is not supported, available commands are:" }
+                .Concat(_commands.Select(x => $"  - {x.Name}").OrderBy(x => x)).JoinNewLine());
+    }
+
+    private IFalloutCommand GetRequired(string name)
+        => _commands.Single(x => x.Name.EqualsOrdinalIgnoreCase(name));
+
+    private static string Normalize(string value) => value.Replace("-", string.Empty);
+}

--- a/src/Fallout.Cli/Commands/DelegateCommand.cs
+++ b/src/Fallout.Cli/Commands/DelegateCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Fallout.Common.IO;
 
 namespace Fallout.Cli.Commands;
@@ -12,16 +13,18 @@ namespace Fallout.Cli.Commands;
 /// </summary>
 internal sealed class DelegateCommand : IFalloutCommand
 {
-    private readonly Func<string[], AbsolutePath, AbsolutePath, int> _handler;
+    private readonly Func<string[], AbsolutePath, AbsolutePath, int> handler;
 
     public DelegateCommand(string name, Func<string[], AbsolutePath, AbsolutePath, int> handler)
     {
         Name = name;
-        _handler = handler;
+        this.handler = handler;
     }
 
     public string Name { get; }
 
-    public int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-        => _handler(args, rootDirectory, buildScript);
+    // The adapted legacy handlers are still synchronous; each #392 conversion replaces one
+    // registration of this adapter with a command type that overrides ExecuteAsync for real.
+    public Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+        => Task.FromResult(handler(args, rootDirectory, buildScript));
 }

--- a/src/Fallout.Cli/Commands/DelegateCommand.cs
+++ b/src/Fallout.Cli/Commands/DelegateCommand.cs
@@ -1,0 +1,27 @@
+using System;
+using Fallout.Common.IO;
+
+namespace Fallout.Cli.Commands;
+
+/// <summary>
+/// Transitional adapter that exposes a not-yet-extracted <c>Program.X</c> handler as an
+/// <see cref="IFalloutCommand"/>, so the dispatcher can route every command uniformly through the
+/// registry while the per-command conversion (issue #392) lands one PR at a time. Each conversion
+/// replaces one registration of this adapter with a real command type; the adapter is deleted once
+/// the last legacy handler is gone.
+/// </summary>
+internal sealed class DelegateCommand : IFalloutCommand
+{
+    private readonly Func<string[], AbsolutePath, AbsolutePath, int> _handler;
+
+    public DelegateCommand(string name, Func<string[], AbsolutePath, AbsolutePath, int> handler)
+    {
+        Name = name;
+        _handler = handler;
+    }
+
+    public string Name { get; }
+
+    public int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+        => _handler(args, rootDirectory, buildScript);
+}

--- a/src/Fallout.Cli/Commands/IFalloutCommand.cs
+++ b/src/Fallout.Cli/Commands/IFalloutCommand.cs
@@ -1,0 +1,30 @@
+using Fallout.Common.IO;
+
+namespace Fallout.Cli.Commands;
+
+/// <summary>
+/// A single global-tool command (e.g. <c>fallout :run</c>, <c>fallout :setup</c>).
+/// One command = one type, resolved by <see cref="Name"/> from the dependency-injection
+/// container — replacing the historical reflection-over-<c>Program</c> dispatch.
+/// </summary>
+/// <remarks>
+/// This surface is intentionally minimal. It is <b>not</b> a stable public plugin contract yet;
+/// when a public command SDK lands (milestone #7) the API will be annotated and versioned
+/// explicitly. Until then, treat additions here as internal-by-convention.
+/// </remarks>
+public interface IFalloutCommand
+{
+    /// <summary>
+    /// The canonical command name as typed after the <c>:</c> prefix, in dash form
+    /// (e.g. <c>"run"</c>, <c>"add-package"</c>, <c>"cake-convert"</c>). Matched case-insensitively.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Executes the command and returns the process exit code.
+    /// </summary>
+    /// <param name="args">The arguments following the command token.</param>
+    /// <param name="rootDirectory">The resolved repository root, or <c>null</c> when none was found.</param>
+    /// <param name="buildScript">The resolved build script / project file, or <c>null</c> when none applies.</param>
+    int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript);
+}

--- a/src/Fallout.Cli/Commands/IFalloutCommand.cs
+++ b/src/Fallout.Cli/Commands/IFalloutCommand.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Fallout.Common.IO;
 
 namespace Fallout.Cli.Commands;
@@ -26,5 +27,5 @@ internal interface IFalloutCommand
     /// <param name="args">The arguments following the command token.</param>
     /// <param name="rootDirectory">The resolved repository root, or <c>null</c> when none was found.</param>
     /// <param name="buildScript">The resolved build script / project file, or <c>null</c> when none applies.</param>
-    int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript);
+    Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript);
 }

--- a/src/Fallout.Cli/Commands/IFalloutCommand.cs
+++ b/src/Fallout.Cli/Commands/IFalloutCommand.cs
@@ -12,12 +12,12 @@ namespace Fallout.Cli.Commands;
 /// when a public command SDK lands (milestone #7) the API will be annotated and versioned
 /// explicitly. Until then, treat additions here as internal-by-convention.
 /// </remarks>
-public interface IFalloutCommand
+internal interface IFalloutCommand
 {
     /// <summary>
-    /// The canonical command name as typed after the <c>:</c> prefix, in dash form
-    /// (e.g. <c>"run"</c>, <c>"add-package"</c>, <c>"cake-convert"</c>). Matched case-insensitively.
-    /// </summary>
+    /// The command name as typed after the <c>:</c> prefix (prefer dash form, e.g. <c>"add-package"</c>).\
+    /// Matched case-insensitively and with dashes ignored (so <c>:addpackage</c> also matches).\
+    /// Legacy commands may still use PascalCase names (e.g. <c>"GetNextDirectory"</c>).
     string Name { get; }
 
     /// <summary>

--- a/src/Fallout.Cli/Commands/RunCommand.cs
+++ b/src/Fallout.Cli/Commands/RunCommand.cs
@@ -8,11 +8,17 @@ using Fallout.Common.IO;
 using Fallout.Common.Utilities;
 using static Fallout.Common.Constants;
 
-namespace Fallout.Cli;
+namespace Fallout.Cli.Commands;
 
-partial class Program
+/// <summary>
+/// <c>fallout :run</c> (and the default, command-less invocation): builds the build project and
+/// runs it, forwarding any remaining arguments to the build.
+/// </summary>
+public sealed class RunCommand : IFalloutCommand
 {
-    private static int Run(string[] forwardedArgs, AbsolutePath rootDirectory, AbsolutePath buildProjectFile)
+    public string Name => "run";
+
+    public int Execute(string[] forwardedArgs, AbsolutePath rootDirectory, AbsolutePath buildProjectFile)
     {
         var dotnet = ResolveDotnet(rootDirectory);
 
@@ -63,7 +69,7 @@ partial class Program
         startInfo.Environment["DOTNET_NOLOGO"] = "1";
         startInfo.Environment["DOTNET_ROLL_FORWARD"] = "Major";
         startInfo.Environment["FALLOUT_TELEMETRY_OPTOUT"] = "1";
-        startInfo.Environment[GlobalToolVersionEnvironmentKey] = typeof(Program).Assembly.GetVersionText();
+        startInfo.Environment[GlobalToolVersionEnvironmentKey] = typeof(RunCommand).Assembly.GetVersionText();
         startInfo.Environment[GlobalToolStartTimeEnvironmentKey] = DateTime.Now.ToString("O");
 
         var process = Process.Start(startInfo).NotNull();

--- a/src/Fallout.Cli/Commands/RunCommand.cs
+++ b/src/Fallout.Cli/Commands/RunCommand.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Fallout.Common;
 using Fallout.Common.IO;
 using Fallout.Common.Utilities;
@@ -18,22 +19,26 @@ public sealed class RunCommand : IFalloutCommand
 {
     public string Name => "run";
 
-    public int Execute(string[] forwardedArgs, AbsolutePath rootDirectory, AbsolutePath buildProjectFile)
+    public async Task<int> ExecuteAsync(string[] forwardedArgs, AbsolutePath rootDirectory, AbsolutePath buildProjectFile)
     {
         var dotnet = ResolveDotnet(rootDirectory);
 
-        var buildExitCode = StartDotnet(dotnet, GetBuildArguments(buildProjectFile));
+        var buildExitCode = await StartDotnetAsync(dotnet, GetBuildArguments(buildProjectFile));
         if (buildExitCode != 0)
+        {
             return buildExitCode;
+        }
 
-        return StartDotnet(dotnet, GetRunArguments(buildProjectFile, forwardedArgs));
+        return await StartDotnetAsync(dotnet, GetRunArguments(buildProjectFile, forwardedArgs));
     }
 
     private static string ResolveDotnet(AbsolutePath rootDirectory)
     {
         var pathDotnet = TryGetDotnetFromPath();
         if (pathDotnet != null)
+        {
             return pathDotnet;
+        }
 
         var shimDirectoryName = EnvironmentInfo.IsWin ? "dotnet-win" : "dotnet-unix";
         var shimExecutableName = EnvironmentInfo.IsWin ? "dotnet.exe" : "dotnet";
@@ -54,7 +59,7 @@ public sealed class RunCommand : IFalloutCommand
             .FirstOrDefault(File.Exists);
     }
 
-    private static int StartDotnet(string dotnet, IEnumerable<string> arguments)
+    private static async Task<int> StartDotnetAsync(string dotnet, IEnumerable<string> arguments)
     {
         var startInfo = new ProcessStartInfo
         {
@@ -63,7 +68,9 @@ public sealed class RunCommand : IFalloutCommand
         };
 
         foreach (var argument in arguments)
+        {
             startInfo.ArgumentList.Add(argument);
+        }
 
         startInfo.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
         startInfo.Environment["DOTNET_NOLOGO"] = "1";
@@ -73,7 +80,7 @@ public sealed class RunCommand : IFalloutCommand
         startInfo.Environment[GlobalToolStartTimeEnvironmentKey] = DateTime.Now.ToString("O");
 
         var process = Process.Start(startInfo).NotNull();
-        process.WaitForExit();
+        await process.WaitForExitAsync();
         return process.ExitCode;
     }
 

--- a/src/Fallout.Cli/Fallout.Cli.csproj
+++ b/src/Fallout.Cli/Fallout.Cli.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />

--- a/src/Fallout.Cli/Program.AddPackage.cs
+++ b/src/Fallout.Cli/Program.AddPackage.cs
@@ -45,7 +45,7 @@ partial class Program
         return 0;
     }
 
-    private static void AddOrReplacePackage(string packageId, string packageVersion, string packageType, string buildProjectFile)
+    internal static void AddOrReplacePackage(string packageId, string packageVersion, string packageType, string buildProjectFile)
     {
         var buildProject = ProjectModelTasks.ParseProject(buildProjectFile).NotNull();
 

--- a/src/Fallout.Cli/Program.GetConfiguration.cs
+++ b/src/Fallout.Cli/Program.GetConfiguration.cs
@@ -11,7 +11,9 @@ namespace Fallout.Cli;
 
 partial class Program
 {
-    private const string BUILD_PROJECT_FILE = nameof(BUILD_PROJECT_FILE);
+    // internal (not private): shared with AddPackage/Update/Cake; will move into a configuration
+    // service in the final #392 collapse PR.
+    internal const string BUILD_PROJECT_FILE = nameof(BUILD_PROJECT_FILE);
     private const string TEMP_DIRECTORY = nameof(TEMP_DIRECTORY);
     private const string DOTNET_GLOBAL_FILE = nameof(DOTNET_GLOBAL_FILE);
     private const string DOTNET_INSTALL_URL = nameof(DOTNET_INSTALL_URL);
@@ -27,7 +29,7 @@ partial class Program
         return 0;
     }
 
-    private static Dictionary<string, string> GetConfiguration(AbsolutePath buildScript, bool evaluate)
+    internal static Dictionary<string, string> GetConfiguration(AbsolutePath buildScript, bool evaluate)
     {
         string ReplaceScriptDirectory(string value)
             => evaluate

--- a/src/Fallout.Cli/Program.Setup.cs
+++ b/src/Fallout.Cli/Program.Setup.cs
@@ -176,13 +176,13 @@ partial class Program
             "EndProject");
     }
 
-    private static string[] GetTemplate(string templateName)
+    internal static string[] GetTemplate(string templateName)
     {
         return ResourceUtility.GetResourceAllLines<Program>($"templates.{templateName}");
     }
 
 
-    private static void WriteBuildScripts(
+    internal static void WriteBuildScripts(
         AbsolutePath scriptDirectory,
         AbsolutePath rootDirectory)
     {
@@ -239,7 +239,7 @@ partial class Program
         }
     }
 
-    private static void WriteConfigurationFile(AbsolutePath rootDirectory, AbsolutePath solutionFile)
+    internal static void WriteConfigurationFile(AbsolutePath rootDirectory, AbsolutePath solutionFile)
     {
         var parametersFile = GetDefaultParametersFile(rootDirectory);
         var dictionary = new Dictionary<string, string> { ["$schema"] = BuildSchemaFileName };

--- a/src/Fallout.Cli/Program.cs
+++ b/src/Fallout.Cli/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Fallout.Cli.Commands;
 using Fallout.Cli.Prompts;
 using Fallout.Common;
@@ -15,7 +16,7 @@ public partial class Program
 {
     internal static string CurrentBuildScriptName => EnvironmentInfo.IsWin ? "build.ps1" : "build.sh";
 
-    private static int Main(string[] args)
+    private static async Task<int> Main(string[] args)
     {
         Console.OutputEncoding = Encoding.UTF8;
 
@@ -29,7 +30,7 @@ public partial class Program
                 : null;
 
             using var services = BuildServiceProvider();
-            return services.GetRequiredService<CommandDispatcher>().Dispatch(args, rootDirectory, buildScript);
+            return await services.GetRequiredService<CommandDispatcher>().DispatchAsync(args, rootDirectory, buildScript);
         }
         catch (Exception exception)
         {

--- a/src/Fallout.Cli/Program.cs
+++ b/src/Fallout.Cli/Program.cs
@@ -1,18 +1,18 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Fallout.Cli.Commands;
+using Fallout.Cli.Prompts;
 using Fallout.Common;
 using Fallout.Common.IO;
 using Fallout.Common.Utilities;
-using Spectre.Console;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Fallout.Cli;
 
 public partial class Program
 {
-    private const char CommandPrefix = ':';
-
     private static string CurrentBuildScriptName => EnvironmentInfo.IsWin ? "build.ps1" : "build.sh";
 
     private static int Main(string[] args)
@@ -28,13 +28,48 @@ public partial class Program
                     .FirstOrDefault(x => Constants.TryGetRootDirectoryFrom(x.Parent) == rootDirectory)
                 : null;
 
-            return Handle(args, rootDirectory, buildScript);
+            using var services = BuildServiceProvider();
+            return services.GetRequiredService<CommandDispatcher>().Dispatch(args, rootDirectory, buildScript);
         }
         catch (Exception exception)
         {
             Host.Error(exception.Unwrap().Message);
             return 1;
         }
+    }
+
+    private static ServiceProvider BuildServiceProvider()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IConsolePrompts, SpectreConsolePrompts>();
+        services.AddSingleton<CommandDispatcher>();
+        RegisterCommands(services);
+
+        return services.BuildServiceProvider();
+    }
+
+    private static void RegisterCommands(IServiceCollection services)
+    {
+        // Real command types — issue #392 converts one legacy handler per PR.
+        services.AddSingleton<IFalloutCommand, RunCommand>();
+
+        // Legacy handlers still living on Program, adapted until they are extracted into command
+        // types. Each conversion deletes one line here plus its Program.X.cs partial.
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("setup", Setup));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("update", Update));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("add-package", AddPackage));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("cake-convert", CakeConvert));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("cake-clean", CakeClean));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("complete", Complete));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("get-configuration", GetConfiguration));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("secrets", Secrets));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("trigger", Trigger));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("GetNextDirectory", (_, _, _) => GetNextDirectory()));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("PopDirectory", (_, _, _) => PopDirectory()));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("PushWithCurrentRootDirectory", (_, rootDirectory, _) => PushWithCurrentRootDirectory(rootDirectory)));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("PushWithParentRootDirectory", (_, rootDirectory, _) => PushWithParentRootDirectory(rootDirectory)));
+        services.AddSingleton<IFalloutCommand>(new DelegateCommand("PushWithChosenRootDirectory", (_, _, _) => PushWithChosenRootDirectory()));
     }
 
     private static void PrintInfo()
@@ -45,7 +80,7 @@ public partial class Program
     private static AbsolutePath TryGetRootDirectory()
     {
         // TODO: copied in FalloutBuild.GetRootDirectory
-        var parameterValue = EnvironmentInfo.GetNamedArgument<AbsolutePath>(Constants.RootDirectoryParameterName);
+        AbsolutePath parameterValue = EnvironmentInfo.GetNamedArgument<AbsolutePath>(Constants.RootDirectoryParameterName);
         if (parameterValue != null)
             return parameterValue;
 
@@ -55,115 +90,18 @@ public partial class Program
         return Constants.TryGetRootDirectoryFrom(Directory.GetCurrentDirectory());
     }
 
-    private static int Handle(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-    {
-        var hasCommand = args.FirstOrDefault()?.StartsWithOrdinalIgnoreCase(CommandPrefix.ToString()) ?? false;
-        if (hasCommand)
-        {
-            var command = args.First().Trim(CommandPrefix).Replace("-", string.Empty);
-            if (string.IsNullOrWhiteSpace(command))
-                Assert.Fail($"No command specified. Usage is: nuke {CommandPrefix}<command> [args]");
+    // ── Transitional Spectre prompt delegators ──────────────────────────────────────────────────
+    // The implementations now live in SpectreConsolePrompts; these forwards keep the not-yet-extracted
+    // Program.X.cs command handlers compiling. As each handler becomes a command type taking
+    // IConsolePrompts via the constructor, its use of these disappears; the last conversion deletes them.
+    private static readonly IConsolePrompts s_prompts = new SpectreConsolePrompts();
 
-            var availableCommands = typeof(Program).GetMethods(ReflectionUtility.Static).Where(x => x.ReturnType == typeof(int)).ToList();
-            var commandHandler = availableCommands.SingleOrDefault(x => x.Name.EqualsOrdinalIgnoreCase(command))
-                .NotNull(new[] { $"Command '{command}' is not supported, available commands are:" }
-                    .Concat(availableCommands.Where(x => x.IsPublic).Select(x => $"  - {x.Name}").OrderBy(x => x)).JoinNewLine());
-            // TODO: add assertions about return type and parameters
-
-            var commandArguments = new object[] { args.Skip(count: 1).ToArray(), rootDirectory, buildScript };
-            return (int)commandHandler.Invoke(obj: null, commandArguments).NotNull($"Command '{command}' did not return exit code");
-        }
-
-        if (rootDirectory == null)
-        {
-            return PromptForConfirmation($"Could not find {Constants.FalloutDirectoryName} directory/file. Do you want to setup a build?")
-                ? Setup(new string[0], rootDirectory: null, buildScript: null)
-                : 0;
-        }
-
-        // TODO: docker
-
-        return Run(args, rootDirectory, BuildProjectResolver.Resolve(rootDirectory));
-    }
-
-    private static void ShowInput(string emoji, string title, string value)
-    {
-        AnsiConsole.MarkupLine($":{emoji}:  {$"{title}:",-25} [turquoise2 bold]{value}[/]");
-    }
-
-    private static void ShowCompletion(string title)
-    {
-        AnsiConsole.WriteLine();
-        AnsiConsole.MarkupLine($"[bold green]{title} completed![/] :party_popper:");
-    }
-
-    private static void ClearPreviousLine()
-    {
-        AnsiConsole.Cursor.MoveUp();
-        Console.WriteLine(' '.Repeat(Console.WindowWidth));
-        AnsiConsole.Cursor.MoveUp();
-    }
-
-    private static bool PromptForConfirmation(string question)
-    {
-        return AnsiConsole.Confirm(question);
-    }
-
-    private static string PromptForInput(string question, string defaultValue = null)
-    {
-        return AnsiConsole.Prompt(
-            new TextPrompt<string>(question)
-                .DefaultValue(defaultValue));
-    }
-
-    private static string PromptForSecret(string title, int? minLength = null)
-    {
-        Assert.False(title.EndsWith(':'));
-
-        return AnsiConsole.Prompt(
-            new TextPrompt<string>($"{title}:")
-                .Secret()
-                .Validate(x => minLength == null || x.Length >= minLength,
-                    message: $"Secret must be at least {minLength} characters long"));
-    }
-
-    private static T PromptForChoice<T>(string question, params (T Value, string Description)[] choices)
-    {
-        var choice = AnsiConsole.Prompt(
-            new SelectionPrompt<T>()
-                .Title(question)
-                .HighlightStyle(new Style(Color.Turquoise2))
-                .UseConverter(x => choices.Single(y => Equals(x, y.Value)).Description)
-                .AddChoices(choices.Select(x => x.Value)));
-        return choice;
-    }
-
-    private static void ConfirmExecution(string title, Action action)
-    {
-        Assert.False(title.EndsWith('?'));
-
-        var confirmation = PromptForConfirmation($"{title}?");
-        ClearPreviousLine();
-
-        if (confirmation)
-        {
-            AnsiConsole.MarkupLine($":hourglass_not_done:  {title} ...");
-            try
-            {
-                action.Invoke();
-            }
-            catch (Exception)
-            {
-                confirmation = false;
-                title = $"{title} (failed)";
-            }
-            finally
-            {
-                ClearPreviousLine();
-            }
-        }
-
-        var (emoji, color) = confirmation ? ("check_mark", "green") : ("multiply", "red");
-        AnsiConsole.MarkupLine($"[{color}]:{emoji}:[/]  {title}");
-    }
+    private static void ShowInput(string emoji, string title, string value) => s_prompts.ShowInput(emoji, title, value);
+    private static void ShowCompletion(string title) => s_prompts.ShowCompletion(title);
+    private static void ClearPreviousLine() => s_prompts.ClearPreviousLine();
+    private static bool PromptForConfirmation(string question) => s_prompts.PromptForConfirmation(question);
+    private static string PromptForInput(string question, string defaultValue = null) => s_prompts.PromptForInput(question, defaultValue);
+    private static string PromptForSecret(string title, int? minLength = null) => s_prompts.PromptForSecret(title, minLength);
+    private static T PromptForChoice<T>(string question, params (T Value, string Description)[] choices) => s_prompts.PromptForChoice(question, choices);
+    private static void ConfirmExecution(string title, Action action) => s_prompts.ConfirmExecution(title, action);
 }

--- a/src/Fallout.Cli/Program.cs
+++ b/src/Fallout.Cli/Program.cs
@@ -13,7 +13,7 @@ namespace Fallout.Cli;
 
 public partial class Program
 {
-    private static string CurrentBuildScriptName => EnvironmentInfo.IsWin ? "build.ps1" : "build.sh";
+    internal static string CurrentBuildScriptName => EnvironmentInfo.IsWin ? "build.ps1" : "build.sh";
 
     private static int Main(string[] args)
     {
@@ -72,7 +72,7 @@ public partial class Program
         services.AddSingleton<IFalloutCommand>(new DelegateCommand("PushWithChosenRootDirectory", (_, _, _) => PushWithChosenRootDirectory()));
     }
 
-    private static void PrintInfo()
+    internal static void PrintInfo()
     {
         Host.Information($"Fallout Global Tool 🌐 {typeof(Program).Assembly.GetInformationalText()}");
     }

--- a/src/Fallout.Cli/Prompts/IConsolePrompts.cs
+++ b/src/Fallout.Cli/Prompts/IConsolePrompts.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace Fallout.Cli.Prompts;
+
+/// <summary>
+/// Interactive console prompts and status rendering used by commands. Injected into commands
+/// so their interaction logic can be unit-tested with a fake, instead of reaching the historical
+/// <c>static</c> Spectre helpers on <c>Program</c>. The default implementation is
+/// <see cref="SpectreConsolePrompts"/>.
+/// </summary>
+public interface IConsolePrompts
+{
+    /// <summary>Renders a labelled, read-only input line (used to echo resolved setup choices).</summary>
+    void ShowInput(string emoji, string title, string value);
+
+    /// <summary>Renders a "<paramref name="title"/> completed!" banner.</summary>
+    void ShowCompletion(string title);
+
+    /// <summary>Clears the previously written console line.</summary>
+    void ClearPreviousLine();
+
+    /// <summary>Asks a yes/no question and returns the answer.</summary>
+    bool PromptForConfirmation(string question);
+
+    /// <summary>Asks for free-text input, optionally with a default value.</summary>
+    string PromptForInput(string question, string defaultValue = null);
+
+    /// <summary>Asks for a masked secret value, optionally enforcing a minimum length.</summary>
+    string PromptForSecret(string title, int? minLength = null);
+
+    /// <summary>Asks the user to pick one of the supplied <paramref name="choices"/>.</summary>
+    T PromptForChoice<T>(string question, params (T Value, string Description)[] choices);
+
+    /// <summary>
+    /// Confirms, then runs <paramref name="action"/> with progress/completion rendering,
+    /// reporting success or failure without throwing.
+    /// </summary>
+    void ConfirmExecution(string title, Action action);
+}

--- a/src/Fallout.Cli/Prompts/IConsolePrompts.cs
+++ b/src/Fallout.Cli/Prompts/IConsolePrompts.cs
@@ -8,7 +8,7 @@ namespace Fallout.Cli.Prompts;
 /// <c>static</c> Spectre helpers on <c>Program</c>. The default implementation is
 /// <see cref="SpectreConsolePrompts"/>.
 /// </summary>
-public interface IConsolePrompts
+internal interface IConsolePrompts
 {
     /// <summary>Renders a labelled, read-only input line (used to echo resolved setup choices).</summary>
     void ShowInput(string emoji, string title, string value);

--- a/src/Fallout.Cli/Prompts/SpectreConsolePrompts.cs
+++ b/src/Fallout.Cli/Prompts/SpectreConsolePrompts.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using Fallout.Common;
+using Fallout.Common.Utilities;
+using Spectre.Console;
+
+namespace Fallout.Cli.Prompts;
+
+/// <summary>
+/// <see cref="IConsolePrompts"/> backed by <see cref="AnsiConsole"/>. This is the single home for
+/// the interactive prompt logic that previously lived as <c>static</c> helpers on <c>Program</c>.
+/// </summary>
+public sealed class SpectreConsolePrompts : IConsolePrompts
+{
+    public void ShowInput(string emoji, string title, string value)
+    {
+        AnsiConsole.MarkupLine($":{emoji}:  {$"{title}:",-25} [turquoise2 bold]{value}[/]");
+    }
+
+    public void ShowCompletion(string title)
+    {
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine($"[bold green]{title} completed![/] :party_popper:");
+    }
+
+    public void ClearPreviousLine()
+    {
+        AnsiConsole.Cursor.MoveUp();
+        System.Console.WriteLine(' '.Repeat(System.Console.WindowWidth));
+        AnsiConsole.Cursor.MoveUp();
+    }
+
+    public bool PromptForConfirmation(string question)
+    {
+        return AnsiConsole.Confirm(question);
+    }
+
+    public string PromptForInput(string question, string defaultValue = null)
+    {
+        return AnsiConsole.Prompt(
+            new TextPrompt<string>(question)
+                .DefaultValue(defaultValue));
+    }
+
+    public string PromptForSecret(string title, int? minLength = null)
+    {
+        Assert.False(title.EndsWith(':'));
+
+        return AnsiConsole.Prompt(
+            new TextPrompt<string>($"{title}:")
+                .Secret()
+                .Validate(x => minLength == null || x.Length >= minLength,
+                    message: $"Secret must be at least {minLength} characters long"));
+    }
+
+    public T PromptForChoice<T>(string question, params (T Value, string Description)[] choices)
+    {
+        var choice = AnsiConsole.Prompt(
+            new SelectionPrompt<T>()
+                .Title(question)
+                .HighlightStyle(new Style(Color.Turquoise2))
+                .UseConverter(x => choices.Single(y => Equals(x, y.Value)).Description)
+                .AddChoices(choices.Select(x => x.Value)));
+        return choice;
+    }
+
+    public void ConfirmExecution(string title, Action action)
+    {
+        Assert.False(title.EndsWith('?'));
+
+        var confirmation = PromptForConfirmation($"{title}?");
+        ClearPreviousLine();
+
+        if (confirmation)
+        {
+            AnsiConsole.MarkupLine($":hourglass_not_done:  {title} ...");
+            try
+            {
+                action.Invoke();
+            }
+            catch (Exception)
+            {
+                confirmation = false;
+                title = $"{title} (failed)";
+            }
+            finally
+            {
+                ClearPreviousLine();
+            }
+        }
+
+        var (emoji, color) = confirmation ? ("check_mark", "green") : ("multiply", "red");
+        AnsiConsole.MarkupLine($"[{color}]:{emoji}:[/]  {title}");
+    }
+}

--- a/src/Fallout.Cli/Prompts/SpectreConsolePrompts.cs
+++ b/src/Fallout.Cli/Prompts/SpectreConsolePrompts.cs
@@ -10,7 +10,7 @@ namespace Fallout.Cli.Prompts;
 /// <see cref="IConsolePrompts"/> backed by <see cref="AnsiConsole"/>. This is the single home for
 /// the interactive prompt logic that previously lived as <c>static</c> helpers on <c>Program</c>.
 /// </summary>
-public sealed class SpectreConsolePrompts : IConsolePrompts
+internal sealed class SpectreConsolePrompts : IConsolePrompts
 {
     public void ShowInput(string emoji, string title, string value)
     {

--- a/tests/Fallout.Cli.Specs/CommandDispatcherSpecs.cs
+++ b/tests/Fallout.Cli.Specs/CommandDispatcherSpecs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Fallout.Cli.Commands;
 using Fallout.Cli.Prompts;
 using Fallout.Common.IO;
@@ -15,13 +16,13 @@ public class CommandDispatcherSpecs
     private static readonly AbsolutePath SomeScript = SomeRoot / "build.sh";
 
     [Fact]
-    public void Dispatch_ColonCommand_InvokesMatchingCommandWithForwardedArgs()
+    public async Task Dispatch_ColonCommand_InvokesMatchingCommandWithForwardedArgs()
     {
         var run = new RecordingCommand("run");
         var setup = new RecordingCommand("setup");
         var dispatcher = new CommandDispatcher(new IFalloutCommand[] { run, setup }, new FakePrompts());
 
-        var exitCode = dispatcher.Dispatch([":setup", "alpha", "beta"], SomeRoot, SomeScript);
+        var exitCode = await dispatcher.DispatchAsync([":setup", "alpha", "beta"], SomeRoot, SomeScript);
 
         exitCode.Should().Be(0);
         setup.WasCalled.Should().BeTrue();
@@ -35,12 +36,12 @@ public class CommandDispatcherSpecs
     [InlineData(":setup")]
     [InlineData(":SETUP")]
     [InlineData(":Setup")]
-    public void Dispatch_MatchesNameCaseInsensitively(string token)
+    public async Task Dispatch_MatchesNameCaseInsensitively(string token)
     {
         var setup = new RecordingCommand("setup");
         var dispatcher = new CommandDispatcher(new IFalloutCommand[] { setup }, new FakePrompts());
 
-        dispatcher.Dispatch([token], SomeRoot, SomeScript);
+        await dispatcher.DispatchAsync([token], SomeRoot, SomeScript);
 
         setup.WasCalled.Should().BeTrue();
     }
@@ -49,59 +50,59 @@ public class CommandDispatcherSpecs
     [InlineData(":add-package")]
     [InlineData(":addpackage")]
     [InlineData(":ADD-PACKAGE")]
-    public void Dispatch_MatchesNameIgnoringDashes(string token)
+    public async Task Dispatch_MatchesNameIgnoringDashes(string token)
     {
         // Preserves every spelling the historical reflection dispatch accepted.
         var addPackage = new RecordingCommand("add-package");
         var dispatcher = new CommandDispatcher(new IFalloutCommand[] { addPackage }, new FakePrompts());
 
-        dispatcher.Dispatch([token], SomeRoot, SomeScript);
+        await dispatcher.DispatchAsync([token], SomeRoot, SomeScript);
 
         addPackage.WasCalled.Should().BeTrue();
     }
 
     [Fact]
-    public void Dispatch_ReturnsCommandExitCode()
+    public async Task Dispatch_ReturnsCommandExitCode()
     {
         var trigger = new RecordingCommand("trigger", exitCode: 42);
         var dispatcher = new CommandDispatcher(new IFalloutCommand[] { trigger }, new FakePrompts());
 
-        dispatcher.Dispatch([":trigger"], SomeRoot, SomeScript).Should().Be(42);
+        (await dispatcher.DispatchAsync([":trigger"], SomeRoot, SomeScript)).Should().Be(42);
     }
 
     [Fact]
-    public void Dispatch_UnknownCommand_ThrowsWithAvailableCommandListing()
+    public async Task Dispatch_UnknownCommand_ThrowsWithAvailableCommandListing()
     {
         var dispatcher = new CommandDispatcher(
             new IFalloutCommand[] { new RecordingCommand("run"), new RecordingCommand("setup") },
             new FakePrompts());
 
-        var action = () => dispatcher.Dispatch([":bogus"], SomeRoot, SomeScript);
+        var action = () => dispatcher.DispatchAsync([":bogus"], SomeRoot, SomeScript);
 
-        action.Should().Throw<Exception>()
-            .WithMessage("*'bogus' is not supported*")
+        (await action.Should().ThrowAsync<Exception>()
+            .WithMessage("*'bogus' is not supported*"))
             .And.Message.Should().ContainAll("- run", "- setup");
     }
 
     [Fact]
-    public void Dispatch_EmptyCommandToken_Fails()
+    public async Task Dispatch_EmptyCommandToken_Fails()
     {
         var dispatcher = new CommandDispatcher(new IFalloutCommand[] { new RecordingCommand("run") }, new FakePrompts());
 
-        var action = () => dispatcher.Dispatch([":"], SomeRoot, SomeScript);
+        var action = () => dispatcher.DispatchAsync([":"], SomeRoot, SomeScript);
 
-        action.Should().Throw<Exception>().WithMessage("*No command specified*");
+        await action.Should().ThrowAsync<Exception>().WithMessage("*No command specified*");
     }
 
     [Fact]
-    public void Dispatch_NoCommand_NullRoot_Confirmed_InvokesSetup()
+    public async Task Dispatch_NoCommand_NullRoot_Confirmed_InvokesSetup()
     {
         var setup = new RecordingCommand("setup");
         var dispatcher = new CommandDispatcher(
             new IFalloutCommand[] { new RecordingCommand("run"), setup },
             new FakePrompts(confirm: true));
 
-        dispatcher.Dispatch(["whatever"], rootDirectory: null, buildScript: null);
+        await dispatcher.DispatchAsync(["whatever"], rootDirectory: null, buildScript: null);
 
         setup.WasCalled.Should().BeTrue();
         setup.ReceivedArgs.Should().BeEmpty();
@@ -109,21 +110,21 @@ public class CommandDispatcherSpecs
     }
 
     [Fact]
-    public void Dispatch_NoCommand_NullRoot_Declined_ReturnsZeroWithoutSetup()
+    public async Task Dispatch_NoCommand_NullRoot_Declined_ReturnsZeroWithoutSetup()
     {
         var setup = new RecordingCommand("setup");
         var dispatcher = new CommandDispatcher(
             new IFalloutCommand[] { new RecordingCommand("run"), setup },
             new FakePrompts(confirm: false));
 
-        var exitCode = dispatcher.Dispatch(["whatever"], rootDirectory: null, buildScript: null);
+        var exitCode = await dispatcher.DispatchAsync(["whatever"], rootDirectory: null, buildScript: null);
 
         exitCode.Should().Be(0);
         setup.WasCalled.Should().BeFalse();
     }
 
     [Fact]
-    public void Dispatch_NoCommand_WithRoot_InvokesRunWithResolvedBuildProject()
+    public async Task Dispatch_NoCommand_WithRoot_InvokesRunWithResolvedBuildProject()
     {
         using var root = TempRoot.Create();
         var buildProject = root.WriteBuildProjectAtConvention();
@@ -132,7 +133,7 @@ public class CommandDispatcherSpecs
             new IFalloutCommand[] { run, new RecordingCommand("setup") },
             new FakePrompts());
 
-        dispatcher.Dispatch(["compile", "--verbose"], root.Path, buildScript: null);
+        await dispatcher.DispatchAsync(["compile", "--verbose"], root.Path, buildScript: null);
 
         run.WasCalled.Should().BeTrue();
         run.ReceivedArgs.Should().Equal("compile", "--verbose");
@@ -141,12 +142,12 @@ public class CommandDispatcherSpecs
 
     private sealed class RecordingCommand : IFalloutCommand
     {
-        private readonly int _exitCode;
+        private readonly int exitCode;
 
         public RecordingCommand(string name, int exitCode = 0)
         {
             Name = name;
-            _exitCode = exitCode;
+            this.exitCode = exitCode;
         }
 
         public string Name { get; }
@@ -155,23 +156,23 @@ public class CommandDispatcherSpecs
         public AbsolutePath ReceivedRoot { get; private set; }
         public AbsolutePath ReceivedBuildScript { get; private set; }
 
-        public int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+        public Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
         {
             WasCalled = true;
             ReceivedArgs = args;
             ReceivedRoot = rootDirectory;
             ReceivedBuildScript = buildScript;
-            return _exitCode;
+            return Task.FromResult(exitCode);
         }
     }
 
     private sealed class FakePrompts : IConsolePrompts
     {
-        private readonly bool _confirm;
+        private readonly bool confirm;
 
-        public FakePrompts(bool confirm = false) => _confirm = confirm;
+        public FakePrompts(bool confirm = false) => this.confirm = confirm;
 
-        public bool PromptForConfirmation(string question) => _confirm;
+        public bool PromptForConfirmation(string question) => confirm;
 
         public void ShowInput(string emoji, string title, string value) { }
         public void ShowCompletion(string title) { }
@@ -211,7 +212,9 @@ public class CommandDispatcherSpecs
         public void Dispose()
         {
             if (Directory.Exists(Path))
+            {
                 Directory.Delete(Path, recursive: true);
+            }
         }
     }
 }

--- a/tests/Fallout.Cli.Specs/CommandDispatcherSpecs.cs
+++ b/tests/Fallout.Cli.Specs/CommandDispatcherSpecs.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Fallout.Cli.Commands;
+using Fallout.Cli.Prompts;
+using Fallout.Common.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.Cli.Specs;
+
+public class CommandDispatcherSpecs
+{
+    private static readonly AbsolutePath SomeRoot = (AbsolutePath)Path.Combine(Path.GetTempPath(), "fallout-dispatch-root");
+    private static readonly AbsolutePath SomeScript = SomeRoot / "build.sh";
+
+    [Fact]
+    public void Dispatch_ColonCommand_InvokesMatchingCommandWithForwardedArgs()
+    {
+        var run = new RecordingCommand("run");
+        var setup = new RecordingCommand("setup");
+        var dispatcher = new CommandDispatcher(new IFalloutCommand[] { run, setup }, new FakePrompts());
+
+        var exitCode = dispatcher.Dispatch([":setup", "alpha", "beta"], SomeRoot, SomeScript);
+
+        exitCode.Should().Be(0);
+        setup.WasCalled.Should().BeTrue();
+        setup.ReceivedArgs.Should().Equal("alpha", "beta");
+        setup.ReceivedRoot.Should().Be(SomeRoot);
+        setup.ReceivedBuildScript.Should().Be(SomeScript);
+        run.WasCalled.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(":setup")]
+    [InlineData(":SETUP")]
+    [InlineData(":Setup")]
+    public void Dispatch_MatchesNameCaseInsensitively(string token)
+    {
+        var setup = new RecordingCommand("setup");
+        var dispatcher = new CommandDispatcher(new IFalloutCommand[] { setup }, new FakePrompts());
+
+        dispatcher.Dispatch([token], SomeRoot, SomeScript);
+
+        setup.WasCalled.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(":add-package")]
+    [InlineData(":addpackage")]
+    [InlineData(":ADD-PACKAGE")]
+    public void Dispatch_MatchesNameIgnoringDashes(string token)
+    {
+        // Preserves every spelling the historical reflection dispatch accepted.
+        var addPackage = new RecordingCommand("add-package");
+        var dispatcher = new CommandDispatcher(new IFalloutCommand[] { addPackage }, new FakePrompts());
+
+        dispatcher.Dispatch([token], SomeRoot, SomeScript);
+
+        addPackage.WasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Dispatch_ReturnsCommandExitCode()
+    {
+        var trigger = new RecordingCommand("trigger", exitCode: 42);
+        var dispatcher = new CommandDispatcher(new IFalloutCommand[] { trigger }, new FakePrompts());
+
+        dispatcher.Dispatch([":trigger"], SomeRoot, SomeScript).Should().Be(42);
+    }
+
+    [Fact]
+    public void Dispatch_UnknownCommand_ThrowsWithAvailableCommandListing()
+    {
+        var dispatcher = new CommandDispatcher(
+            new IFalloutCommand[] { new RecordingCommand("run"), new RecordingCommand("setup") },
+            new FakePrompts());
+
+        var action = () => dispatcher.Dispatch([":bogus"], SomeRoot, SomeScript);
+
+        action.Should().Throw<Exception>()
+            .WithMessage("*'bogus' is not supported*")
+            .And.Message.Should().ContainAll("- run", "- setup");
+    }
+
+    [Fact]
+    public void Dispatch_EmptyCommandToken_Fails()
+    {
+        var dispatcher = new CommandDispatcher(new IFalloutCommand[] { new RecordingCommand("run") }, new FakePrompts());
+
+        var action = () => dispatcher.Dispatch([":"], SomeRoot, SomeScript);
+
+        action.Should().Throw<Exception>().WithMessage("*No command specified*");
+    }
+
+    [Fact]
+    public void Dispatch_NoCommand_NullRoot_Confirmed_InvokesSetup()
+    {
+        var setup = new RecordingCommand("setup");
+        var dispatcher = new CommandDispatcher(
+            new IFalloutCommand[] { new RecordingCommand("run"), setup },
+            new FakePrompts(confirm: true));
+
+        dispatcher.Dispatch(["whatever"], rootDirectory: null, buildScript: null);
+
+        setup.WasCalled.Should().BeTrue();
+        setup.ReceivedArgs.Should().BeEmpty();
+        setup.ReceivedRoot.Should().BeNull();
+    }
+
+    [Fact]
+    public void Dispatch_NoCommand_NullRoot_Declined_ReturnsZeroWithoutSetup()
+    {
+        var setup = new RecordingCommand("setup");
+        var dispatcher = new CommandDispatcher(
+            new IFalloutCommand[] { new RecordingCommand("run"), setup },
+            new FakePrompts(confirm: false));
+
+        var exitCode = dispatcher.Dispatch(["whatever"], rootDirectory: null, buildScript: null);
+
+        exitCode.Should().Be(0);
+        setup.WasCalled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Dispatch_NoCommand_WithRoot_InvokesRunWithResolvedBuildProject()
+    {
+        using var root = TempRoot.Create();
+        var buildProject = root.WriteBuildProjectAtConvention();
+        var run = new RecordingCommand("run");
+        var dispatcher = new CommandDispatcher(
+            new IFalloutCommand[] { run, new RecordingCommand("setup") },
+            new FakePrompts());
+
+        dispatcher.Dispatch(["compile", "--verbose"], root.Path, buildScript: null);
+
+        run.WasCalled.Should().BeTrue();
+        run.ReceivedArgs.Should().Equal("compile", "--verbose");
+        run.ReceivedBuildScript.Should().Be(buildProject);
+    }
+
+    private sealed class RecordingCommand : IFalloutCommand
+    {
+        private readonly int _exitCode;
+
+        public RecordingCommand(string name, int exitCode = 0)
+        {
+            Name = name;
+            _exitCode = exitCode;
+        }
+
+        public string Name { get; }
+        public bool WasCalled { get; private set; }
+        public string[] ReceivedArgs { get; private set; }
+        public AbsolutePath ReceivedRoot { get; private set; }
+        public AbsolutePath ReceivedBuildScript { get; private set; }
+
+        public int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+        {
+            WasCalled = true;
+            ReceivedArgs = args;
+            ReceivedRoot = rootDirectory;
+            ReceivedBuildScript = buildScript;
+            return _exitCode;
+        }
+    }
+
+    private sealed class FakePrompts : IConsolePrompts
+    {
+        private readonly bool _confirm;
+
+        public FakePrompts(bool confirm = false) => _confirm = confirm;
+
+        public bool PromptForConfirmation(string question) => _confirm;
+
+        public void ShowInput(string emoji, string title, string value) { }
+        public void ShowCompletion(string title) { }
+        public void ClearPreviousLine() { }
+        public string PromptForInput(string question, string defaultValue = null) => defaultValue;
+        public string PromptForSecret(string title, int? minLength = null) => string.Empty;
+        public T PromptForChoice<T>(string question, params (T Value, string Description)[] choices) => default;
+        public void ConfirmExecution(string title, Action action) => action();
+    }
+
+    private sealed class TempRoot : IDisposable
+    {
+        public AbsolutePath Path { get; }
+
+        private TempRoot(AbsolutePath path)
+        {
+            Path = path;
+            (path / ".fallout").CreateDirectory();
+        }
+
+        public static TempRoot Create()
+        {
+            var dir = (AbsolutePath)System.IO.Path.Combine(System.IO.Path.GetTempPath(), "fallout-dispatch-" + Guid.NewGuid().ToString("N"));
+            dir.CreateDirectory();
+            return new TempRoot(dir);
+        }
+
+        public AbsolutePath WriteBuildProjectAtConvention()
+        {
+            var buildDir = Path / "build";
+            buildDir.CreateDirectory();
+            var projectFile = buildDir / "_build.csproj";
+            File.WriteAllText(projectFile, string.Empty);
+            return projectFile;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Replaces the reflection-over-`Program` CLI dispatch with one-command-per-type behind a typed `IFalloutCommand`, resolved via Microsoft.Extensions.DependencyInjection. PR 0 of an incremental series — lands the abstraction, dispatcher, and first conversion; a transitional adapter keeps the other 13 handlers working so nothing regresses.

### What changed
- `IFalloutCommand` + `CommandDispatcher` replace `Program.Handle`; resolution stays dash/case-insensitive (every spelling the old reflection accepted).
- `IConsolePrompts` / `SpectreConsolePrompts` — Spectre prompt helpers lifted off `Program` into an injectable service.
- `RunCommand` — first real conversion. `DelegateCommand` adapts the 13 still-legacy handlers so dispatch is uniform; each follow-up PR deletes one.
- Reflection dispatch removed; `CommandDispatcherTests` add first dispatch coverage.

### Why it's not breaking
`Fallout.Cli` is the tool Exe, not a consumed library; the `:command` surface and shell-function names are preserved exactly. Hence `target/2026` / `main`, no `breaking-change` label.

### Verification
`dotnet build src/Fallout.Cli` clean · `Fallout.Cli.Tests` 30 pass · `fallout :bogus` prints the full command manifest.

Follow-ups (#392): setup · update · add-package · cake-convert/clean · complete · get-configuration · secrets · trigger · navigation → then collapse `Program` to a thin entry point. Raised sequentially off this branch as it lands.

Part of #392.

---
_Re-raised from the fork (`ChrisonSimtian:cli-command-dispatch-foundation`) to move the branch off the main repo. Supersedes #394; same history and diff. Bottom of the cli-cmd stack — follow-ups open one at a time as each merges._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
