### PR TITLE
Fix `UpdateSolutionFileContentSpecs` not testing anything

### DIFF
--- a/tests/Fallout.Cli.Specs/UpdateSolutionFileContentSpecs.Test_number=1.verified.txt
+++ b/tests/Fallout.Cli.Specs/UpdateSolutionFileContentSpecs.Test_number=1.verified.txt
@@ -4,7 +4,7 @@ VisualStudioVersion = 15.0.27703.2047
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp1", "ConsoleApp1\ConsoleApp1.csproj", "{1992CC3B-CF32-485C-8DBC-77D0B6F18A82}"
 EndProject
-Project("{KIND}") = "NAME", "RELATIVE", "{GUID}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NAME", "RELATIVE", "{GUID}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/tests/Fallout.Cli.Specs/UpdateSolutionFileContentSpecs.Test_number=2.verified.txt
+++ b/tests/Fallout.Cli.Specs/UpdateSolutionFileContentSpecs.Test_number=2.verified.txt
@@ -1,5 +1,5 @@
 ﻿Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{KIND}") = "NAME", "RELATIVE", "{GUID}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NAME", "RELATIVE", "{GUID}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/tests/Fallout.Cli.Specs/UpdateSolutionFileContentSpecs.Test_number=3.verified.txt
+++ b/tests/Fallout.Cli.Specs/UpdateSolutionFileContentSpecs.Test_number=3.verified.txt
@@ -1,5 +1,5 @@
 ﻿Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{KIND}") = "NAME", "RELATIVE", "{GUID}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NAME", "RELATIVE", "{GUID}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/tests/Fallout.Cli.Specs/UpdateSolutionFileContentSpecs.cs
+++ b/tests/Fallout.Cli.Specs/UpdateSolutionFileContentSpecs.cs
@@ -37,63 +37,12 @@ public class UpdateSolutionFileContentSpecs
                 		SolutionGuid = {61B2112A-2DA2-45AC-AFF5-6C50A10BB92F}
                 	EndGlobalSection
                 EndGlobal
-                """,
-        """
-                Microsoft Visual Studio Solution File, Format Version 12.00
-                # Visual Studio 15
-                VisualStudioVersion = 15.0.27703.2047
-                MinimumVisualStudioVersion = 10.0.40219.1
-                Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp1", "ConsoleApp1\ConsoleApp1.csproj", "{1992CC3B-CF32-485C-8DBC-77D0B6F18A82}"
-                EndProject
-                Project("{KIND}") = "NAME", "RELATIVE", "{GUID}"
-                EndProject
-                Global
-                	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                		Debug|Any CPU = Debug|Any CPU
-                		Release|Any CPU = Release|Any CPU
-                	EndGlobalSection
-                	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                		{GUID}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                		{GUID}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                		{1992CC3B-CF32-485C-8DBC-77D0B6F18A82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                		{1992CC3B-CF32-485C-8DBC-77D0B6F18A82}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                		{1992CC3B-CF32-485C-8DBC-77D0B6F18A82}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                		{1992CC3B-CF32-485C-8DBC-77D0B6F18A82}.Release|Any CPU.Build.0 = Release|Any CPU
-                	EndGlobalSection
-                	GlobalSection(SolutionProperties) = preSolution
-                		HideSolutionNode = FALSE
-                	EndGlobalSection
-                	GlobalSection(ExtensibilityGlobals) = postSolution
-                		SolutionGuid = {61B2112A-2DA2-45AC-AFF5-6C50A10BB92F}
-                	EndGlobalSection
-                EndGlobal
                 """)]
     [InlineData(
         2,
         """
                 Microsoft Visual Studio Solution File, Format Version 12.00
                 Global
-                	GlobalSection(SolutionProperties) = preSolution
-                		HideSolutionNode = FALSE
-                	EndGlobalSection
-                	GlobalSection(ExtensibilityGlobals) = postSolution
-                		SolutionGuid = {77D83C53-98F5-4275-8217-14700BCA05BB}
-                	EndGlobalSection
-                EndGlobal
-                """,
-        """
-                Microsoft Visual Studio Solution File, Format Version 12.00
-                Project("{KIND}") = "NAME", "RELATIVE", "{GUID}"
-                EndProject
-                Global
-                	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                		Debug|Any CPU = Debug|Any CPU
-                		Release|Any CPU = Release|Any CPU
-                	EndGlobalSection
-                	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                		{GUID}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                		{GUID}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                	EndGlobalSection
                 	GlobalSection(SolutionProperties) = preSolution
                 		HideSolutionNode = FALSE
                 	EndGlobalSection
@@ -112,28 +61,13 @@ public class UpdateSolutionFileContentSpecs
                 		Release|Any CPU = Release|Any CPU
                 	EndGlobalSection
                 EndGlobal
-                """,
-        """
-                Microsoft Visual Studio Solution File, Format Version 12.00
-                Project("{KIND}") = "NAME", "RELATIVE", "{GUID}"
-                EndProject
-                Global
-                	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                		Debug|Any CPU = Debug|Any CPU
-                		Release|Any CPU = Release|Any CPU
-                	EndGlobalSection
-                	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                		{GUID}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                		{GUID}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                	EndGlobalSection
-                EndGlobal
                 """)]
-    public Task Test(int number, string input, string expected)
+    public Task Test(int number, string input)
     {
         var content = input.SplitLineBreaks().ToList();
         Program.UpdateSolutionFileContent(content, "RELATIVE", "GUID", "NAME");
 
-        return Verifier.Verify(expected)
+        return Verifier.Verify(string.Join(Environment.NewLine, content))
             .UseParameters(number);
     }
 }


### PR DESCRIPTION
<!-- Keep it terse: one-line summary, then short "what changed" bullets. -->
<!-- Link the issue and summarize it — don't recite it. See docs/agents/issue-and-pr-style.md. -->
<!-- Or let Copilot draft one, then trim it. -->

I realized while studying the `UpdateSolutionFileContentSpecs` while preparing #461 that the tests above actually not testing anything, because passing in a string and verify this exact string isn't what a test is for ;)

<!-- This repo merges via rebase only (linear history). Curate your commits into a -->
<!-- clean sequence before final approval — see CONTRIBUTING.md → Merging. -->
