### PR TITLE
Move ParameterService onto the BuildContext (FT-4)

### DIFF
--- a/src/Fallout.Build/Execution/BuildContext.cs
+++ b/src/Fallout.Build/Execution/BuildContext.cs
@@ -21,7 +21,8 @@ namespace Fallout.Common.Execution;
 /// <remarks>
 /// FT-2 / <see href="https://github.com/Fallout-build/Fallout/issues/307">#307</see>. Intentionally
 /// <c>internal</c> — not a public contract until the SDK lands (milestone #7). Subsequent steps move
-/// the per-run services (parameters, logging scope, tool-path config) onto this context.
+/// the remaining per-run services (logging scope, tool-path config) onto this context; the parameter
+/// service already rides it (FT-4 / <see href="https://github.com/Fallout-build/Fallout/issues/309">#309</see>).
 /// </remarks>
 internal sealed class BuildContext : IDisposable
 {
@@ -33,6 +34,15 @@ internal sealed class BuildContext : IDisposable
     private readonly LinkedList<Action> cancellationHandlers = new();
     private readonly ConsoleCancelEventHandler onCancelKeyPress;
     private readonly EventHandler onToolOptionsCreated;
+
+    /// <summary>
+    /// The parameter service for this run. FT-4 / <see href="https://github.com/Fallout-build/Fallout/issues/309">#309</see>:
+    /// this instance is what the static <see cref="ParameterService.Instance"/> facade resolves to, so a
+    /// build reads parameters through the same instance form the specs already use, and the service's
+    /// mutable fields die with the run instead of leaking into the next one.
+    /// </summary>
+    public ParameterService Parameters { get; } =
+        new(() => EnvironmentInfo.ArgumentParser, () => EnvironmentInfo.Variables);
 
     private BuildContext()
     {

--- a/src/Fallout.Build/Execution/ParameterService.Statics.cs
+++ b/src/Fallout.Build/Execution/ParameterService.Statics.cs
@@ -1,15 +1,21 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using Fallout.Common.Execution;
 using Fallout.Common.Utilities;
 
 namespace Fallout.Common;
 
 internal partial class ParameterService
 {
-    internal static ParameterService Instance = new(
-        () => EnvironmentInfo.ArgumentParser,
-        () => EnvironmentInfo.Variables);
+    // FT-4 (#309): the active service is the per-run one on BuildContext, so a build reads parameters
+    // through the same instance form the specs use and nothing leaks into the next run. The fallback
+    // covers access outside a run — process-wide, but there is no cross-run state to leak there — and
+    // can retire once that path is confirmed dead.
+    private static readonly Lazy<ParameterService> ambientInstance = new(
+        () => new ParameterService(() => EnvironmentInfo.ArgumentParser, () => EnvironmentInfo.Variables));
+
+    internal static ParameterService Instance => BuildContext.Current?.Parameters ?? ambientInstance.Value;
 
     public static T GetParameter<T>(string name, char? separator = null)
     {

--- a/tests/Fallout.Build.Specs/BuildContextSpecs.cs
+++ b/tests/Fallout.Build.Specs/BuildContextSpecs.cs
@@ -44,6 +44,52 @@ public class BuildContextSpecs
     }
 
     [Fact]
+    public void Parameter_service_facade_resolves_the_current_contexts_instance()
+    {
+        using var context = BuildContext.Activate();
+
+        // FT-4 (#309): the static facade is a pointer at the running context, not its own singleton.
+        ParameterService.Instance.Should().BeSameAs(context.Parameters);
+    }
+
+    [Fact]
+    public void Parameter_service_facade_falls_back_to_an_ambient_instance_outside_a_run()
+    {
+        BuildContext.Current.Should().BeNull();
+
+        // Nothing to route to outside a run, so the facade hands back a stable process-wide instance
+        // rather than throwing — this is the path the fallback exists for.
+        ParameterService.Instance.Should().NotBeNull();
+        ParameterService.Instance.Should().BeSameAs(ParameterService.Instance);
+    }
+
+    [Fact]
+    public void Each_run_gets_its_own_parameter_service()
+    {
+        ParameterService first;
+        ParameterService second;
+
+        using (var context = BuildContext.Activate())
+            first = context.Parameters;
+        using (var context = BuildContext.Activate())
+            second = context.Parameters;
+
+        second.Should().NotBeSameAs(first);
+    }
+
+    [Fact]
+    public void Parameter_service_state_does_not_leak_into_the_next_run()
+    {
+        using (BuildContext.Activate())
+            ParameterService.Instance.ArgumentsFromCommitMessageService = new ArgumentParser(["-arg", "value"]);
+
+        // The mutable per-run fields (commit-message args, args-from-files) died with the previous
+        // context — the whole point of moving the service off a process-global singleton.
+        using (BuildContext.Activate())
+            ParameterService.Instance.ArgumentsFromCommitMessageService.Should().BeNull();
+    }
+
+    [Fact]
     public void Disposing_a_superseded_context_leaves_the_newer_one_current()
     {
         var first = BuildContext.Activate();


### PR DESCRIPTION
Moves `ParameterService` from a static singleton onto `BuildContext`, so each build run gets its own instance instead of sharing process-wide state.

### What changed
- Adds a `Parameters` property to `BuildContext` holding a per-run `ParameterService`.
- `ParameterService.Instance` becomes a facade over `BuildContext.Current.Parameters`, with a lazy ambient fallback for use outside a run.
- Adds four cases to `BuildContextSpecs`: the facade resolves the running context's instance, falls back to a stable instance outside a run, each run gets its own service, and a mutated per-run field doesn't leak into the next run.

### Why
Production and the specs now use the same instance form — the specs already built `ParameterService` directly, but production relied on the static singleton. The singleton's mutable fields (`ArgumentsFromFilesService`, `ArgumentsFromCommitMessageService`) used to live for the whole process, so state could leak between runs. Scoping the service to `BuildContext` closes that gap.

The ambient ("ready-to-use without setup") ​fallback stays process-wide for now, since there's no cross-run state left to leak on that path. It can be removed once we confirm nothing uses `ParameterService` outside a run.

Non-breaking — the static `ParameterService` API is unchanged.

Part of #309 (FT-4, the third step of the engine de-statification work), following #450 (FT-1) and #451 (FT-2, which set up the pattern this PR reuses). Part of the epic #315.

### Verification
Full build + full spec suite green (14 projects, 0 failures).