### PR TITLE
Introduce the per-run BuildContext foundation (FT-2)

### DIFF
--- a/src/Fallout.Build/Execution/BuildContext.cs
+++ b/src/Fallout.Build/Execution/BuildContext.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Fallout.Common.Tooling;
+using Fallout.Common.Utilities.Collections;
+using Fallout.Common.ValueInjection;
+
+namespace Fallout.Common.Execution;
+
+/// <summary>
+/// Per-run, process-ambient build state. Activated once at the top of <see cref="BuildManager.Execute{T}"/>
+/// and disposed at the end of the run, so the process-global statics a build touches are owned by a
+/// scope rather than leaking across invocations (the cleanup FT-1 centralised now lives here).
+/// The static surface (e.g. <see cref="BuildManager.CancellationHandler"/>) reads through
+/// <see cref="Current"/>, which is <c>AsyncLocal</c> — so concurrent runs each resolve their own
+/// context. That isolates the ambient pointer and the per-run state hanging off it (the cancellation
+/// handlers, the event subscriptions), <em>not</em> the process-global singletons the teardown resets
+/// (in-memory sink, value-injection cache, tool-path resolver config); those stay shared, so
+/// concurrent runs in one process still interfere through them.
+/// </summary>
+/// <remarks>
+/// FT-2 / <see href="https://github.com/Fallout-build/Fallout/issues/307">#307</see>. Intentionally
+/// <c>internal</c> — not a public contract until the SDK lands (milestone #7). Subsequent steps move
+/// the per-run services (parameters, logging scope, tool-path config) onto this context.
+/// </remarks>
+internal sealed class BuildContext : IDisposable
+{
+    private static readonly AsyncLocal<BuildContext> currentInstance = new();
+
+    /// <summary>The context for the current build run, or <c>null</c> outside a run.</summary>
+    public static BuildContext Current => currentInstance.Value;
+
+    private readonly LinkedList<Action> cancellationHandlers = new();
+    private readonly ConsoleCancelEventHandler onCancelKeyPress;
+    private readonly EventHandler onToolOptionsCreated;
+
+    private BuildContext()
+    {
+        onCancelKeyPress = (_, _) => cancellationHandlers.ForEach(x => x());
+        onToolOptionsCreated = (options, _) => VerbosityMapping.Apply((ToolOptions)options);
+        Console.CancelKeyPress += onCancelKeyPress;
+        ToolOptions.Created += onToolOptionsCreated;
+    }
+
+    /// <summary>Creates the ambient context for a build run and installs it as <see cref="Current"/>.</summary>
+    public static BuildContext Activate() => currentInstance.Value = new BuildContext();
+
+    public void RegisterCancellationHandler(Action handler) => cancellationHandlers.AddFirst(handler);
+
+    public void UnregisterCancellationHandler(Action handler) => cancellationHandlers.Remove(handler);
+
+    public void Dispose()
+    {
+        // This scope's own subscriptions come off unconditionally — they are per-instance, so undoing
+        // them can never affect another context.
+        Console.CancelKeyPress -= onCancelKeyPress;
+        ToolOptions.Created -= onToolOptionsCreated;
+
+        // The rest is shared process-wide state, so only the context that is still Current may reset
+        // it — a superseded scope disposing out of order must not clobber the newer run.
+        if (!ReferenceEquals(currentInstance.Value, this))
+            return;
+
+        Logging.InMemorySink.Instance.Clear();
+        ValueInjectionUtility.ClearCache();
+        NuGetToolPathResolver.Reset();
+        NpmToolPathResolver.Reset();
+
+        currentInstance.Value = null;
+    }
+}

--- a/src/Fallout.Build/Execution/BuildManager.cs
+++ b/src/Fallout.Build/Execution/BuildManager.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.DependencyModel;
 using Fallout.Common.Tooling;
 using Fallout.Common.Utilities;
 using Fallout.Common.Utilities.Collections;
-using Fallout.Common.ValueInjection;
 using Serilog;
 #pragma warning disable CA2255
 
@@ -18,12 +17,12 @@ internal static class BuildManager
 {
     private const int ErrorExitCode = -1;
 
-    private static readonly LinkedList<Action> cancellationHandlers = new();
-
+    // Facade over the active BuildContext (FT-2): callers register/unregister during a run; the
+    // context owns the handler list and discards it on dispose.
     public static event Action CancellationHandler
     {
-        add => cancellationHandlers.AddFirst(value);
-        remove => cancellationHandlers.Remove(value);
+        add => BuildContext.Current?.RegisterCancellationHandler(value);
+        remove => BuildContext.Current?.UnregisterCancellationHandler(value);
     }
 
     [ModuleInitializer]
@@ -40,15 +39,10 @@ internal static class BuildManager
         Console.OutputEncoding = Encoding.UTF8;
         Console.InputEncoding = Encoding.UTF8;
 
+        // The per-run scope owns the global subscriptions + teardown (FT-2 / #307). Disposed at
+        // method exit, so re-invocation in the same process starts clean even if `new T()` throws.
+        using var context = BuildContext.Activate();
         var build = new T();
-
-        // Hold the per-run global subscriptions in locals so the finally can undo exactly them —
-        // otherwise each Execute in the same process (tests, hosted scenarios) accumulates handlers.
-        // FT-1 / #306.
-        ConsoleCancelEventHandler onCancelKeyPress = (_, _) => cancellationHandlers.ForEach(x => x());
-        EventHandler onToolOptionsCreated = (options, _) => VerbosityMapping.Apply((ToolOptions)options);
-        Console.CancelKeyPress += onCancelKeyPress;
-        ToolOptions.Created += onToolOptionsCreated;
 
         try
         {
@@ -95,16 +89,8 @@ internal static class BuildManager
         {
             Finish();
             Log.CloseAndFlush();
-
-            // FT-1 (#306): undo this run's process-global state so a subsequent Execute in the same
-            // process starts clean — no accumulated handlers, no carried-over log events / caches / config.
-            CancellationHandler -= Finish;
-            Console.CancelKeyPress -= onCancelKeyPress;
-            ToolOptions.Created -= onToolOptionsCreated;
-            Logging.InMemorySink.Instance.Clear();
-            ValueInjectionUtility.ClearCache();
-            NuGetToolPathResolver.Reset();
-            NpmToolPathResolver.Reset();
+            // Per-run teardown (handler unsubscription + state reset) is owned by the BuildContext,
+            // run when `context` is disposed at method exit.
         }
 
         void Finish()

--- a/tests/Fallout.Build.Specs/BuildContextSpecs.cs
+++ b/tests/Fallout.Build.Specs/BuildContextSpecs.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Reflection;
+using FluentAssertions;
+using Fallout.Common.Execution;
+using Fallout.Common.IO;
+using Fallout.Common.Tooling;
+using Fallout.Common.ValueInjection;
+using Serilog.Events;
+using Serilog.Parsing;
+using Xunit;
+
+namespace Fallout.Common.Specs.Execution;
+
+/// <summary>
+/// Covers <see cref="BuildContext"/> (FT-2 / #307) — the per-run ambient scope that owns the
+/// process-global state a build touches. <see cref="BuildContext.Current"/> is <c>AsyncLocal</c>, so
+/// each case resolves its own context, but the singletons the teardown resets (in-memory sink,
+/// value-injection cache, resolver config) remain process-wide — assertions that touch them key on a
+/// sentinel rather than on the singleton being empty.
+/// </summary>
+[Collection(ProcessGlobalStateCollection.Name)]
+public class BuildContextSpecs
+{
+    [Fact]
+    public void Current_is_null_outside_a_run()
+    {
+        BuildContext.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public void Activate_installs_the_returned_context_as_current()
+    {
+        using var context = BuildContext.Activate();
+
+        BuildContext.Current.Should().BeSameAs(context);
+    }
+
+    [Fact]
+    public void Dispose_clears_current()
+    {
+        var context = BuildContext.Activate();
+        context.Dispose();
+
+        BuildContext.Current.Should().BeNull();
+    }
+
+    [Fact]
+    public void Disposing_a_superseded_context_leaves_the_newer_one_current()
+    {
+        var first = BuildContext.Activate();
+        using var second = BuildContext.Activate();
+
+        // Disposing the older scope must not clobber the newer Current — the guard keys on identity.
+        first.Dispose();
+
+        BuildContext.Current.Should().BeSameAs(second);
+    }
+
+    [Fact]
+    public void Disposing_a_superseded_context_leaves_the_shared_state_intact()
+    {
+        var sink = Logging.InMemorySink.Instance;
+        var sentinel = $"build-context-superseded-{Guid.NewGuid()}";
+
+        var first = BuildContext.Activate();
+        using var second = BuildContext.Activate();
+        NuGetToolPathResolver.EmbeddedPackagesDirectory = sentinel;
+        sink.Emit(CreateLogEvent(sentinel));
+
+        // `second` is the live run and this state belongs to it. The teardown resets are process-wide,
+        // so a superseded scope disposing out of order must skip them entirely — clearing Current is
+        // not the only thing the identity guard protects.
+        first.Dispose();
+
+        sink.LogEvents.Should().Contain(x => x.MessageTemplate.Text == sentinel);
+        NuGetToolPathResolver.EmbeddedPackagesDirectory.Should().Be(sentinel);
+    }
+
+    [Fact]
+    public void Dispose_resets_the_tool_path_resolver_configuration()
+    {
+        using (BuildContext.Activate())
+        {
+            NuGetToolPathResolver.EmbeddedPackagesDirectory = "/packages";
+            NuGetToolPathResolver.NuGetPackagesConfigFile = "/packages.config";
+            NpmToolPathResolver.NpmPackageJsonFile = (AbsolutePath)"/npm/package.json";
+        }
+
+        NuGetToolPathResolver.EmbeddedPackagesDirectory.Should().BeNull();
+        NuGetToolPathResolver.NuGetPackagesConfigFile.Should().BeNull();
+        NpmToolPathResolver.NpmPackageJsonFile.Should().BeNull();
+    }
+
+    [Fact]
+    public void Dispose_clears_the_value_injection_cache()
+    {
+        ValueInjectionUtility.ClearCache();
+        CountingInjectionAttribute.Reset();
+        var subject = new Subject();
+
+        using (BuildContext.Activate())
+            ValueInjectionUtility.TryGetValue(() => subject.Value).Should().Be("1");
+
+        // The context's teardown cleared the cache, so this read re-injects rather than replaying the
+        // value the previous run computed.
+        ValueInjectionUtility.TryGetValue(() => subject.Value).Should().Be("2");
+        CountingInjectionAttribute.Invocations.Should().Be(2);
+    }
+
+    [Fact]
+    public void Cancellation_handler_facade_is_a_no_op_without_an_active_context()
+    {
+        Action noop = () => { };
+
+        // Register/unregister route through Current; outside a run there is nothing to route to, so
+        // the facade must swallow the call rather than throw.
+        var subscribe = () =>
+        {
+            BuildManager.CancellationHandler += noop;
+            BuildManager.CancellationHandler -= noop;
+        };
+
+        subscribe.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Dispose_runs_the_per_run_teardown()
+    {
+        var sink = Logging.InMemorySink.Instance;
+        var sentinel = $"build-context-teardown-{Guid.NewGuid()}";
+
+        using (BuildContext.Activate())
+            sink.Emit(CreateLogEvent(sentinel));
+
+        // Leaving the scope disposes the context, whose teardown clears the shared in-memory sink so a
+        // subsequent run in the same process starts clean. Assert on the sentinel specifically so a
+        // build emitting on another flow can't make this flaky.
+        sink.LogEvents.Should().NotContain(x => x.MessageTemplate.Text == sentinel);
+    }
+
+    private static LogEvent CreateLogEvent(string message) =>
+        new(
+            timestamp: DateTimeOffset.UnixEpoch,
+            level: LogEventLevel.Warning,
+            exception: null,
+            messageTemplate: new MessageTemplateParser().Parse(message),
+            properties: Array.Empty<LogEventProperty>());
+
+    // Makes the injected-value cache observable: the value is the running invocation count, so a
+    // cached read repeats the previous value while a re-injected one increments.
+    private sealed class Subject
+    {
+        [CountingInjection]
+        public string Value;
+    }
+
+    private sealed class CountingInjectionAttribute : ValueInjectionAttributeBase
+    {
+        public static int Invocations { get; private set; }
+
+        public static void Reset() => Invocations = 0;
+
+        public override object GetValue(MemberInfo member, object instance) => (++Invocations).ToString();
+    }
+}

--- a/tests/Fallout.Build.Specs/InMemorySinkSpecs.cs
+++ b/tests/Fallout.Build.Specs/InMemorySinkSpecs.cs
@@ -13,6 +13,7 @@ namespace Fallout.Common.Specs;
 /// stop one run's warnings/errors bleeding into the next build in the same process; <c>Dispose()</c>
 /// delegates to the same reset.
 /// </summary>
+[Collection(ProcessGlobalStateCollection.Name)]
 public class InMemorySinkSpecs
 {
     private static readonly Logging.InMemorySink Sink = Logging.InMemorySink.Instance;

--- a/tests/Fallout.Build.Specs/ProcessGlobalStateCollection.cs
+++ b/tests/Fallout.Build.Specs/ProcessGlobalStateCollection.cs
@@ -1,0 +1,15 @@
+using Xunit;
+
+namespace Fallout.Common.Specs;
+
+/// <summary>
+/// Serialises the specs that read or mutate the process-wide singletons a build run touches — the
+/// in-memory sink, the value-injection cache, the tool-path resolver config. xUnit runs test classes
+/// in parallel by default, and these singletons are shared across every flow, so without a common
+/// collection one class's reset can land in the middle of another's arrange/assert.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class ProcessGlobalStateCollection
+{
+    public const string Name = "process-global state";
+}

--- a/tests/Fallout.Build.Specs/ValueInjectionUtilitySpecs.cs
+++ b/tests/Fallout.Build.Specs/ValueInjectionUtilitySpecs.cs
@@ -14,6 +14,7 @@ namespace Fallout.Common.Specs;
 /// A counting attribute makes the cache observable: the injected value is the running call count, so
 /// a cached read repeats the previous value while a post-<c>ClearCache</c> read re-injects a fresh one.
 /// </summary>
+[Collection(ProcessGlobalStateCollection.Name)]
 public class ValueInjectionUtilitySpecs
 {
     [Fact]


### PR DESCRIPTION
Engine de-statification ([Foundation] epic [#315](https://github.com/Fallout-build/Fallout/issues/315)) — **FT-2 / [#307](https://github.com/Fallout-build/Fallout/issues/307)**. The foundation the rest of the de-static work rides. Rebased onto `main` now that FT-1 ([#450](https://github.com/Fallout-build/Fallout/pull/450)) has landed, so the diff is just the FT-2 change.

Adds **`BuildContext`** — an internal, per-run, `AsyncLocal`-ambient scope:
- activated at the top of `BuildManager.Execute` (`using var context = BuildContext.Activate()`), disposed at method exit;
- **owns the per-run global-state lifecycle** — the `Console.CancelKeyPress` / `ToolOptions.Created` subscriptions, the cancellation-handler list (moved off `BuildManager`), and the FT-1 teardown (now run on dispose);
- `BuildManager.CancellationHandler` becomes a thin facade over `BuildContext.Current` — the first "static surface over the context" seam.

Because the handler list is now owned by the context and discarded wholesale on dispose, `BuildExecutor`'s `ExecuteAssuredTargets` subscription — which was never explicitly unsubscribed — no longer persists across in-process invocations. FT-2 tightens that leak in passing.

Subsequent steps move the per-run services onto the context: FT-4 `ParameterService`, FT-5 tool-path config, FT-6 logging scope. Internal-only — not a public contract until the SDK (milestone #7). Disposing on method exit means a failed `new T()` also leaks nothing.

**Tests** — `BuildContextSpecs` covers the new surface: `Current` lifecycle, the identity guard that stops a superseded context from clobbering a newer `Current`, the facade no-op outside a run, and that dispose runs the per-run teardown. Full build + test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
