### PR TITLE
Fix ADR AGENTS.md docs link

### DIFF
--- a/docs/adr/0007-cut-release-branch-on-demand.md
+++ b/docs/adr/0007-cut-release-branch-on-demand.md
@@ -56,4 +56,4 @@ Maintainer framing (Chris): *"release/2026 should not really be there unless we 
 ## References
 - [ADR-0001](0001-release-branch-model.md) — branching section amended here.
 - [ADR-0004](0004-calendar-versioning-and-dual-pace-channels.md) §3 — amended here.
-- [docs/branching-and-release.md](../branching-and-release.md), [docs/agents/release-and-versioning.md](../agents/release-and-versioning.md), [AGENTS.md](../../AGENTS.md) — updated for the on-demand lifecycle.
+- [docs/branching-and-release.md](../branching-and-release.md), [docs/agents/release-and-versioning.md](../agents/release-and-versioning.md), [AGENTS.md](https://github.com/Fallout-build/Fallout/blob/main/AGENTS.md) — updated for the on-demand lifecycle.


### PR DESCRIPTION
Fixes Fallout-build/docs.fallout.build#9

Summary:
- Replace the ADR-0007 AGENTS.md relative link that the docs.fallout.build deploy reports as broken.
- Point readers to the source repository's root AGENTS.md on GitHub, matching the existing docs pattern for root-level files.

Validation:
- Confirmed docs.fallout.build issue #9 reports ../../AGENTS.md from the Docusaurus deploy.
- Confirmed docusaurus.config.ts builds docs from ./fallout-source/docs.
- Confirmed docs/branching-and-release.md, docs/agents/release-and-versioning.md, and root AGENTS.md exist in source.
- curl -L for https://github.com/Fallout-build/Fallout/blob/main/AGENTS.md returned HTTP 200.
- git diff --check passed.

Note: I did not run a full Docusaurus build locally because npm ci in the docs-site clone did not complete promptly on this Windows-mounted worktree, so it was not a cheap validation path.