### PR TITLE
Rewrite fallout-migrate argument parsing and path handling

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Glob" Version="1.1.9" />
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageVersion Include="Humanizer" Version="3.0.1" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
@@ -31,6 +32,7 @@
     <PackageVersion Include="System.Text.Json" Version="10.0.8" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>
   <!-- Testing -->
   <ItemGroup>

--- a/src/Fallout.Migrate/CodeRewriter.cs
+++ b/src/Fallout.Migrate/CodeRewriter.cs
@@ -8,20 +8,34 @@ internal static class CodeRewriter
     // attribute references, qualified type names, namespace declarations.
     // The trailing `(?=[A-Z])` lookahead avoids matching `Nuke.json` filenames
     // or other lowercase tails the prefix audit deliberately preserved.
-    private static readonly Regex NamespacePrefix =
+    private static readonly Regex namespacePrefix =
         new(@"\bNuke\.(?=[A-Z])", RegexOptions.Compiled);
 
     // Bare type renames done in the Fallout rebrand (#59).
-    private static readonly Regex NukeBuildType = new(@"\bNukeBuild\b", RegexOptions.Compiled);
-    private static readonly Regex INukeBuildType = new(@"\bINukeBuild\b", RegexOptions.Compiled);
+    private static readonly Regex nukeBuildType = new(@"\bNukeBuild\b", RegexOptions.Compiled);
+    private static readonly Regex iNukeBuildType = new(@"\bINukeBuild\b", RegexOptions.Compiled);
 
     public static RewriteResult Rewrite(string original)
     {
         var edits = 0;
 
-        var content = NamespacePrefix.Replace(original, _ => { edits++; return "Fallout."; });
-        content = INukeBuildType.Replace(content, _ => { edits++; return "IFalloutBuild"; });
-        content = NukeBuildType.Replace(content, _ => { edits++; return "FalloutBuild"; });
+        var content = namespacePrefix.Replace(original, _ =>
+        {
+            edits++;
+            return "Fallout.";
+        });
+
+        content = iNukeBuildType.Replace(content, _ =>
+        {
+            edits++;
+            return "IFalloutBuild";
+        });
+
+        content = nukeBuildType.Replace(content, _ =>
+        {
+            edits++;
+            return "FalloutBuild";
+        });
 
         return new RewriteResult(content, edits);
     }

--- a/src/Fallout.Migrate/CsprojRewriter.cs
+++ b/src/Fallout.Migrate/CsprojRewriter.cs
@@ -10,21 +10,21 @@ internal static class CsprojRewriter
     // `WarningsAsErrors` in the migrated project escalates. Bumping in the same pass avoids
     // a broken post-migrate build (#217). Tolerates extra attributes between Include and Version
     // (e.g. `PrivateAssets="all"`).
-    private static readonly Regex NukePackageWithInlineVersionPattern = new(
+    private static readonly Regex nukePackageWithInlineVersionPattern = new(
         @"(?<prefix><PackageReference\s+Include="")Nuke\.(?<name>[A-Z][A-Za-z0-9.]+)(?<between>""[^>]*?\s+Version="")[^""]+",
         RegexOptions.Compiled);
 
     // PackageReference / ProjectReference `Include="Nuke.X"` → `Include="Fallout.X"` — namespace
     // only. Catches references that DON'T have an inline Version (central package management).
     // Must run AFTER NukePackageWithInlineVersionPattern so it only touches what's left.
-    private static readonly Regex PackageReferencePattern =
+    private static readonly Regex packageReferencePattern =
         new(@"(?<=\b(?:Include|Update|Remove)="")Nuke\.(?=[A-Z])", RegexOptions.Compiled);
 
     // MSBuild element/property names that begin with `Nuke` followed by an uppercase
     // letter (e.g. <NukeRootDirectory>...). Limited to known consumer-facing names from
     // P3.5b so we don't rewrite unrelated user-defined identifiers that happen to start
     // with the literal "Nuke".
-    private static readonly Regex MSBuildPropertyPattern = new(
+    private static readonly Regex msBuildPropertyPattern = new(
         @"\bNuke(?=" +
         "(?:RootDirectory|ScriptDirectory|TelemetryVersion|BaseDirectory|BaseNamespace|" +
         "UseNestedNamespaces|RepositoryUrl|UpdateReferences|ContinueOnError|TaskTimeout|" +
@@ -39,7 +39,7 @@ internal static class CsprojRewriter
     // downgrade"). Removing the explicit pin lets the transitive version win, which is what the
     // migrated project wants (#217). Matches a self-closing element with optional surrounding
     // indentation + trailing newline.
-    private static readonly Regex CryptographyXmlPackageRefPattern = new(
+    private static readonly Regex cryptographyXmlPackageRefPattern = new(
         @"^[ \t]*<PackageReference\s+Include=""System\.Security\.Cryptography\.Xml""[^/]*/>\s*\r?\n?",
         RegexOptions.Compiled | RegexOptions.Multiline);
 
@@ -49,7 +49,7 @@ internal static class CsprojRewriter
         var content = original;
 
         // Pass 1 — combined Include + Version rewrite for Nuke.X PackageReferences with inline Version.
-        content = NukePackageWithInlineVersionPattern.Replace(content, m =>
+        content = nukePackageWithInlineVersionPattern.Replace(content, m =>
         {
             edits++;
             return m.Groups["prefix"].Value
@@ -60,11 +60,24 @@ internal static class CsprojRewriter
 
         // Pass 2 — namespace-only rewrites for anything Pass 1 didn't consume (CPM-managed
         // PackageReferences without inline Version, ProjectReferences, MSBuild properties).
-        content = PackageReferencePattern.Replace(content, _ => { edits++; return "Fallout."; });
-        content = MSBuildPropertyPattern.Replace(content, _ => { edits++; return "Fallout"; });
+        content = packageReferencePattern.Replace(content, _ =>
+        {
+            edits++;
+            return "Fallout.";
+        });
+
+        content = msBuildPropertyPattern.Replace(content, _ =>
+        {
+            edits++;
+            return "Fallout";
+        });
 
         // Pass 3 — strip the stale System.Security.Cryptography.Xml direct pin.
-        content = CryptographyXmlPackageRefPattern.Replace(content, _ => { edits++; return string.Empty; });
+        content = cryptographyXmlPackageRefPattern.Replace(content, _ =>
+        {
+            edits++;
+            return string.Empty;
+        });
 
         return new RewriteResult(content, edits);
     }

--- a/src/Fallout.Migrate/Fallout.Migrate.csproj
+++ b/src/Fallout.Migrate/Fallout.Migrate.csproj
@@ -14,4 +14,13 @@
     <InternalsVisibleTo Include="Fallout.Migrate.Specs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" />
+    <PackageReference Include="Spectre.Console.Cli" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Fallout.Utilities\Fallout.Utilities.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Fallout.Migrate/MigrateCommand.cs
+++ b/src/Fallout.Migrate/MigrateCommand.cs
@@ -1,0 +1,96 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using Fallout.Common;
+using Fallout.Common.IO;
+using JetBrains.Annotations;
+using Spectre.Console.Cli;
+
+namespace Fallout.Migrate;
+
+[Description("""
+             Migrate a NUKE consumer repo to Fallout.
+
+             What it does:
+               - Rewrites Nuke.* PackageReferences and MSBuild properties in .csproj
+               - Rewrites `using Nuke.*` directives and qualified type references in .cs
+               - Rewrites `dotnet nuke` -> `dotnet fallout` and legacy NUKE_* env vars
+                 in build.cmd / build.ps1 / build.sh
+               - Renames .nuke/ to .fallout/
+               - Prints a summary of files changed and warnings to address manually
+             """)]
+[UsedImplicitly]
+internal sealed class MigrateCommand : Command<MigrateSettings>
+{
+    public override int Execute(CommandContext context, MigrateSettings settings)
+    {
+        var rootDirectory = ResolveRootDirectory(settings.Path);
+        if (rootDirectory is null)
+        {
+            Console.Error.WriteLine(
+                "error: could not locate a repository root containing a build orchestrator project (_build.csproj) under the working directory.");
+
+            Console.Error.WriteLine("       pass an explicit path: fallout-migrate <path>");
+            return 1;
+        }
+
+        PrintBanner(rootDirectory, settings.DryRun);
+
+        var migration = new Migration(rootDirectory, settings.DryRun, Console.Out);
+        var summary = migration.Run();
+
+        PrintSummary(summary, settings.DryRun);
+        return 0;
+    }
+
+    private static AbsolutePath ResolveRootDirectory(string explicitArg)
+    {
+        if (explicitArg != null)
+        {
+            return Path.GetFullPath(explicitArg);
+        }
+
+        return EnvironmentInfo.WorkingDirectory.FindParentOrSelf(current =>
+            (current / "build").DirectoryExists() ||
+            (current / ".nuke").DirectoryExists() ||
+            (current / ".fallout").DirectoryExists() ||
+            (current / "build.cmd").FileExists() ||
+            (current / "build.ps1").FileExists() ||
+            (current / "build.sh").FileExists());
+    }
+
+    private static void PrintBanner(AbsolutePath rootDirectory, bool dryRun)
+    {
+        Console.WriteLine($"fallout-migrate — migrating: {rootDirectory}");
+        if (dryRun)
+        {
+            Console.WriteLine("(dry-run — no files will be modified)");
+        }
+
+        Console.WriteLine();
+    }
+
+    private static void PrintSummary(Migration.Summary summary, bool dryRun)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Files changed:   {summary.FilesChanged}");
+        Console.WriteLine($"Edits made:      {summary.EditCount}");
+        Console.WriteLine($"Directories:     {summary.DirectoriesRenamed} renamed");
+        if (summary.Warnings.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Warnings:");
+            foreach (var w in summary.Warnings)
+            {
+                Console.WriteLine($"  - {w}");
+            }
+        }
+
+        Console.WriteLine();
+        Console.WriteLine(dryRun
+            ? "Dry-run complete. Re-run without --dry-run to apply changes."
+            : "Migration complete. Verify the build:  ./build.ps1   (or ./build.sh on unix)");
+
+        Console.WriteLine("Migration guide: https://fallout.build  (see #37 for the full guide)");
+    }
+}

--- a/src/Fallout.Migrate/MigrateSettings.cs
+++ b/src/Fallout.Migrate/MigrateSettings.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel;
+using JetBrains.Annotations;
+using Spectre.Console.Cli;
+
+namespace Fallout.Migrate;
+
+[UsedImplicitly]
+internal sealed class MigrateSettings : CommandSettings
+{
+    [CommandArgument(0, "[path]")]
+    [Description("Repository root. Defaults to walking up from the working directory to find " +
+                 "one (looking for build.cmd / build.ps1 / build.sh, .nuke/, or build/).")]
+    public string Path { get; init; }
+
+    [CommandOption("-n|--dry-run")]
+    [Description("Show what would change without writing.")]
+    public bool DryRun { get; init; }
+}

--- a/src/Fallout.Migrate/Migration.cs
+++ b/src/Fallout.Migrate/Migration.cs
@@ -1,21 +1,23 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using Fallout.Common.IO;
 
 namespace Fallout.Migrate;
 
-public sealed class Migration
+internal sealed class Migration
 {
-    private readonly string _rootDirectory;
-    private readonly bool _dryRun;
-    private readonly TextWriter _log;
+    private readonly AbsolutePath rootDirectory;
+    private readonly bool dryRun;
+    private readonly TextWriter log;
 
-    public Migration(string rootDirectory, bool dryRun, TextWriter log)
+    public Migration(AbsolutePath rootDirectory, bool dryRun, TextWriter log)
     {
-        _rootDirectory = rootDirectory ?? throw new ArgumentNullException(nameof(rootDirectory));
-        _dryRun = dryRun;
-        _log = log ?? throw new ArgumentNullException(nameof(log));
+        this.rootDirectory = rootDirectory ?? throw new ArgumentNullException(nameof(rootDirectory));
+        this.dryRun = dryRun;
+        this.log = log ?? throw new ArgumentNullException(nameof(log));
     }
 
     public Summary Run()
@@ -34,7 +36,9 @@ public sealed class Migration
     {
         var falloutVersion = ResolveFalloutVersion();
         foreach (var path in EnumerateFiles("*.csproj"))
+        {
             ApplyRewrite(path, content => CsprojRewriter.Rewrite(content, falloutVersion), summary);
+        }
     }
 
     // Pinned into migrated `<PackageReference Include="Fallout.X" Version="..." />` lines.
@@ -45,17 +49,22 @@ public sealed class Migration
     // bogus pin like Version="LOCAL". Inlined to keep Fallout.Migrate dependency-free.
     private static string ResolveFalloutVersion()
     {
-        const string Fallback = "11.0.0";
+        const string fallback = "10.3.49";
 
         var informational = typeof(Migration).Assembly
             .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion;
-        if (string.IsNullOrEmpty(informational))
-            return Fallback;
 
-        var plusIndex = informational.IndexOf('+');
+        if (string.IsNullOrEmpty(informational))
+        {
+            return fallback;
+        }
+
+        int plusIndex = informational.IndexOf('+');
         if (plusIndex == -1)
-            return Fallback;
+        {
+            return fallback;
+        }
 
         return informational[..plusIndex];
     }
@@ -63,63 +72,84 @@ public sealed class Migration
     private void RewriteCsFiles(Summary summary)
     {
         foreach (var path in EnumerateFiles("*.cs"))
+        {
             ApplyRewrite(path, CodeRewriter.Rewrite, summary);
+        }
     }
 
     private void RewriteBootstrapScripts(Summary summary)
     {
-        foreach (var name in new[] { "build.cmd", "build.ps1", "build.sh" })
+        foreach (var name in new[]
+                 {
+                     "build.cmd",
+                     "build.ps1",
+                     "build.sh"
+                 })
         {
-            var path = Path.Combine(_rootDirectory, name);
-            if (File.Exists(path))
+            var path = rootDirectory / name;
+            if (path.FileExists())
+            {
                 ApplyRewrite(path, ScriptRewriter.Rewrite, summary);
+            }
         }
     }
 
     private void RenameNukeDirectory(Summary summary)
     {
-        var legacy = Path.Combine(_rootDirectory, ".nuke");
-        var canonical = Path.Combine(_rootDirectory, ".fallout");
+        var legacy = rootDirectory / ".nuke";
+        var canonical = rootDirectory / ".fallout";
 
-        if (!Directory.Exists(legacy))
-            return;
-
-        if (Directory.Exists(canonical))
+        if (!legacy.DirectoryExists())
         {
-            summary.Warnings.Add(
-                "Both .nuke/ and .fallout/ exist. Skipped rename; merge their contents manually.");
             return;
         }
 
-        Log($"rename  {RelativePath(legacy)} -> {RelativePath(canonical)}");
-        if (!_dryRun)
+        if (canonical.DirectoryExists())
+        {
+            summary.Warnings.Add(
+                "Both .nuke/ and .fallout/ exist. Skipped rename; merge their contents manually.");
+
+            return;
+        }
+
+        Log($"rename {RelativePath(legacy)} -> {RelativePath(canonical)}");
+        if (!dryRun)
+        {
+            // We purposely use the .NET directory move as this is atomic. Fallout's own
+            // Move/MoveDirectory moves them one by one.
             Directory.Move(legacy, canonical);
+        }
+
         summary.DirectoriesRenamed++;
     }
 
-    private IEnumerable<string> EnumerateFiles(string pattern)
+    private IEnumerable<AbsolutePath> EnumerateFiles(string pattern)
     {
-        foreach (var file in Directory.EnumerateFiles(_rootDirectory, pattern, SearchOption.AllDirectories))
+        foreach (var file in rootDirectory.GetFiles(pattern, depth: int.MaxValue))
         {
             if (IsIgnored(file))
+            {
                 continue;
+            }
+
             yield return file;
         }
     }
 
-    private static bool IsIgnored(string path)
+    private static bool IsIgnored(AbsolutePath path)
     {
-        return path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
-            || path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
-            || path.Contains($"{Path.DirectorySeparatorChar}.git{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+        string text = path;
+        return text.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+               || text.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+               || text.Contains($"{Path.DirectorySeparatorChar}.git{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
     }
 
-    private void ApplyRewrite(string path, Func<string, RewriteResult> rewriter, Summary summary)
+    private void ApplyRewrite(AbsolutePath path, Func<string, RewriteResult> rewriter, Summary summary)
     {
         string original;
         try
         {
-            original = File.ReadAllText(path);
+            original = path.ReadAllText();
         }
         catch (IOException ex)
         {
@@ -129,28 +159,38 @@ public sealed class Migration
 
         var result = rewriter(original);
         if (result.EditCount == 0)
+        {
             return;
+        }
 
         Log($"edit    {RelativePath(path)}  ({result.EditCount} change{(result.EditCount == 1 ? "" : "s")})");
         summary.FilesChanged++;
         summary.EditCount += result.EditCount;
 
-        if (!_dryRun)
-            File.WriteAllText(path, result.Content);
+        if (!dryRun)
+        {
+            // eofLineBreak: false preserves today's exact byte-for-byte write behavior;
+            // AbsolutePath.WriteAllText's default normalizes trailing line endings, which
+            // would otherwise sneak unrelated diff noise into migrated consumer repos.
+            path.WriteAllText(result.Content, eofLineBreak: false);
+        }
     }
 
-    private string RelativePath(string absolute) =>
-        Path.GetRelativePath(_rootDirectory, absolute).Replace('\\', '/');
+    private string RelativePath(AbsolutePath absolute) =>
+        rootDirectory.GetUnixRelativePathTo(absolute);
 
-    private void Log(string line) => _log.WriteLine(line);
+    private void Log(string line) => log.WriteLine(line);
 
-    public sealed class Summary
+    internal sealed class Summary
     {
         public int FilesChanged { get; set; }
+
         public int EditCount { get; set; }
+
         public int DirectoriesRenamed { get; set; }
+
         public List<string> Warnings { get; } = new();
     }
 }
 
-public readonly record struct RewriteResult(string Content, int EditCount);
+internal readonly record struct RewriteResult(string Content, int EditCount);

--- a/src/Fallout.Migrate/Program.cs
+++ b/src/Fallout.Migrate/Program.cs
@@ -1,5 +1,4 @@
-using System;
-using System.IO;
+using Spectre.Console.Cli;
 
 namespace Fallout.Migrate;
 
@@ -7,105 +6,14 @@ public static class Program
 {
     public static int Main(string[] args)
     {
-        var dryRun = Array.Exists(args, a => a is "--dry-run" or "-n");
-        var helpRequested = Array.Exists(args, a => a is "--help" or "-h" or "/?");
-        var rootArg = Array.Find(args, a => !a.StartsWith('-') && !a.StartsWith('/'));
-
-        if (helpRequested)
+        var app = new CommandApp<MigrateCommand>();
+        app.Configure(config =>
         {
-            PrintHelp();
-            return 0;
-        }
+            config.SetApplicationName("fallout-migrate");
+            config.AddExample("--dry-run");
+            config.AddExample("path/to/repo");
+        });
 
-        var rootDirectory = ResolveRootDirectory(rootArg);
-        if (rootDirectory == null)
-        {
-            Console.Error.WriteLine("error: could not locate a repository root containing a build orchestrator project (_build.csproj) under the working directory.");
-            Console.Error.WriteLine("       pass an explicit path: fallout-migrate <path>");
-            return 1;
-        }
-
-        Console.WriteLine($"fallout-migrate — migrating: {rootDirectory}");
-        if (dryRun)
-            Console.WriteLine("(dry-run — no files will be modified)");
-        Console.WriteLine();
-
-        var migration = new Migration(rootDirectory, dryRun, Console.Out);
-        var summary = migration.Run();
-
-        Console.WriteLine();
-        Console.WriteLine($"Files changed:   {summary.FilesChanged}");
-        Console.WriteLine($"Edits made:      {summary.EditCount}");
-        Console.WriteLine($"Directories:     {summary.DirectoriesRenamed} renamed");
-        if (summary.Warnings.Count > 0)
-        {
-            Console.WriteLine();
-            Console.WriteLine("Warnings:");
-            foreach (var w in summary.Warnings)
-                Console.WriteLine($"  - {w}");
-        }
-
-        Console.WriteLine();
-        Console.WriteLine(dryRun
-            ? "Dry-run complete. Re-run without --dry-run to apply changes."
-            : "Migration complete. Verify the build:  ./build.ps1   (or ./build.sh on unix)");
-        Console.WriteLine("Migration guide: https://fallout.build  (see #37 for the full guide)");
-        return 0;
-    }
-
-    private static string ResolveRootDirectory(string explicitArg)
-    {
-        if (explicitArg != null)
-            return Path.GetFullPath(explicitArg);
-
-        var current = new DirectoryInfo(Environment.CurrentDirectory);
-        while (current != null)
-        {
-            if (Directory.Exists(Path.Combine(current.FullName, "build")) ||
-                Directory.Exists(Path.Combine(current.FullName, ".nuke")) ||
-                Directory.Exists(Path.Combine(current.FullName, ".fallout")))
-            {
-                return current.FullName;
-            }
-
-            // Heuristic: any _build.csproj or build.cmd / build.ps1 anywhere below.
-            if (current.GetFiles("build.cmd", SearchOption.TopDirectoryOnly).Length > 0 ||
-                current.GetFiles("build.ps1", SearchOption.TopDirectoryOnly).Length > 0 ||
-                current.GetFiles("build.sh", SearchOption.TopDirectoryOnly).Length > 0)
-            {
-                return current.FullName;
-            }
-
-            current = current.Parent;
-        }
-
-        return null;
-    }
-
-    private static void PrintHelp()
-    {
-        Console.WriteLine("""
-            fallout-migrate — migrate a NUKE consumer repo to Fallout.
-
-            Usage:
-              fallout-migrate [path] [options]
-
-            Arguments:
-              path        Repository root. Defaults to walking up from the working
-                          directory to find one (looking for build.cmd / build.ps1 /
-                          build.sh, .nuke/, or build/).
-
-            Options:
-              --dry-run, -n      Show what would change without writing.
-              --help, -h, /?     Show this message.
-
-            What it does:
-              - Rewrites Nuke.* PackageReferences and MSBuild properties in .csproj
-              - Rewrites `using Nuke.*` directives and qualified type references in .cs
-              - Rewrites `dotnet nuke` → `dotnet fallout` and legacy NUKE_* env vars
-                in build.cmd / build.ps1 / build.sh
-              - Renames .nuke/ to .fallout/
-              - Prints a summary of files changed and warnings to address manually
-            """);
+        return app.Run(args);
     }
 }

--- a/src/Fallout.Migrate/ScriptRewriter.cs
+++ b/src/Fallout.Migrate/ScriptRewriter.cs
@@ -4,7 +4,7 @@ namespace Fallout.Migrate;
 
 internal static class ScriptRewriter
 {
-    private static readonly (Regex Pattern, string Replacement)[] Patterns =
+    private static readonly (Regex Pattern, string Replacement)[] patterns =
     {
         // `dotnet nuke` invocations
         (new Regex(@"\bdotnet\s+nuke\b", RegexOptions.Compiled), "dotnet fallout"),
@@ -21,10 +21,15 @@ internal static class ScriptRewriter
     {
         var edits = 0;
         var content = original;
-        foreach (var (pattern, replacement) in Patterns)
+        foreach (var (pattern, replacement) in patterns)
         {
-            content = pattern.Replace(content, _ => { edits++; return replacement; });
+            content = pattern.Replace(content, _ =>
+            {
+                edits++;
+                return replacement;
+            });
         }
+
         return new RewriteResult(content, edits);
     }
 }

--- a/tests/Fallout.Migrate.Specs/CodeRewriterSpecs.cs
+++ b/tests/Fallout.Migrate.Specs/CodeRewriterSpecs.cs
@@ -9,10 +9,10 @@ public class CodeRewriterSpecs
     public void RewritesUsingDirective()
     {
         const string input = """
-            using Nuke.Common;
-            using Nuke.Common.IO;
-            using Fallout.Common;
-            """;
+                             using Nuke.Common;
+                             using Nuke.Common.IO;
+                             using Fallout.Common;
+                             """;
 
         var result = CodeRewriter.Rewrite(input);
 

--- a/tests/Fallout.Migrate.Specs/CsprojRewriterSpecs.cs
+++ b/tests/Fallout.Migrate.Specs/CsprojRewriterSpecs.cs
@@ -11,13 +11,13 @@ public class CsprojRewriterSpecs
     public void RewritesPackageReferenceNamespace()
     {
         const string input = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <ItemGroup>
-                <PackageReference Include="Nuke.Common" Version="9.0.0" />
-                <PackageReference Include="Nuke.Components" />
-              </ItemGroup>
-            </Project>
-            """;
+                             <Project Sdk="Microsoft.NET.Sdk">
+                               <ItemGroup>
+                                 <PackageReference Include="Nuke.Common" Version="9.0.0" />
+                                 <PackageReference Include="Nuke.Components" />
+                               </ItemGroup>
+                             </Project>
+                             """;
 
         var result = CsprojRewriter.Rewrite(input, TestFalloutVersion);
 
@@ -31,17 +31,17 @@ public class CsprojRewriterSpecs
     public void RewritesNukeRootDirectoryProperty()
     {
         const string input = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-                <NukeRootDirectory>.\..</NukeRootDirectory>
-                <NukeTelemetryVersion>1</NukeTelemetryVersion>
-              </PropertyGroup>
-            </Project>
-            """;
+                             <Project Sdk="Microsoft.NET.Sdk">
+                               <PropertyGroup>
+                                 <NukeRootDirectory>.\..</NukeRootDirectory>
+                                 <NukeTelemetryVersion>1</NukeTelemetryVersion>
+                               </PropertyGroup>
+                             </Project>
+                             """;
 
         var result = CsprojRewriter.Rewrite(input, TestFalloutVersion);
 
-        result.EditCount.Should().Be(4);  // 2 opening + 2 closing tags
+        result.EditCount.Should().Be(4); // 2 opening + 2 closing tags
         result.Content.Should().Contain("<FalloutRootDirectory>");
         result.Content.Should().Contain("</FalloutRootDirectory>");
         result.Content.Should().Contain("<FalloutTelemetryVersion>");
@@ -52,12 +52,12 @@ public class CsprojRewriterSpecs
     public void LeavesUnrelatedNukePrefixedIdentifiersAlone()
     {
         const string input = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-                <NukeSomeRandomConsumerProp>x</NukeSomeRandomConsumerProp>
-              </PropertyGroup>
-            </Project>
-            """;
+                             <Project Sdk="Microsoft.NET.Sdk">
+                               <PropertyGroup>
+                                 <NukeSomeRandomConsumerProp>x</NukeSomeRandomConsumerProp>
+                               </PropertyGroup>
+                             </Project>
+                             """;
 
         var result = CsprojRewriter.Rewrite(input, TestFalloutVersion);
 
@@ -69,12 +69,12 @@ public class CsprojRewriterSpecs
     public void ReturnsZeroEditsForUnchangedContent()
     {
         const string input = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-                <TargetFramework>net10.0</TargetFramework>
-              </PropertyGroup>
-            </Project>
-            """;
+                             <Project Sdk="Microsoft.NET.Sdk">
+                               <PropertyGroup>
+                                 <TargetFramework>net10.0</TargetFramework>
+                               </PropertyGroup>
+                             </Project>
+                             """;
 
         var result = CsprojRewriter.Rewrite(input, TestFalloutVersion);
 
@@ -88,13 +88,13 @@ public class CsprojRewriterSpecs
         // Regression guard for #217: NUKE-era pins like 10.1.0 never existed as Fallout.X
         // and would trip NU1603 on the migrated project. Migrate must bump in the same pass.
         const string input = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <ItemGroup>
-                <PackageReference Include="Nuke.Common" Version="10.1.0" />
-                <PackageReference Include="Nuke.Components" Version="10.1.0" />
-              </ItemGroup>
-            </Project>
-            """;
+                             <Project Sdk="Microsoft.NET.Sdk">
+                               <ItemGroup>
+                                 <PackageReference Include="Nuke.Common" Version="10.1.0" />
+                                 <PackageReference Include="Nuke.Components" Version="10.1.0" />
+                               </ItemGroup>
+                             </Project>
+                             """;
 
         var result = CsprojRewriter.Rewrite(input, TestFalloutVersion);
 
@@ -109,12 +109,12 @@ public class CsprojRewriterSpecs
         // PrivateAssets / IncludeAssets are common NUKE-era attributes that sit between
         // Include and Version. The combined-rewrite pattern needs to tolerate them.
         const string input = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <ItemGroup>
-                <PackageReference Include="Nuke.Common" PrivateAssets="all" Version="10.1.0" />
-              </ItemGroup>
-            </Project>
-            """;
+                             <Project Sdk="Microsoft.NET.Sdk">
+                               <ItemGroup>
+                                 <PackageReference Include="Nuke.Common" PrivateAssets="all" Version="10.1.0" />
+                               </ItemGroup>
+                             </Project>
+                             """;
 
         var result = CsprojRewriter.Rewrite(input, TestFalloutVersion);
 
@@ -128,12 +128,12 @@ public class CsprojRewriterSpecs
         // Directory.Packages.props. The namespace-only pass still renames Nuke. → Fallout.
         // but we must NOT inject a Version where there wasn't one.
         const string input = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <ItemGroup>
-                <PackageReference Include="Nuke.Common" />
-              </ItemGroup>
-            </Project>
-            """;
+                             <Project Sdk="Microsoft.NET.Sdk">
+                               <ItemGroup>
+                                 <PackageReference Include="Nuke.Common" />
+                               </ItemGroup>
+                             </Project>
+                             """;
 
         var result = CsprojRewriter.Rewrite(input, TestFalloutVersion);
 
@@ -148,13 +148,13 @@ public class CsprojRewriterSpecs
         // that conflicts with Fallout.Common's transitive >= 10.0.6 requirement (NU1605 downgrade).
         // Removing the explicit pin lets the transitive version win.
         const string input = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <ItemGroup>
-                <PackageReference Include="Nuke.Common" Version="10.1.0" />
-                <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.15" />
-              </ItemGroup>
-            </Project>
-            """;
+                             <Project Sdk="Microsoft.NET.Sdk">
+                               <ItemGroup>
+                                 <PackageReference Include="Nuke.Common" Version="10.1.0" />
+                                 <PackageReference Include="System.Security.Cryptography.Xml" Version="9.0.15" />
+                               </ItemGroup>
+                             </Project>
+                             """;
 
         var result = CsprojRewriter.Rewrite(input, TestFalloutVersion);
 
@@ -169,13 +169,13 @@ public class CsprojRewriterSpecs
         // (System.Text.Json etc.) stay as the user pinned them — they're not in any known
         // conflict path.
         const string input = """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <ItemGroup>
-                <PackageReference Include="System.Text.Json" Version="9.0.0" />
-                <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-              </ItemGroup>
-            </Project>
-            """;
+                             <Project Sdk="Microsoft.NET.Sdk">
+                               <ItemGroup>
+                                 <PackageReference Include="System.Text.Json" Version="9.0.0" />
+                                 <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+                               </ItemGroup>
+                             </Project>
+                             """;
 
         var result = CsprojRewriter.Rewrite(input, TestFalloutVersion);
 

--- a/tests/Fallout.Migrate.Specs/MigrationIntegrationSpecs.cs
+++ b/tests/Fallout.Migrate.Specs/MigrationIntegrationSpecs.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Text;
 using FluentAssertions;
 using Xunit;
@@ -67,7 +66,7 @@ public class MigrationIntegrationSpecs
 
             File.ReadAllText(Path.Combine(temp, "build", "_build.csproj")).Should().Be(beforeCsproj);
             Directory.Exists(Path.Combine(temp, ".nuke")).Should().Be(beforeNukeDir);
-            summary.FilesChanged.Should().BeGreaterThan(0);  // counts intended edits
+            summary.FilesChanged.Should().BeGreaterThan(0); // counts intended edits
         }
         finally
         {
@@ -103,37 +102,37 @@ public class MigrationIntegrationSpecs
         Directory.CreateDirectory(Path.Combine(dir, ".nuke"));
 
         File.WriteAllText(Path.Combine(dir, "build", "_build.csproj"), """
-            <Project Sdk="Microsoft.NET.Sdk">
-              <PropertyGroup>
-                <OutputType>Exe</OutputType>
-                <TargetFramework>net8.0</TargetFramework>
-                <NukeRootDirectory>.\..</NukeRootDirectory>
-                <NukeTelemetryVersion>1</NukeTelemetryVersion>
-              </PropertyGroup>
-              <ItemGroup>
-                <PackageReference Include="Nuke.Common" Version="9.0.0" />
-              </ItemGroup>
-            </Project>
-            """);
+                                                                       <Project Sdk="Microsoft.NET.Sdk">
+                                                                         <PropertyGroup>
+                                                                           <OutputType>Exe</OutputType>
+                                                                           <TargetFramework>net8.0</TargetFramework>
+                                                                           <NukeRootDirectory>.\..</NukeRootDirectory>
+                                                                           <NukeTelemetryVersion>1</NukeTelemetryVersion>
+                                                                         </PropertyGroup>
+                                                                         <ItemGroup>
+                                                                           <PackageReference Include="Nuke.Common" Version="9.0.0" />
+                                                                         </ItemGroup>
+                                                                       </Project>
+                                                                       """);
 
         File.WriteAllText(Path.Combine(dir, "build", "Build.cs"), """
-            using Nuke.Common;
-            using Nuke.Common.Tools.DotNet;
+                                                                  using Nuke.Common;
+                                                                  using Nuke.Common.Tools.DotNet;
 
-            class Build : NukeBuild
-            {
-                public static int Main () => Execute<Build>(x => x.Compile);
+                                                                  class Build : NukeBuild
+                                                                  {
+                                                                      public static int Main () => Execute<Build>(x => x.Compile);
 
-                Target Compile => _ => _.Executes(() => { });
-            }
-            """);
+                                                                      Target Compile => _ => _.Executes(() => { });
+                                                                  }
+                                                                  """);
 
         File.WriteAllText(Path.Combine(dir, "build.sh"), """
-            #!/usr/bin/env bash
-            export NUKE_TELEMETRY_OPTOUT=1
-            TEMP_DIRECTORY="$SCRIPT_DIR/.nuke/temp"
-            dotnet nuke "$@"
-            """, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                                                         #!/usr/bin/env bash
+                                                         export NUKE_TELEMETRY_OPTOUT=1
+                                                         TEMP_DIRECTORY="$SCRIPT_DIR/.nuke/temp"
+                                                         dotnet nuke "$@"
+                                                         """, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
 
         File.WriteAllText(Path.Combine(dir, ".nuke", "parameters.json"), "{}");
 

--- a/tests/Fallout.Migrate.Specs/ScriptRewriterSpecs.cs
+++ b/tests/Fallout.Migrate.Specs/ScriptRewriterSpecs.cs
@@ -26,9 +26,10 @@ public class ScriptRewriterSpecs
     public void RewritesLegacyEnvVars()
     {
         const string input = """
-            export NUKE_TELEMETRY_OPTOUT=1
-            $env:NUKE_GLOBAL_TOOL_VERSION = "10.0"
-            """;
+                             export NUKE_TELEMETRY_OPTOUT=1
+                             $env:NUKE_GLOBAL_TOOL_VERSION = "10.0"
+                             """;
+
         var result = ScriptRewriter.Rewrite(input);
         result.EditCount.Should().Be(2);
         result.Content.Should().Contain("FALLOUT_TELEMETRY_OPTOUT");


### PR DESCRIPTION
Rewrite fallout-migrate's argument parsing and path handling to use Spectre.Console.Cli and Fallout.Common.IO.AbsolutePath. This is mostly to prepare for #372.

### What changed
- Replace the hand-rolled `Main` argument parser with a Spectre.Console.Cli `CommandApp<MigrateCommand>` (`CommandSettings` with `[CommandArgument]`/`[CommandOption]`, built-in `--help` generation).
- Replace raw `System.IO` path handling in `Migration.cs` with `AbsolutePath` (`/` combinator, `.FileExists()`/`.DirectoryExists()`, `.GetFiles(depth:)`, `.Move(ExistsPolicy.Fail)`, `.ReadAllText()`/`.WriteAllText(eofLineBreak: false)`, `.GetUnixRelativePathTo(...)`).
- Flip `Migration`, `Summary`, and `RewriteResult` to `internal`, matching the already-internal rewriter classes.
- Add `Spectre.Console.Cli` (0.49.1, matching `Spectre.Console`) to `Directory.Packages.props` and a `ProjectReference` to `Fallout.Utilities`.

### Why
`fallout-migrate` hand-rolled its own arg parsing and used raw string paths. This aligns it with the CLI framework already used for prompts (`Spectre.Console`) and the path type used throughout the rest of the codebase (`AbsolutePath`).

### Verification
- `dotnet build src/Fallout.Migrate` — clean.
- `dotnet test tests/Fallout.Migrate.Specs` — 22/22 passing, unchanged.
- Manual: `--help` renders via Spectre; `--dry-run` and a real run against a scratch NUKE-style fixture produced byte-identical rewrites and correctly renamed `.nuke/` → `.fallout/`.

Note: losing `/?` as a help alias (Spectre only recognizes `-h`/`--help`) is a minor, deliberate side effect of switching to Spectre's built-in help.