### PR TITLE
Escape single quotes correctly in YAML CI writers

### DIFF
--- a/src/Fallout.Common/CI/AzurePipelines/AzurePipelines.cs
+++ b/src/Fallout.Common/CI/AzurePipelines/AzurePipelines.cs
@@ -175,7 +175,7 @@ public partial class AzurePipelines : Host, IBuildServer
                 .AddPairWhenValueNotNull("mergeResults", mergeResults)
                 .AddPairWhenValueNotNull("platform", platform)
                 .AddPairWhenValueNotNull("config", configuration)
-                .AddPairWhenValueNotNull("runTitle", title.SingleQuote())
+                .AddPairWhenValueNotNull("runTitle", title.SingleQuoteYaml())
                 .AddPairWhenValueNotNull("publishRunAttachments", publishRunAttachments));
     }
 

--- a/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesCacheStep.cs
+++ b/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesCacheStep.cs
@@ -27,7 +27,7 @@ public class AzurePipelinesCacheStep : AzurePipelinesStep
     {
         using (writer.WriteBlock("- task: Cache@2"))
         {
-            writer.WriteLine("displayName: " + $"Cache: {Identifier}".SingleQuote());
+            writer.WriteLine("displayName: " + $"Cache: {Identifier}".SingleQuoteYaml());
             using (writer.WriteBlock("inputs:"))
             {
                 writer.WriteLine($"key: $(Agent.OS) | {Identifier} | {KeyFiles.JoinCommaSpace()}");

--- a/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesCmdStep.cs
+++ b/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesCmdStep.cs
@@ -17,7 +17,7 @@ public class AzurePipelinesCmdStep : AzurePipelinesStep
     {
         using (writer.WriteBlock("- task: CmdLine@2"))
         {
-            writer.WriteLine("displayName: " + $"Run: {InvokedTargets.JoinCommaSpace()}".SingleQuote());
+            writer.WriteLine("displayName: " + $"Run: {InvokedTargets.JoinCommaSpace()}".SingleQuoteYaml());
 
             var arguments = $"{InvokedTargets.JoinSpace()} --skip";
             if (PartitionSize != null)

--- a/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesDownloadStep.cs
+++ b/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesDownloadStep.cs
@@ -17,7 +17,7 @@ public class AzurePipelinesDownloadStep : AzurePipelinesStep
             using (writer.WriteBlock("inputs:"))
             {
                 writer.WriteLine($"artifactName: {ArtifactName}");
-                writer.WriteLine($"downloadPath: {DownloadPath.SingleQuote()}");
+                writer.WriteLine($"downloadPath: {DownloadPath.SingleQuoteYaml()}");
             }
         }
     }

--- a/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesJob.cs
+++ b/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesJob.cs
@@ -19,14 +19,14 @@ public class AzurePipelinesJob : ConfigurationEntity
     {
         using (writer.WriteBlock($"- job: {Name}"))
         {
-            writer.WriteLine($"displayName: {DisplayName.SingleQuote()}");
+            writer.WriteLine($"displayName: {DisplayName.SingleQuoteYaml()}");
             writer.WriteLine($"dependsOn: [ {Dependencies.Select(x => x.Name).JoinCommaSpace()} ]");
 
             if (Image != null)
             {
                 using (writer.WriteBlock("pool:"))
                 {
-                    writer.WriteLine($"vmImage: {Image.Value.GetValue().SingleQuote().SingleQuote()}");
+                    writer.WriteLine($"vmImage: {Image.Value.GetValue().SingleQuoteYaml()}");
                 }
             }
 

--- a/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesPublishStep.cs
+++ b/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesPublishStep.cs
@@ -13,11 +13,11 @@ public class AzurePipelinesPublishStep : AzurePipelinesStep
     {
         using (writer.WriteBlock("- task: PublishBuildArtifacts@1"))
         {
-            writer.WriteLine("displayName: " + $"Publish: {ArtifactName}".SingleQuote());
+            writer.WriteLine("displayName: " + $"Publish: {ArtifactName}".SingleQuoteYaml());
             using (writer.WriteBlock("inputs:"))
             {
                 writer.WriteLine($"artifactName: {ArtifactName}");
-                writer.WriteLine($"pathToPublish: {PathToPublish.SingleQuote()}");
+                writer.WriteLine($"pathToPublish: {PathToPublish.SingleQuoteYaml()}");
             }
         }
     }

--- a/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesStage.cs
+++ b/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesStage.cs
@@ -18,14 +18,14 @@ public class AzurePipelinesStage : ConfigurationEntity
     {
         using (writer.WriteBlock($"- stage: {Name}"))
         {
-            writer.WriteLine($"displayName: {DisplayName.SingleQuote()}");
+            writer.WriteLine($"displayName: {DisplayName.SingleQuoteYaml()}");
             writer.WriteLine($"dependsOn: [ {Dependencies.Select(x => x.Name).JoinCommaSpace()} ]");
 
             if (Image != null)
             {
                 using (writer.WriteBlock("pool:"))
                 {
-                    writer.WriteLine($"vmImage: {Image.Value.GetValue().SingleQuote()}");
+                    writer.WriteLine($"vmImage: {Image.Value.GetValue().SingleQuoteYaml()}");
                 }
             }
 

--- a/src/Fallout.Common/CI/GitHubActions/Configuration/GitHubActionsArtifactStep.cs
+++ b/src/Fallout.Common/CI/GitHubActions/Configuration/GitHubActionsArtifactStep.cs
@@ -12,7 +12,7 @@ public class GitHubActionsArtifactStep : GitHubActionsStep
 
     public override void Write(CustomFileWriter writer)
     {
-        writer.WriteLine("- name: " + $"Publish: {Name}".SingleQuote());
+        writer.WriteLine("- name: " + $"Publish: {Name}".SingleQuoteYaml());
         writer.WriteLine("  uses: actions/upload-artifact@v5");
 
         using (writer.Indent())

--- a/src/Fallout.Common/CI/GitHubActions/Configuration/GitHubActionsCacheStep.cs
+++ b/src/Fallout.Common/CI/GitHubActions/Configuration/GitHubActionsCacheStep.cs
@@ -14,7 +14,7 @@ public class GitHubActionsCacheStep : GitHubActionsStep
 
     public override void Write(CustomFileWriter writer)
     {
-        writer.WriteLine("- name: " + $"Cache: {IncludePatterns.JoinCommaSpace()}".SingleQuote());
+        writer.WriteLine("- name: " + $"Cache: {IncludePatterns.JoinCommaSpace()}".SingleQuoteYaml());
         using (writer.Indent())
         {
             writer.WriteLine("uses: actions/cache@v4");
@@ -24,7 +24,7 @@ public class GitHubActionsCacheStep : GitHubActionsStep
                 writer.WriteLine("path: |");
                 IncludePatterns.ForEach(x => writer.WriteLine($"  {x}"));
                 ExcludePatterns.ForEach(x => writer.WriteLine($"  !{x}"));
-                writer.WriteLine($"key: ${{{{ runner.os }}}}-${{{{ hashFiles({KeyFiles.Select(x => x.SingleQuote()).JoinCommaSpace()}) }}}}");
+                writer.WriteLine($"key: ${{{{ runner.os }}}}-${{{{ hashFiles({KeyFiles.Select(x => x.SingleQuoteYaml()).JoinCommaSpace()}) }}}}");
             }
         }
     }

--- a/src/Fallout.Common/CI/GitHubActions/Configuration/GitHubActionsRunStep.cs
+++ b/src/Fallout.Common/CI/GitHubActions/Configuration/GitHubActionsRunStep.cs
@@ -28,7 +28,7 @@ public class GitHubActionsRunStep : GitHubActionsStep
             writer.WriteLine("run: dotnet tool restore");
         }
 
-        writer.WriteLine("- name: " + $"Run: {InvokedTargets.JoinCommaSpace()}".SingleQuote());
+        writer.WriteLine("- name: " + $"Run: {InvokedTargets.JoinCommaSpace()}".SingleQuoteYaml());
         using (writer.Indent())
         {
             writer.WriteLine($"run: dotnet fallout {InvokedTargets.JoinSpace()}");

--- a/tests/Fallout.Common.Specs/CI/AzurePipelinesJobSpecs.DisplayName_with_an_apostrophe_is_yaml_escaped.verified.txt
+++ b/tests/Fallout.Common.Specs/CI/AzurePipelinesJobSpecs.DisplayName_with_an_apostrophe_is_yaml_escaped.verified.txt
@@ -1,4 +1,4 @@
 ﻿- job: Compile
-  displayName: 'Yousif''s Job'
+  displayName: 'Bob''s Job'
   dependsOn: [  ]
   steps:

--- a/tests/Fallout.Common.Specs/CI/AzurePipelinesJobSpecs.DisplayName_with_an_apostrophe_is_yaml_escaped.verified.txt
+++ b/tests/Fallout.Common.Specs/CI/AzurePipelinesJobSpecs.DisplayName_with_an_apostrophe_is_yaml_escaped.verified.txt
@@ -1,0 +1,4 @@
+﻿- job: Compile
+  displayName: 'Yousif''s Job'
+  dependsOn: [  ]
+  steps:

--- a/tests/Fallout.Common.Specs/CI/AzurePipelinesJobSpecs.VmImage_is_quoted_correctly_without_double_wrapping_quirk.verified.txt
+++ b/tests/Fallout.Common.Specs/CI/AzurePipelinesJobSpecs.VmImage_is_quoted_correctly_without_double_wrapping_quirk.verified.txt
@@ -1,0 +1,6 @@
+﻿- job: Compile
+  displayName: 'Compile Job'
+  dependsOn: [  ]
+  pool:
+    vmImage: 'ubuntu-22.04'
+  steps:

--- a/tests/Fallout.Common.Specs/CI/AzurePipelinesJobSpecs.cs
+++ b/tests/Fallout.Common.Specs/CI/AzurePipelinesJobSpecs.cs
@@ -1,0 +1,44 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Fallout.Common.CI.AzurePipelines;
+using Fallout.Common.CI.AzurePipelines.Configuration;
+using Fallout.Common.Utilities;
+using VerifyXunit;
+using Xunit;
+
+namespace Fallout.Common.Specs.CI;
+
+public class AzurePipelinesJobSpecs
+{
+    private static Task Verify(AzurePipelinesJob job)
+    {
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream, leaveOpen: true);
+        job.Write(new CustomFileWriter(writer, indentationFactor: 2, commentPrefix: "#"));
+        writer.Flush();
+
+        stream.Seek(offset: 0, SeekOrigin.Begin);
+        return Verifier.Verify(new StreamReader(stream).ReadToEnd());
+    }
+
+    [Fact]
+    public Task DisplayName_with_an_apostrophe_is_yaml_escaped()
+        => Verify(new AzurePipelinesJob
+                  {
+                      Name = "Compile",
+                      DisplayName = "Yousif's Job",
+                      Dependencies = new AzurePipelinesJob[0],
+                      Steps = new AzurePipelinesStep[0]
+                  });
+
+    [Fact]
+    public Task VmImage_is_quoted_correctly_without_double_wrapping_quirk()
+        => Verify(new AzurePipelinesJob
+                  {
+                      Name = "Compile",
+                      DisplayName = "Compile Job",
+                      Dependencies = new AzurePipelinesJob[0],
+                      Steps = new AzurePipelinesStep[0],
+                      Image = AzurePipelinesImage.Ubuntu2204
+                  });
+}

--- a/tests/Fallout.Common.Specs/CI/AzurePipelinesJobSpecs.cs
+++ b/tests/Fallout.Common.Specs/CI/AzurePipelinesJobSpecs.cs
@@ -2,28 +2,15 @@
 using System.Threading.Tasks;
 using Fallout.Common.CI.AzurePipelines;
 using Fallout.Common.CI.AzurePipelines.Configuration;
-using Fallout.Common.Utilities;
-using VerifyXunit;
 using Xunit;
 
 namespace Fallout.Common.Specs.CI;
 
 public class AzurePipelinesJobSpecs
 {
-    private static Task Verify(AzurePipelinesJob job)
-    {
-        var stream = new MemoryStream();
-        var writer = new StreamWriter(stream, leaveOpen: true);
-        job.Write(new CustomFileWriter(writer, indentationFactor: 2, commentPrefix: "#"));
-        writer.Flush();
-
-        stream.Seek(offset: 0, SeekOrigin.Begin);
-        return Verifier.Verify(new StreamReader(stream).ReadToEnd());
-    }
-
     [Fact]
     public Task DisplayName_with_an_apostrophe_is_yaml_escaped()
-        => Verify(new AzurePipelinesJob
+        => ConfigurationEntityVerifier.Verify(new AzurePipelinesJob
                   {
                       Name = "Compile",
                       DisplayName = "Bob's Job",
@@ -33,7 +20,7 @@ public class AzurePipelinesJobSpecs
 
     [Fact]
     public Task VmImage_is_quoted_correctly_without_double_wrapping_quirk()
-        => Verify(new AzurePipelinesJob
+        => ConfigurationEntityVerifier.Verify(new AzurePipelinesJob
                   {
                       Name = "Compile",
                       DisplayName = "Compile Job",

--- a/tests/Fallout.Common.Specs/CI/AzurePipelinesJobSpecs.cs
+++ b/tests/Fallout.Common.Specs/CI/AzurePipelinesJobSpecs.cs
@@ -26,7 +26,7 @@ public class AzurePipelinesJobSpecs
         => Verify(new AzurePipelinesJob
                   {
                       Name = "Compile",
-                      DisplayName = "Yousif's Job",
+                      DisplayName = "Bob's Job",
                       Dependencies = new AzurePipelinesJob[0],
                       Steps = new AzurePipelinesStep[0]
                   });

--- a/tests/Fallout.Common.Specs/CI/ConfigurationEntityVerifier.cs
+++ b/tests/Fallout.Common.Specs/CI/ConfigurationEntityVerifier.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Fallout.Common.CI;
+using Fallout.Common.Utilities;
+using VerifyXunit;
+
+namespace Fallout.Common.Specs.CI;
+
+public static class ConfigurationEntityVerifier
+{
+    public static Task Verify(ConfigurationEntity entity)
+    {
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream, leaveOpen: true);
+        entity.Write(new CustomFileWriter(writer, indentationFactor: 2, commentPrefix: "#"));
+        writer.Flush();
+
+        stream.Seek(offset: 0, SeekOrigin.Begin);
+        return Verifier.Verify(new StreamReader(stream).ReadToEnd());
+    }
+}

--- a/tests/Fallout.Common.Specs/CI/GitHubActionsArtifactStepSpecs.Name_with_an_apostrophe_is_yaml_escaped.verified.txt
+++ b/tests/Fallout.Common.Specs/CI/GitHubActionsArtifactStepSpecs.Name_with_an_apostrophe_is_yaml_escaped.verified.txt
@@ -1,0 +1,5 @@
+﻿- name: 'Publish: Yousif''s Build'
+  uses: actions/upload-artifact@v5
+  with:
+    name: Yousif's Build
+    path: out

--- a/tests/Fallout.Common.Specs/CI/GitHubActionsArtifactStepSpecs.Name_with_an_apostrophe_is_yaml_escaped.verified.txt
+++ b/tests/Fallout.Common.Specs/CI/GitHubActionsArtifactStepSpecs.Name_with_an_apostrophe_is_yaml_escaped.verified.txt
@@ -1,5 +1,5 @@
-﻿- name: 'Publish: Yousif''s Build'
+﻿- name: 'Publish: Bob''s Build'
   uses: actions/upload-artifact@v5
   with:
-    name: Yousif's Build
+    name: Bob's Build
     path: out

--- a/tests/Fallout.Common.Specs/CI/GitHubActionsArtifactStepSpecs.cs
+++ b/tests/Fallout.Common.Specs/CI/GitHubActionsArtifactStepSpecs.cs
@@ -22,5 +22,5 @@ public class GitHubActionsArtifactStepSpecs
 
     [Fact]
     public Task Name_with_an_apostrophe_is_yaml_escaped()
-        => Verify(new GitHubActionsArtifactStep { Name = "Yousif's Build", Path = "out", Condition = "" });
+        => Verify(new GitHubActionsArtifactStep { Name = "Bob's Build", Path = "out", Condition = "" });
 }

--- a/tests/Fallout.Common.Specs/CI/GitHubActionsArtifactStepSpecs.cs
+++ b/tests/Fallout.Common.Specs/CI/GitHubActionsArtifactStepSpecs.cs
@@ -1,0 +1,26 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using Fallout.Common.CI.GitHubActions.Configuration;
+using Fallout.Common.Utilities;
+using VerifyXunit;
+using Xunit;
+
+namespace Fallout.Common.Specs.CI;
+
+public class GitHubActionsArtifactStepSpecs
+{
+    private static Task Verify(GitHubActionsArtifactStep step)
+    {
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream, leaveOpen: true);
+        step.Write(new CustomFileWriter(writer, indentationFactor: 2, commentPrefix: "#"));
+        writer.Flush();
+
+        stream.Seek(offset: 0, SeekOrigin.Begin);
+        return Verifier.Verify(new StreamReader(stream).ReadToEnd());
+    }
+
+    [Fact]
+    public Task Name_with_an_apostrophe_is_yaml_escaped()
+        => Verify(new GitHubActionsArtifactStep { Name = "Yousif's Build", Path = "out", Condition = "" });
+}

--- a/tests/Fallout.Common.Specs/CI/GitHubActionsArtifactStepSpecs.cs
+++ b/tests/Fallout.Common.Specs/CI/GitHubActionsArtifactStepSpecs.cs
@@ -1,26 +1,13 @@
 ﻿using System.IO;
 using System.Threading.Tasks;
 using Fallout.Common.CI.GitHubActions.Configuration;
-using Fallout.Common.Utilities;
-using VerifyXunit;
 using Xunit;
 
 namespace Fallout.Common.Specs.CI;
 
 public class GitHubActionsArtifactStepSpecs
 {
-    private static Task Verify(GitHubActionsArtifactStep step)
-    {
-        var stream = new MemoryStream();
-        var writer = new StreamWriter(stream, leaveOpen: true);
-        step.Write(new CustomFileWriter(writer, indentationFactor: 2, commentPrefix: "#"));
-        writer.Flush();
-
-        stream.Seek(offset: 0, SeekOrigin.Begin);
-        return Verifier.Verify(new StreamReader(stream).ReadToEnd());
-    }
-
     [Fact]
     public Task Name_with_an_apostrophe_is_yaml_escaped()
-        => Verify(new GitHubActionsArtifactStep { Name = "Bob's Build", Path = "out", Condition = "" });
+        => ConfigurationEntityVerifier.Verify(new GitHubActionsArtifactStep { Name = "Bob's Build", Path = "out", Condition = "" });
 }


### PR DESCRIPTION
Fixes #483

**Description:**
This PR updates the YAML CI writers to use `SingleQuoteYaml()` instead of `SingleQuote()`, ensuring that embedded apostrophes are properly escaped by doubling the quote (e.g., `''`) rather than using a backslash `\'` which results in invalid YAML.

**Changes:**
- Migrated all requested call sites in `GitHubActions` and `AzurePipelines` configuration files to `SingleQuoteYaml()`.
- Addressed the pre-existing quirk in `AzurePipelinesJob.cs` (`vmImage`). Removed the double wrapping (`.SingleQuote().SingleQuote()`) and replaced it with a single `SingleQuoteYaml()` call, which produces the correct intended output.
- Left the non-YAML `SingleQuote()` callers unchanged as requested.
- Added regression specs in `AzurePipelinesJobSpecs` and `GitHubActionsArtifactStepSpecs` to verify apostrophe escaping and correct `vmImage` rendering without snapshot churn.