### PR TITLE
Reset per-run global state at the end of Execute (cross-invocation leaks, FT-1)

### DIFF
--- a/src/Fallout.Build/Execution/BuildManager.cs
+++ b/src/Fallout.Build/Execution/BuildManager.cs
@@ -18,12 +18,12 @@ internal static class BuildManager
 {
     private const int ErrorExitCode = -1;
 
-    private static readonly LinkedList<Action> s_cancellationHandlers = new();
+    private static readonly LinkedList<Action> cancellationHandlers = new();
 
     public static event Action CancellationHandler
     {
-        add => s_cancellationHandlers.AddFirst(value);
-        remove => s_cancellationHandlers.Remove(value);
+        add => cancellationHandlers.AddFirst(value);
+        remove => cancellationHandlers.Remove(value);
     }
 
     [ModuleInitializer]
@@ -45,7 +45,7 @@ internal static class BuildManager
         // Hold the per-run global subscriptions in locals so the finally can undo exactly them —
         // otherwise each Execute in the same process (tests, hosted scenarios) accumulates handlers.
         // FT-1 / #306.
-        ConsoleCancelEventHandler onCancelKeyPress = (_, _) => s_cancellationHandlers.ForEach(x => x());
+        ConsoleCancelEventHandler onCancelKeyPress = (_, _) => cancellationHandlers.ForEach(x => x());
         EventHandler onToolOptionsCreated = (options, _) => VerbosityMapping.Apply((ToolOptions)options);
         Console.CancelKeyPress += onCancelKeyPress;
         ToolOptions.Created += onToolOptionsCreated;

--- a/src/Fallout.Build/Execution/BuildManager.cs
+++ b/src/Fallout.Build/Execution/BuildManager.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyModel;
 using Fallout.Common.Tooling;
 using Fallout.Common.Utilities;
 using Fallout.Common.Utilities.Collections;
+using Fallout.Common.ValueInjection;
 using Serilog;
 #pragma warning disable CA2255
 
@@ -38,10 +39,16 @@ internal static class BuildManager
     {
         Console.OutputEncoding = Encoding.UTF8;
         Console.InputEncoding = Encoding.UTF8;
-        Console.CancelKeyPress += (_, _) => s_cancellationHandlers.ForEach(x => x());
-        ToolOptions.Created += (options, _) => VerbosityMapping.Apply((ToolOptions)options);
 
         var build = new T();
+
+        // Hold the per-run global subscriptions in locals so the finally can undo exactly them —
+        // otherwise each Execute in the same process (tests, hosted scenarios) accumulates handlers.
+        // FT-1 / #306.
+        ConsoleCancelEventHandler onCancelKeyPress = (_, _) => s_cancellationHandlers.ForEach(x => x());
+        EventHandler onToolOptionsCreated = (options, _) => VerbosityMapping.Apply((ToolOptions)options);
+        Console.CancelKeyPress += onCancelKeyPress;
+        ToolOptions.Created += onToolOptionsCreated;
 
         try
         {
@@ -88,6 +95,16 @@ internal static class BuildManager
         {
             Finish();
             Log.CloseAndFlush();
+
+            // FT-1 (#306): undo this run's process-global state so a subsequent Execute in the same
+            // process starts clean — no accumulated handlers, no carried-over log events / caches / config.
+            CancellationHandler -= Finish;
+            Console.CancelKeyPress -= onCancelKeyPress;
+            ToolOptions.Created -= onToolOptionsCreated;
+            Logging.InMemorySink.Instance.Clear();
+            ValueInjectionUtility.ClearCache();
+            NuGetToolPathResolver.Reset();
+            NpmToolPathResolver.Reset();
         }
 
         void Finish()

--- a/src/Fallout.Build/Execution/ValueInjectionUtility.cs
+++ b/src/Fallout.Build/Execution/ValueInjectionUtility.cs
@@ -12,6 +12,9 @@ internal static class ValueInjectionUtility
 {
     private static readonly Dictionary<MemberInfo, object> s_valueCache = new();
 
+    /// <summary>Clears the per-run injected-value cache so a subsequent build in the same process re-injects. FT-1 / #306.</summary>
+    internal static void ClearCache() => s_valueCache.Clear();
+
     public static T TryGetValue<T>(Expression<Func<T>> parameterExpression)
         where T : class
     {

--- a/src/Fallout.Build/Logging.cs
+++ b/src/Fallout.Build/Logging.cs
@@ -228,9 +228,15 @@ public static class Logging
             _logEvents.Add(logEvent);
         }
 
-        public void Dispose()
+        /// <summary>Drops accumulated events so a subsequent build in the same process starts clean. FT-1 / #306.</summary>
+        public void Clear()
         {
             _logEvents.Clear();
+        }
+
+        public void Dispose()
+        {
+            Clear();
         }
     }
 

--- a/src/Fallout.Tooling/NpmToolPathResolver.cs
+++ b/src/Fallout.Tooling/NpmToolPathResolver.cs
@@ -8,6 +8,12 @@ public static class NpmToolPathResolver
 {
     public static AbsolutePath NpmPackageJsonFile;
 
+    /// <summary>Resets the per-run package.json location so a subsequent build in the same process starts from defaults. FT-1 / #306.</summary>
+    public static void Reset()
+    {
+        NpmPackageJsonFile = null;
+    }
+
     public static string GetNpmExecutable(string npmExecutable)
     {
         Assert.FileExists(NpmPackageJsonFile);

--- a/src/Fallout.Tooling/NuGetToolPathResolver.cs
+++ b/src/Fallout.Tooling/NuGetToolPathResolver.cs
@@ -16,6 +16,15 @@ public static class NuGetToolPathResolver
     public static string NuGetAssetsConfigFile;
     public static string PaketPackagesConfigFile;
 
+    /// <summary>Resets the per-run package-location config so a subsequent build in the same process starts from defaults. FT-1 / #306.</summary>
+    public static void Reset()
+    {
+        EmbeddedPackagesDirectory = null;
+        NuGetPackagesConfigFile = null;
+        NuGetAssetsConfigFile = null;
+        PaketPackagesConfigFile = null;
+    }
+
     public static string GetPackageExecutable(string packageId, string packageExecutable, string version = null, string framework = null)
     {
         Assert.True(packageId != null && packageExecutable != null);

--- a/tests/Fallout.Build.Specs/InMemorySinkSpecs.cs
+++ b/tests/Fallout.Build.Specs/InMemorySinkSpecs.cs
@@ -1,0 +1,67 @@
+using System;
+using FluentAssertions;
+using Fallout.Common.Execution;
+using Serilog.Events;
+using Serilog.Parsing;
+using Xunit;
+
+namespace Fallout.Common.Specs;
+
+/// <summary>
+/// Covers <see cref="Logging.InMemorySink"/>'s reset added in FT-1 / #306. The sink is a
+/// process-wide singleton, so <c>BuildManager.Execute</c>'s <c>finally</c> calls <c>Clear()</c> to
+/// stop one run's warnings/errors bleeding into the next build in the same process; <c>Dispose()</c>
+/// delegates to the same reset.
+/// </summary>
+public class InMemorySinkSpecs
+{
+    private static readonly Logging.InMemorySink Sink = Logging.InMemorySink.Instance;
+
+    public InMemorySinkSpecs()
+    {
+        // Normalize the shared singleton before each case — prior runs (or a real logging pipeline)
+        // may have left events behind.
+        Sink.Clear();
+    }
+
+    [Fact]
+    public void Clear_drops_accumulated_events()
+    {
+        Sink.Emit(CreateLogEvent("first"));
+        Sink.Emit(CreateLogEvent("second"));
+        Sink.LogEvents.Should().HaveCount(2);
+
+        Sink.Clear();
+
+        Sink.LogEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Dispose_drops_accumulated_events()
+    {
+        Sink.Emit(CreateLogEvent("only"));
+        Sink.LogEvents.Should().ContainSingle();
+
+        Sink.Dispose();
+
+        Sink.LogEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Clear_on_an_empty_sink_is_a_no_op()
+    {
+        Sink.LogEvents.Should().BeEmpty();
+
+        Sink.Clear();
+
+        Sink.LogEvents.Should().BeEmpty();
+    }
+
+    private static LogEvent CreateLogEvent(string message) =>
+        new(
+            timestamp: DateTimeOffset.UnixEpoch,
+            level: LogEventLevel.Warning,
+            exception: null,
+            messageTemplate: new MessageTemplateParser().Parse(message),
+            properties: Array.Empty<LogEventProperty>());
+}

--- a/tests/Fallout.Build.Specs/ValueInjectionUtilitySpecs.cs
+++ b/tests/Fallout.Build.Specs/ValueInjectionUtilitySpecs.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+using FluentAssertions;
+using Fallout.Common.ValueInjection;
+using Xunit;
+
+namespace Fallout.Common.Specs;
+
+/// <summary>
+/// Covers <see cref="ValueInjectionUtility.ClearCache"/> added in FT-1 / #306. The injected-value
+/// cache is keyed by member and lives for the process, so <c>BuildManager.Execute</c>'s <c>finally</c>
+/// clears it — otherwise a second build in the same process would re-serve the first run's injected
+/// values instead of re-computing them.
+///
+/// A counting attribute makes the cache observable: the injected value is the running call count, so
+/// a cached read repeats the previous value while a post-<c>ClearCache</c> read re-injects a fresh one.
+/// </summary>
+public class ValueInjectionUtilitySpecs
+{
+    [Fact]
+    public void Value_is_cached_after_the_first_injection()
+    {
+        ValueInjectionUtility.ClearCache();
+        CountingInjectionAttribute.Reset();
+        var subject = new Subject();
+
+        var first = ValueInjectionUtility.TryGetValue(() => subject.Value);
+        var second = ValueInjectionUtility.TryGetValue(() => subject.Value);
+
+        first.Should().Be("1");
+        second.Should().Be("1", "the second read is served from the cache, not re-injected");
+        CountingInjectionAttribute.Invocations.Should().Be(1);
+    }
+
+    [Fact]
+    public void ClearCache_forces_re_injection_on_the_next_read()
+    {
+        ValueInjectionUtility.ClearCache();
+        CountingInjectionAttribute.Reset();
+        var subject = new Subject();
+
+        var first = ValueInjectionUtility.TryGetValue(() => subject.Value);
+
+        ValueInjectionUtility.ClearCache();
+        var afterClear = ValueInjectionUtility.TryGetValue(() => subject.Value);
+
+        first.Should().Be("1");
+        afterClear.Should().Be("2", "clearing the cache re-runs the injection");
+        CountingInjectionAttribute.Invocations.Should().Be(2);
+    }
+
+    private sealed class Subject
+    {
+        [CountingInjection]
+        public string Value;
+    }
+
+    private sealed class CountingInjectionAttribute : ValueInjectionAttributeBase
+    {
+        public static int Invocations { get; private set; }
+
+        public static void Reset() => Invocations = 0;
+
+        public override object GetValue(MemberInfo member, object instance) => (++Invocations).ToString();
+    }
+}

--- a/tests/Fallout.Tooling.Specs/ToolPathResolverResetSpecs.cs
+++ b/tests/Fallout.Tooling.Specs/ToolPathResolverResetSpecs.cs
@@ -1,0 +1,68 @@
+using System;
+using FluentAssertions;
+using Fallout.Common.IO;
+using Fallout.Common.Tooling;
+using Xunit;
+
+namespace Fallout.Common.Specs;
+
+/// <summary>
+/// Covers the per-run <c>Reset()</c> hooks added in FT-1 / #306: <see cref="BuildManager"/>'s
+/// <c>finally</c> calls these so a subsequent build in the same process starts from default
+/// package-location config instead of inheriting the previous run's residue.
+///
+/// Shares the resolvers' process-global static fields with <see cref="ToolTasksToolPathSpecs"/>,
+/// so both classes live in a non-parallelized collection — otherwise a concurrent test could
+/// observe a field mid-reset.
+/// </summary>
+[Collection(ToolPathResolverStateCollection.Name)]
+public class ToolPathResolverResetSpecs : IDisposable
+{
+    private readonly string _embeddedPackagesDirectory = NuGetToolPathResolver.EmbeddedPackagesDirectory;
+    private readonly string _nuGetPackagesConfigFile = NuGetToolPathResolver.NuGetPackagesConfigFile;
+    private readonly string _nuGetAssetsConfigFile = NuGetToolPathResolver.NuGetAssetsConfigFile;
+    private readonly string _paketPackagesConfigFile = NuGetToolPathResolver.PaketPackagesConfigFile;
+    private readonly AbsolutePath _npmPackageJsonFile = NpmToolPathResolver.NpmPackageJsonFile;
+
+    [Fact]
+    public void NuGetToolPathResolver_Reset_clears_every_package_location_field()
+    {
+        NuGetToolPathResolver.EmbeddedPackagesDirectory = "/packages";
+        NuGetToolPathResolver.NuGetPackagesConfigFile = "/packages.config";
+        NuGetToolPathResolver.NuGetAssetsConfigFile = "/project.assets.json";
+        NuGetToolPathResolver.PaketPackagesConfigFile = "/paket.dependencies";
+
+        NuGetToolPathResolver.Reset();
+
+        NuGetToolPathResolver.EmbeddedPackagesDirectory.Should().BeNull();
+        NuGetToolPathResolver.NuGetPackagesConfigFile.Should().BeNull();
+        NuGetToolPathResolver.NuGetAssetsConfigFile.Should().BeNull();
+        NuGetToolPathResolver.PaketPackagesConfigFile.Should().BeNull();
+    }
+
+    [Fact]
+    public void NpmToolPathResolver_Reset_clears_the_package_json_location()
+    {
+        NpmToolPathResolver.NpmPackageJsonFile = "/tmp/package.json";
+
+        NpmToolPathResolver.Reset();
+
+        NpmToolPathResolver.NpmPackageJsonFile.Should().BeNull();
+    }
+
+    // Restore whatever the ambient environment had so these mutations don't leak into sibling tests.
+    public void Dispose()
+    {
+        NuGetToolPathResolver.EmbeddedPackagesDirectory = _embeddedPackagesDirectory;
+        NuGetToolPathResolver.NuGetPackagesConfigFile = _nuGetPackagesConfigFile;
+        NuGetToolPathResolver.NuGetAssetsConfigFile = _nuGetAssetsConfigFile;
+        NuGetToolPathResolver.PaketPackagesConfigFile = _paketPackagesConfigFile;
+        NpmToolPathResolver.NpmPackageJsonFile = _npmPackageJsonFile;
+    }
+}
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class ToolPathResolverStateCollection
+{
+    public const string Name = "ToolPathResolverState";
+}

--- a/tests/Fallout.Tooling.Specs/ToolTasksToolPathSpecs.cs
+++ b/tests/Fallout.Tooling.Specs/ToolTasksToolPathSpecs.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Fallout.Common.Specs;
 
+[Collection(ToolPathResolverStateCollection.Name)]
 public class ToolTasksToolPathSpecs
 {
     public ToolTasksToolPathSpecs()


### PR DESCRIPTION
First step of the engine de-statification ([Foundation] epic [#315](https://github.com/Fallout-build/Fallout/issues/315)) — **FT-1 / [#306](https://github.com/Fallout-build/Fallout/issues/306)**. Non-breaking groundwork before the `BuildContext` foundation (FT-2).

`BuildManager.Execute` leaked process-global state across invocations, so a second build in the same process (tests, hosted/reentrant scenarios) inherited the first's residue:

- `Console.CancelKeyPress` / `ToolOptions.Created` handlers were re-subscribed every call and never removed — **accumulating**;
- the cancellation-handler list kept each run's `Finish` (capturing a stale `build`);
- `Logging.InMemorySink.Instance` carried log events over;
- `ValueInjectionUtility`'s value cache and the NuGet/Npm tool-path resolver config persisted.

**Fix:** the two global handlers are held in locals and the `finally` undoes exactly what the run set — unsubscribes both, drops `Finish` from the cancellation list, and resets the carried-over state (`InMemorySink.Clear`, `ValueInjectionUtility.ClearCache`, `NuGet`/`NpmToolPathResolver.Reset`). `new T()` moved ahead of the subscriptions so a failed build creation leaks nothing.

No public API change. The reentrancy guarantee itself is asserted by FT-9 (the isolation harness); this PR removes the leaks it will assert against. Full build + test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)