### PR TITLE
Codify camelCase private-field naming (no s_ prefix) in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -70,6 +70,20 @@ dotnet_naming_symbols.constant_fields.required_modifiers = const
 
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
+# name private fields (instance and static) using camelCase, with no _ / m_ / g_ / s_ prefix
+# CSharpGuidelines AV1702 (camelCase private fields) + AV1705 (no field prefixes).
+# Ordered after constant_fields so private const still resolves to PascalCase above.
+# Severity is suggestion for now: the repo still carries ~100 s_-prefixed fields, so a
+# warning/error flip is gated on the one-time migration sweep (see PR description).
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.private_fields_should_be_camel_case.symbols  = private_fields
+dotnet_naming_rule.private_fields_should_be_camel_case.style    = camel_case_style
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
 # Code style defaults
 csharp_using_directive_placement = outside_namespace:warning
 dotnet_sort_system_directives_first = true


### PR DESCRIPTION
## Problem
No enforced repo standard for private field naming. Fields are split between the dotnet/runtime `s_camelCase` style (~100 occurrences, 39 files) and ad-hoc `PascalCase`. `.editorconfig` only governs `const` fields today.

## What this does
Adds a `dotnet_naming_rule` codifying **CSharpGuidelines AV1702** (camelCase private fields) + **AV1705** (no `_`/`m_`/`g_`/`s_` prefixes). Ordered after the existing constant-fields rule so `private const` still resolves to PascalCase.

## Why draft — this is a coordinated workstream
Severity is **`suggestion`** deliberately. The ~100 existing `s_` fields mean a `warning`/`error` flip fails the build until they're renamed. Open questions to settle before this leaves draft:

- [ ] Target severity (`suggestion` → `warning` → `error`?)
- [ ] Sequence the one-time migration sweep (single mechanical PR vs. incremental as files are touched)
- [ ] Confirm `PascalCase` static-readonly cases (e.g. `KnownWords`, regex `Pattern` fields) are in scope for the rename
- [ ] Decide whether `AV1708` (`Manager`/`Utility`/`Helper` in type names, e.g. `BuildManager`) is folded in or tracked separately

The localized `s_cancellationHandlers` → `cancellationHandlers` rename already landed on #450 as manual cleanup; this PR is the repo-wide follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
