### PR TITLE
Relax DotNetTasks diagnostic ID log level patterns to reduce false negatives

### DIFF
--- a/src/Fallout.Common/Tools/DotNet/DotNetTasks.cs
+++ b/src/Fallout.Common/Tools/DotNet/DotNetTasks.cs
@@ -17,8 +17,8 @@ public class DotNetVerbosityMappingAttribute : VerbosityMappingAttribute
     }
 }
 
-[LogLevelPattern(LogEventLevel.Warning, @": warning \w{2,5}\d{1,5}:")]
-[LogLevelPattern(LogEventLevel.Error, @": error \w{2,5}\d{1,5}:")]
+[LogLevelPattern(LogEventLevel.Warning, @": warning \w{2,}\d+:")]
+[LogLevelPattern(LogEventLevel.Error, @": error \w{2,}\d+:")]
 partial class DotNetTasks;
 
 public partial class DotNetTasks


### PR DESCRIPTION
### Problem

Current Diagnostic ID LogLevelPattern only allows up to 5 letters in the prefix, for example [SYSLIB](https://github.com/dotnet/runtime/blob/main/docs/project/list-of-diagnostics.md) and and [VSTHRD](https://microsoft.github.io/vs-threading/analyzers/index.html) diagnostic ids aren't being picked up. 

Diagnostic ID [guidelines](https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/choosing-diagnostic-ids) only suggest a` <PREFIX><number> `format and a 15 character limit.

### What was done

DotNetTasks.cs LogLevelPattern was changed from` \w{2,5}\d{1,5}` to` \w{2,}\d+` for both error and warning.
This removes the upper limit of 5 characters for the prefix and the number.

Relevant Issue https://github.com/nuke-build/nuke/issues/1559
