### PR TITLE
Per-run logging scope: in-memory sink onto BuildContext (FT-6)

### DIFF
--- a/src/Fallout.Build/Execution/BuildContext.cs
+++ b/src/Fallout.Build/Execution/BuildContext.cs
@@ -21,7 +21,8 @@ namespace Fallout.Common.Execution;
 /// <remarks>
 /// FT-2 / <see href="https://github.com/Fallout-build/Fallout/issues/307">#307</see>. Intentionally
 /// <c>internal</c> — not a public contract until the SDK lands (milestone #7). Subsequent steps move
-/// the per-run services (parameters, logging scope, tool-path config) onto this context.
+/// the remaining per-run services (logging scope, tool-path config) onto this context; the parameter
+/// service already rides it (FT-4 / <see href="https://github.com/Fallout-build/Fallout/issues/309">#309</see>).
 /// </remarks>
 internal sealed class BuildContext : IDisposable
 {
@@ -33,6 +34,15 @@ internal sealed class BuildContext : IDisposable
     private readonly LinkedList<Action> cancellationHandlers = new();
     private readonly ConsoleCancelEventHandler onCancelKeyPress;
     private readonly EventHandler onToolOptionsCreated;
+
+    /// <summary>
+    /// The parameter service for this run. FT-4 / <see href="https://github.com/Fallout-build/Fallout/issues/309">#309</see>:
+    /// this instance is what the static <see cref="ParameterService.Instance"/> facade resolves to, so a
+    /// build reads parameters through the same instance form the specs already use, and the service's
+    /// mutable fields die with the run instead of leaking into the next one.
+    /// </summary>
+    public ParameterService Parameters { get; } =
+        new(() => EnvironmentInfo.ArgumentParser, () => EnvironmentInfo.Variables);
 
     private BuildContext()
     {

--- a/src/Fallout.Build/Execution/BuildContext.cs
+++ b/src/Fallout.Build/Execution/BuildContext.cs
@@ -14,15 +14,16 @@ namespace Fallout.Common.Execution;
 /// The static surface (e.g. <see cref="BuildManager.CancellationHandler"/>) reads through
 /// <see cref="Current"/>, which is <c>AsyncLocal</c> — so concurrent runs each resolve their own
 /// context. That isolates the ambient pointer and the per-run state hanging off it (the cancellation
-/// handlers, the event subscriptions), <em>not</em> the process-global singletons the teardown resets
-/// (in-memory sink, value-injection cache, tool-path resolver config); those stay shared, so
+/// handlers, the event subscriptions, the services below), <em>not</em> the process-global singletons
+/// the teardown resets (value-injection cache, tool-path resolver config); those stay shared, so
 /// concurrent runs in one process still interfere through them.
 /// </summary>
 /// <remarks>
 /// FT-2 / <see href="https://github.com/Fallout-build/Fallout/issues/307">#307</see>. Intentionally
-/// <c>internal</c> — not a public contract until the SDK lands (milestone #7). Subsequent steps move
-/// the remaining per-run services (logging scope, tool-path config) onto this context; the parameter
-/// service already rides it (FT-4 / <see href="https://github.com/Fallout-build/Fallout/issues/309">#309</see>).
+/// <c>internal</c> — not a public contract until the SDK lands (milestone #7). Services move onto this
+/// context one step at a time: the parameter service (FT-4 / <see href="https://github.com/Fallout-build/Fallout/issues/309">#309</see>)
+/// and the in-memory log sink (FT-6 / <see href="https://github.com/Fallout-build/Fallout/issues/311">#311</see>)
+/// ride it already; the tool-path configuration is next.
 /// </remarks>
 internal sealed class BuildContext : IDisposable
 {
@@ -44,6 +45,14 @@ internal sealed class BuildContext : IDisposable
     public ParameterService Parameters { get; } =
         new(() => EnvironmentInfo.ArgumentParser, () => EnvironmentInfo.Variables);
 
+    /// <summary>
+    /// The in-memory log sink for this run. FT-6 / <see href="https://github.com/Fallout-build/Fallout/issues/311">#311</see>:
+    /// <c>Logging.ConfigureInMemory</c> wires Serilog to this instance at the top of the run and
+    /// <c>WriteErrorsAndWarnings</c> reads it back at the end, both inside the scope — so a run's
+    /// warnings and errors are discarded with it rather than resurfacing in the next build.
+    /// </summary>
+    public Logging.InMemorySink LogSink { get; } = new();
+
     private BuildContext()
     {
         onCancelKeyPress = (_, _) => cancellationHandlers.ForEach(x => x());
@@ -62,18 +71,18 @@ internal sealed class BuildContext : IDisposable
     public void Dispose()
     {
         // This scope's own subscriptions come off unconditionally — they are per-instance, so undoing
-        // them can never affect another context.
+        // them can never affect another context. The same goes for the per-run services hanging off
+        // this instance (Parameters, LogSink): they are discarded with the context, never reset.
         Console.CancelKeyPress -= onCancelKeyPress;
         ToolOptions.Created -= onToolOptionsCreated;
 
-        // The rest is shared process-wide state, so only the context that is still Current may reset
-        // it — a superseded scope disposing out of order must not clobber the newer run.
+        // What remains below is shared process-wide state, so only the context that is still Current
+        // may reset it — a superseded scope disposing out of order must not clobber the newer run.
         if (!ReferenceEquals(currentInstance.Value, this))
         {
             return;
         }
 
-        Logging.InMemorySink.Instance.Clear();
         ValueInjectionUtility.ClearCache();
         NuGetToolPathResolver.Reset();
         NpmToolPathResolver.Reset();

--- a/src/Fallout.Build/Execution/ParameterService.Statics.cs
+++ b/src/Fallout.Build/Execution/ParameterService.Statics.cs
@@ -1,15 +1,21 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using Fallout.Common.Execution;
 using Fallout.Common.Utilities;
 
 namespace Fallout.Common;
 
 internal partial class ParameterService
 {
-    internal static ParameterService Instance = new(
-        () => EnvironmentInfo.ArgumentParser,
-        () => EnvironmentInfo.Variables);
+    // FT-4 (#309): the active service is the per-run one on BuildContext, so a build reads parameters
+    // through the same instance form the specs use and nothing leaks into the next run. The fallback
+    // covers access outside a run — process-wide, but there is no cross-run state to leak there — and
+    // can retire once that path is confirmed dead.
+    private static readonly Lazy<ParameterService> ambientInstance = new(
+        () => new ParameterService(() => EnvironmentInfo.ArgumentParser, () => EnvironmentInfo.Variables));
+
+    internal static ParameterService Instance => BuildContext.Current?.Parameters ?? ambientInstance.Value;
 
     public static T GetParameter<T>(string name, char? separator = null)
     {

--- a/src/Fallout.Build/Logging.cs
+++ b/src/Fallout.Build/Logging.cs
@@ -242,11 +242,16 @@ public static class Logging
 
     public class InMemorySink : ILogEventSink, IDisposable
     {
-        public static InMemorySink Instance { get; } = new();
+        // FT-6 (#311): the active sink is the per-run one on BuildContext, so one build's warnings and
+        // errors cannot resurface in the next build in the same process. The fallback covers logging
+        // outside a run — process-wide, but with no run for its events to bleed into.
+        private static readonly Lazy<InMemorySink> ambientInstance = new(() => new InMemorySink());
+
+        public static InMemorySink Instance => BuildContext.Current?.LogSink ?? ambientInstance.Value;
 
         private readonly List<LogEvent> logEvents;
 
-        private InMemorySink()
+        internal InMemorySink()
         {
             logEvents = new List<LogEvent>();
         }
@@ -259,7 +264,11 @@ public static class Logging
             logEvents.Add(logEvent);
         }
 
-        /// <summary>Drops accumulated events so a subsequent build in the same process starts clean. FT-1 / #306.</summary>
+        /// <summary>
+        /// Drops accumulated events. Since FT-6 / #311 a run's sink is discarded with its
+        /// <see cref="BuildContext"/>, so this is no longer needed to keep runs from bleeding into each
+        /// other — it stays for explicit resets (and for <see cref="Dispose"/>).
+        /// </summary>
         public void Clear()
         {
             logEvents.Clear();

--- a/tests/Fallout.Build.Specs/BuildContextSpecs.cs
+++ b/tests/Fallout.Build.Specs/BuildContextSpecs.cs
@@ -44,6 +44,52 @@ public class BuildContextSpecs
     }
 
     [Fact]
+    public void Parameter_service_facade_resolves_the_current_contexts_instance()
+    {
+        using var context = BuildContext.Activate();
+
+        // FT-4 (#309): the static facade is a pointer at the running context, not its own singleton.
+        ParameterService.Instance.Should().BeSameAs(context.Parameters);
+    }
+
+    [Fact]
+    public void Parameter_service_facade_falls_back_to_an_ambient_instance_outside_a_run()
+    {
+        BuildContext.Current.Should().BeNull();
+
+        // Nothing to route to outside a run, so the facade hands back a stable process-wide instance
+        // rather than throwing — this is the path the fallback exists for.
+        ParameterService.Instance.Should().NotBeNull();
+        ParameterService.Instance.Should().BeSameAs(ParameterService.Instance);
+    }
+
+    [Fact]
+    public void Each_run_gets_its_own_parameter_service()
+    {
+        ParameterService first;
+        ParameterService second;
+
+        using (var context = BuildContext.Activate())
+            first = context.Parameters;
+        using (var context = BuildContext.Activate())
+            second = context.Parameters;
+
+        second.Should().NotBeSameAs(first);
+    }
+
+    [Fact]
+    public void Parameter_service_state_does_not_leak_into_the_next_run()
+    {
+        using (BuildContext.Activate())
+            ParameterService.Instance.ArgumentsFromCommitMessageService = new ArgumentParser(["-arg", "value"]);
+
+        // The mutable per-run fields (commit-message args, args-from-files) died with the previous
+        // context — the whole point of moving the service off a process-global singleton.
+        using (BuildContext.Activate())
+            ParameterService.Instance.ArgumentsFromCommitMessageService.Should().BeNull();
+    }
+
+    [Fact]
     public void Disposing_a_superseded_context_leaves_the_newer_one_current()
     {
         var first = BuildContext.Activate();

--- a/tests/Fallout.Build.Specs/BuildContextSpecs.cs
+++ b/tests/Fallout.Build.Specs/BuildContextSpecs.cs
@@ -12,10 +12,11 @@ namespace Fallout.Common.Specs.Execution;
 
 /// <summary>
 /// Covers <see cref="BuildContext"/> (FT-2 / #307) — the per-run ambient scope that owns the
-/// process-global state a build touches. <see cref="BuildContext.Current"/> is <c>AsyncLocal</c>, so
-/// each case resolves its own context, but the singletons the teardown resets (in-memory sink,
-/// value-injection cache, resolver config) remain process-wide — assertions that touch them key on a
-/// sentinel rather than on the singleton being empty.
+/// process-global state a build touches, plus the services that have since moved onto it (the
+/// parameter service, FT-4 / #309; the in-memory log sink, FT-6 / #311).
+/// <see cref="BuildContext.Current"/> is <c>AsyncLocal</c>, so each case resolves its own context, but
+/// the singletons the teardown still resets (value-injection cache, resolver config) remain
+/// process-wide — assertions that touch those key on a sentinel rather than on the singleton being empty.
 /// </summary>
 [Collection(ProcessGlobalStateCollection.Name)]
 public class BuildContextSpecs
@@ -90,6 +91,39 @@ public class BuildContextSpecs
     }
 
     [Fact]
+    public void Log_sink_facade_resolves_the_current_contexts_sink()
+    {
+        using var context = BuildContext.Activate();
+
+        // FT-6 (#311): same seam as the parameter service — the static sink is a pointer at the run.
+        Logging.InMemorySink.Instance.Should().BeSameAs(context.LogSink);
+    }
+
+    [Fact]
+    public void Log_sink_facade_falls_back_to_an_ambient_sink_outside_a_run()
+    {
+        BuildContext.Current.Should().BeNull();
+
+        // Logging outside a run (a CLI command, a spec) has to land somewhere rather than throw.
+        Logging.InMemorySink.Instance.Should().NotBeNull();
+        Logging.InMemorySink.Instance.Should().BeSameAs(Logging.InMemorySink.Instance);
+    }
+
+    [Fact]
+    public void Each_run_gets_its_own_log_sink()
+    {
+        Logging.InMemorySink first;
+        Logging.InMemorySink second;
+
+        using (var context = BuildContext.Activate())
+            first = context.LogSink;
+        using (var context = BuildContext.Activate())
+            second = context.LogSink;
+
+        second.Should().NotBeSameAs(first);
+    }
+
+    [Fact]
     public void Disposing_a_superseded_context_leaves_the_newer_one_current()
     {
         var first = BuildContext.Activate();
@@ -104,20 +138,17 @@ public class BuildContextSpecs
     [Fact]
     public void Disposing_a_superseded_context_leaves_the_shared_state_intact()
     {
-        var sink = Logging.InMemorySink.Instance;
         var sentinel = $"build-context-superseded-{Guid.NewGuid()}";
 
         var first = BuildContext.Activate();
         using var second = BuildContext.Activate();
         NuGetToolPathResolver.EmbeddedPackagesDirectory = sentinel;
-        sink.Emit(CreateLogEvent(sentinel));
 
-        // `second` is the live run and this state belongs to it. The teardown resets are process-wide,
+        // `second` is the live run and this config belongs to it. The teardown resets are process-wide,
         // so a superseded scope disposing out of order must skip them entirely — clearing Current is
         // not the only thing the identity guard protects.
         first.Dispose();
 
-        sink.LogEvents.Should().Contain(x => x.MessageTemplate.Text == sentinel);
         NuGetToolPathResolver.EmbeddedPackagesDirectory.Should().Be(sentinel);
     }
 
@@ -171,20 +202,22 @@ public class BuildContextSpecs
     }
 
     [Fact]
-    public void Dispose_runs_the_per_run_teardown()
+    public void Log_events_do_not_carry_into_the_next_run()
     {
-        var sink = Logging.InMemorySink.Instance;
-        var sentinel = $"build-context-teardown-{Guid.NewGuid()}";
+        var sentinel = $"build-context-log-{Guid.NewGuid()}";
 
         using (BuildContext.Activate())
         {
-            sink.Emit(CreateLogEvent(sentinel));
+            Logging.InMemorySink.Instance.Emit(CreateLogEvent(sentinel));
         }
 
-        // Leaving the scope disposes the context, whose teardown clears the shared in-memory sink so a
-        // subsequent run in the same process starts clean. Assert on the sentinel specifically so a
-        // build emitting on another flow can't make this flaky.
-        sink.LogEvents.Should().NotContain(x => x.MessageTemplate.Text == sentinel);
+        // FT-6 (#311): the sink belonged to the run that just ended and went out of scope with it, so
+        // the next run starts on an empty one. Nothing clears a shared sink — there is no shared sink.
+        // Assert on the sentinel specifically so a build emitting on another flow can't make it flaky.
+        using (BuildContext.Activate())
+        {
+            Logging.InMemorySink.Instance.LogEvents.Should().NotContain(x => x.MessageTemplate.Text == sentinel);
+        }
     }
 
     private static LogEvent CreateLogEvent(string message) =>

--- a/tests/Fallout.Build.Specs/InMemorySinkSpecs.cs
+++ b/tests/Fallout.Build.Specs/InMemorySinkSpecs.cs
@@ -8,54 +8,53 @@ using Xunit;
 namespace Fallout.Common.Specs;
 
 /// <summary>
-/// Covers <see cref="Logging.InMemorySink"/>'s reset added in FT-1 / #306. The sink is a
-/// process-wide singleton, so <c>BuildManager.Execute</c>'s <c>finally</c> calls <c>Clear()</c> to
-/// stop one run's warnings/errors bleeding into the next build in the same process; <c>Dispose()</c>
-/// delegates to the same reset.
+/// Covers <see cref="Logging.InMemorySink"/>'s own reset behaviour (FT-1 / #306). Since FT-6 / #311 a
+/// sink is per-run state owned by a <see cref="BuildContext"/> rather than a process-wide singleton, so
+/// each case exercises its own instance and nothing here needs serialising against other specs. How the
+/// per-run sink is resolved and scoped is covered by <c>BuildContextSpecs</c>.
 /// </summary>
-[Collection(ProcessGlobalStateCollection.Name)]
 public class InMemorySinkSpecs
 {
-    private static readonly Logging.InMemorySink Sink = Logging.InMemorySink.Instance;
-
-    public InMemorySinkSpecs()
-    {
-        // Normalize the shared singleton before each case — prior runs (or a real logging pipeline)
-        // may have left events behind.
-        Sink.Clear();
-    }
+    private readonly Logging.InMemorySink sink = new();
 
     [Fact]
     public void Clear_drops_accumulated_events()
     {
-        Sink.Emit(CreateLogEvent("first"));
-        Sink.Emit(CreateLogEvent("second"));
-        Sink.LogEvents.Should().HaveCount(2);
+        sink.Emit(CreateLogEvent("first"));
+        sink.Emit(CreateLogEvent("second"));
+        sink.LogEvents.Should().HaveCount(2);
 
-        Sink.Clear();
+        sink.Clear();
 
-        Sink.LogEvents.Should().BeEmpty();
+        sink.LogEvents.Should().BeEmpty();
     }
 
     [Fact]
     public void Dispose_drops_accumulated_events()
     {
-        Sink.Emit(CreateLogEvent("only"));
-        Sink.LogEvents.Should().ContainSingle();
+        sink.Emit(CreateLogEvent("only"));
+        sink.LogEvents.Should().ContainSingle();
 
-        Sink.Dispose();
+        sink.Dispose();
 
-        Sink.LogEvents.Should().BeEmpty();
+        sink.LogEvents.Should().BeEmpty();
     }
 
     [Fact]
     public void Clear_on_an_empty_sink_is_a_no_op()
     {
-        Sink.LogEvents.Should().BeEmpty();
+        sink.LogEvents.Should().BeEmpty();
 
-        Sink.Clear();
+        sink.Clear();
 
-        Sink.LogEvents.Should().BeEmpty();
+        sink.LogEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void A_new_sink_starts_empty()
+    {
+        // A run's sink is constructed with its context, so a build never inherits earlier events.
+        new Logging.InMemorySink().LogEvents.Should().BeEmpty();
     }
 
     private static LogEvent CreateLogEvent(string message) =>


### PR DESCRIPTION
⏳ **Stacked on [#452](https://github.com/Fallout-build/Fallout/pull/452)** (FT-4) — the diff includes its two commits until it merges. FT-1 and FT-2 have landed and are gone from the diff.

Engine de-statification ([Foundation] epic [#315](https://github.com/Fallout-build/Fallout/issues/315)) — **FT-6 / [#311](https://github.com/Fallout-build/Fallout/issues/311)**. Second service to ride the `BuildContext` rail.

`Logging.InMemorySink` is now owned per-run by `BuildContext.LogSink`; the static `InMemorySink.Instance` is a facade over `BuildContext.Current`, with a lazy ambient fallback outside a run. `ConfigureInMemory` wires the sink at the top of the run and `WriteErrorsAndWarnings` reads it at the end — both inside the scope — so **a build's warnings and errors are discarded with its context** instead of resurfacing in the next in-process invocation.

The FT-1 `InMemorySink.Clear()` on dispose is dropped: there is no shared sink left to clear. `Clear()` itself stays for explicit resets, and the constructor becomes `internal` so a context (or a spec) can make its own.

**Tests** — mirrors the FT-4 cases for the sink (facade resolves the run's sink, ambient fallback outside a run, each run gets its own). Two existing cases moved with the mechanism:

- `Dispose_runs_the_per_run_teardown` used the shared sink as its witness and **fails once dispose stops clearing it** — verified against this branch. It becomes `Log_events_do_not_carry_into_the_next_run`, asserting the guarantee directly instead of via the reset.
- `Disposing_a_superseded_context_leaves_the_shared_state_intact` drops its sink witness (no longer shared state) and keeps the resolver-config one.

`InMemorySinkSpecs` now exercises its own instance, so it leaves the process-global collection.

Non-breaking — the public `Logging` surface is unchanged; `InMemorySink.Instance` keeps its signature and only changes *which* sink it hands back during a run. Full build + full spec suite green (14 projects, 0 failures; `Build.Specs` 160 → 164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
