### PR TITLE
Change diagnostic ID from `NUKE001` to `FALLOUT001` in `StrongTypedSolutionGenerator`

### DIFF
--- a/src/Fallout.SourceGenerators/StronglyTypedSolutionGenerator.cs
+++ b/src/Fallout.SourceGenerators/StronglyTypedSolutionGenerator.cs
@@ -138,7 +138,7 @@ public class StronglyTypedSolutionGenerator : ISourceGenerator
         }
         catch (Exception exception)
         {
-            var diagnostic = Diagnostic.Create(
+            var diagnosticLegacy = Diagnostic.Create(
                 "NUKE001",
                 nameof(StronglyTypedSolutionGenerator),
                 exception.Message,
@@ -146,7 +146,17 @@ public class StronglyTypedSolutionGenerator : ISourceGenerator
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true,
                 warningLevel: 0);
-            context.ReportDiagnostic(diagnostic);
+
+            var diagnosticNew = Diagnostic.Create(
+                "FALLOUT001",
+                nameof(StronglyTypedSolutionGenerator),
+                exception.Message,
+                DiagnosticSeverity.Error,
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true,
+                warningLevel: 0);
+            context.ReportDiagnostic(diagnosticLegacy);
+            context.ReportDiagnostic(diagnosticNew);
         }
 
         return;

--- a/src/Fallout.SourceGenerators/StronglyTypedSolutionGenerator.cs
+++ b/src/Fallout.SourceGenerators/StronglyTypedSolutionGenerator.cs
@@ -138,16 +138,7 @@ public class StronglyTypedSolutionGenerator : ISourceGenerator
         }
         catch (Exception exception)
         {
-            var diagnosticLegacy = Diagnostic.Create(
-                "NUKE001",
-                nameof(StronglyTypedSolutionGenerator),
-                exception.Message,
-                DiagnosticSeverity.Error,
-                DiagnosticSeverity.Error,
-                isEnabledByDefault: true,
-                warningLevel: 0);
-
-            var diagnosticNew = Diagnostic.Create(
+            var diagnostic = Diagnostic.Create(
                 "FALLOUT001",
                 nameof(StronglyTypedSolutionGenerator),
                 exception.Message,
@@ -155,8 +146,7 @@ public class StronglyTypedSolutionGenerator : ISourceGenerator
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true,
                 warningLevel: 0);
-            context.ReportDiagnostic(diagnosticLegacy);
-            context.ReportDiagnostic(diagnosticNew);
+            context.ReportDiagnostic(diagnostic);
         }
 
         return;


### PR DESCRIPTION
<!-- Keep it terse: one-line summary, then short "what changed" bullets. -->
<!-- Link the issue and summarize it — don't recite it. See docs/agents/issue-and-pr-style.md. -->
<!-- Or let Copilot draft one, then trim it. -->

Just fell over this legacy `NUKEXX` diagnostic id... I don't know if this was left behind intentionally, so I added a new one additionally...

<!-- This repo merges via rebase only (linear history). Curate your commits into a -->
<!-- clean sequence before final approval — see CONTRIBUTING.md → Merging. -->
