### PR TITLE
Fix local run tests, when xunit.runner.console version is globally on…

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -62,7 +62,7 @@
     <PackageDownload Include="ReportGenerator" Version="[5.2.0]" />
     <!-- Used by Fallout.Tooling.Tests' ToolTasksToolPathTest as a sample package
          for tool-path resolution smoke tests. Not used for running our own tests. -->
-    <PackageDownload Include="xunit.runner.console" Version="[2.6.1]" />
+    <PackageDownload Include="xunit.runner.console" Version="[2.9.3]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Fallout.Tooling.Specs/Fallout.Tooling.Specs.csproj
+++ b/tests/Fallout.Tooling.Specs/Fallout.Tooling.Specs.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="xunit.runner.console" Version="[2.6.1]" />
+    <PackageDownload Include="xunit.runner.console" Version="[2.9.3]" />
   </ItemGroup>
 
 </Project>

--- a/tests/Fallout.Tooling.Specs/NuGetPackageResolverSpecs.cs
+++ b/tests/Fallout.Tooling.Specs/NuGetPackageResolverSpecs.cs
@@ -15,6 +15,9 @@ public class NuGetPackageResolverSpecs
 
     private const string XunitConsolePackageVersion = "2.6.1";
 
+    // This is the latest package version of xunit.runner.console (v2 is deprecated)
+    private const string LastXunitConsolePackageVersion = "2.9.3";
+
     [Theory]
     [InlineData("SpecK", true, true, "1.0.1-ci00055")]
     [InlineData("SpecK", false, true, "1.0.0")]
@@ -34,7 +37,7 @@ public class NuGetPackageResolverSpecs
         result.Should().NotBeNull();
         result.Id.Should().Be("xunit.runner.console");
         result.File.Name.Should().EndWith("nupkg");
-        result.Version.OriginalVersion.Should().Be(XunitConsolePackageVersion);
+        result.Version.OriginalVersion.Should().BeOneOf(XunitConsolePackageVersion, LastXunitConsolePackageVersion);
     }
 
     [Fact]

--- a/tests/Fallout.Tooling.Specs/NuGetPackageResolverSpecs.cs
+++ b/tests/Fallout.Tooling.Specs/NuGetPackageResolverSpecs.cs
@@ -13,10 +13,9 @@ public class NuGetPackageResolverSpecs
     private static AbsolutePath ProjectFile => RootDirectory / "tests" / "Fallout.Tooling.Specs" / "Fallout.Tooling.Specs.csproj";
     private static AbsolutePath AssetsFile => ProjectFile.Parent / "obj" / "project.assets.json";
 
-    private const string XunitConsolePackageVersion = "2.6.1";
-
-    // This is the latest package version of xunit.runner.console (v2 is deprecated)
-    private const string LastXunitConsolePackageVersion = "2.9.3";
+    // This version have to match with
+    // - Fallout.Tooling.Specs.csproj -> PackageDownload
+    private const string XunitConsolePackageVersion = "2.9.3";
 
     [Theory]
     [InlineData("SpecK", true, true, "1.0.1-ci00055")]
@@ -37,7 +36,7 @@ public class NuGetPackageResolverSpecs
         result.Should().NotBeNull();
         result.Id.Should().Be("xunit.runner.console");
         result.File.Name.Should().EndWith("nupkg");
-        result.Version.OriginalVersion.Should().BeOneOf(XunitConsolePackageVersion, LastXunitConsolePackageVersion);
+        result.Version.OriginalVersion.Should().Be(XunitConsolePackageVersion);
     }
 
     [Fact]


### PR DESCRIPTION
… higher version

Fixes #471 

<!-- Keep it terse: one-line summary, then short "what changed" bullets. -->
<!-- Link the issue and summarize it — don't recite it. See docs/agents/issue-and-pr-style.md. -->
<!-- Or let Copilot draft one, then trim it. -->

The problem is, that a globally installed xunit.runner.console nuget package from another project breaks this test.

<!-- This repo merges via rebase only (linear history). Curate your commits into a -->
<!-- clean sequence before final approval — see CONTRIBUTING.md → Merging. -->
