### PR TITLE
Support for Windows not on the C drive

### DIFF
--- a/src/Fallout.Tooling/ToolPathResolver.cs
+++ b/src/Fallout.Tooling/ToolPathResolver.cs
@@ -24,7 +24,7 @@ public static class ToolPathResolver
             return Path.GetFullPath(pathExecutable);
 
         var locateExecutable = EnvironmentInfo.IsWin
-            ? @"C:\Windows\System32\where.exe"
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "where.exe")
             : "/usr/bin/which";
 
         if (!File.Exists(locateExecutable))


### PR DESCRIPTION
<!-- Keep it terse: one-line summary, then short "what changed" bullets. -->
<!-- Link the issue and summarize it — don't recite it. See docs/agents/issue-and-pr-style.md. -->
<!-- Or let Copilot draft one, then trim it. -->

More reliable way to find "where" utility based on a real machine with Windows installed on D.

Originates from [here](https://github.com/nuke-build/nuke/pull/1557), as a quick win

Thanks @Uriel6575

<!-- This repo merges via rebase only (linear history). Curate your commits into a -->
<!-- clean sequence before final approval — see CONTRIBUTING.md → Merging. -->
