### PR TITLE
Use Microsoft.Windows.SDK.BuildTools package to get signtool binary

### DIFF
--- a/src/Fallout.Common/Tools/SignTool/SignTool.Generated.cs
+++ b/src/Fallout.Common/Tools/SignTool/SignTool.Generated.cs
@@ -18,9 +18,12 @@ namespace Fallout.Common.Tools.SignTool;
 
 /// <summary><p>Sign Tool is a command-line tool that digitally signs files, verifies signatures in files, and time-stamps files.</p><p>For more details, visit the <a href="https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe">official website</a>.</p></summary>
 [ExcludeFromCodeCoverage]
-public partial class SignToolTasks : ToolTasks
+[NuGetTool(Id = PackageId, Executable = PackageExecutable)]
+public partial class SignToolTasks : ToolTasks, IRequireNuGetPackage
 {
     public static string SignToolPath { get => new SignToolTasks().GetToolPathInternal(); set => new SignToolTasks().SetToolPath(value); }
+    public const string PackageId = "Microsoft.Windows.SDK.BuildTools";
+    public const string PackageExecutable = "signtool.exe";
     /// <summary><p>Sign Tool is a command-line tool that digitally signs files, verifies signatures in files, and time-stamps files.</p><p>For more details, visit the <a href="https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe">official website</a>.</p></summary>
     public static IReadOnlyCollection<Output> SignTool(ArgumentStringHandler arguments, string workingDirectory = null, IReadOnlyDictionary<string, string> environmentVariables = null, int? timeout = null, bool? logOutput = null, bool? logInvocation = null, Action<OutputType, string> logger = null, Func<IProcess, object> exitHandler = null) => new SignToolTasks().Run(arguments, workingDirectory, environmentVariables, timeout, logOutput, logInvocation, logger, exitHandler);
     /// <summary><p>Use the <c>sign</c> command to sign files using embedded signatures. Signing protects a file from tampering, and allows users to verify the signer (you) based on a signing certificate. The options below allow you to specify signing parameters and to select the signing certificate you wish to use.</p><p>For more details, visit the <a href="https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe">official website</a>.</p></summary>

--- a/src/Fallout.Common/Tools/SignTool/SignTool.json
+++ b/src/Fallout.Common/Tools/SignTool/SignTool.json
@@ -6,6 +6,9 @@
   "name": "SignTool",
   "officialUrl": "https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe",
   "help": "Sign Tool is a command-line tool that digitally signs files, verifies signatures in files, and time-stamps files.",
+  "nugetPackageId": "Microsoft.Windows.SDK.BuildTools",
+  "packageExecutable": "signtool.exe",
+  "customExecutable": true,
   "tasks": [
     {
       "help": "Use the <c>sign</c> command to sign files using embedded signatures. Signing protects a file from tampering, and allows users to verify the signer (you) based on a signing certificate. The options below allow you to specify signing parameters and to select the signing certificate you wish to use.",

--- a/src/Fallout.Common/Tools/SignTool/SignToolTasks.cs
+++ b/src/Fallout.Common/Tools/SignTool/SignToolTasks.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Linq;
-using Fallout.Common.IO;
+using System.Runtime.InteropServices;
 using Fallout.Common.Tooling;
 
 namespace Fallout.Common.Tools.SignTool;
@@ -9,24 +8,17 @@ partial class SignToolTasks
 {
     protected override string GetToolPath(ToolOptions options = null)
     {
-        var programDirectory = EnvironmentInfo.SpecialFolder(
-            EnvironmentInfo.Is64Bit
-                ? SpecialFolders.ProgramFilesX86
-                : SpecialFolders.ProgramFiles).NotNull();
+        var architecture = RuntimeInformation.OSArchitecture switch
+        {
+            Architecture.Arm64 => "arm64",
+            Architecture.X86 => "x86",
+            Architecture.X64 => "x64",
+            _ => throw new ArgumentException("Unsupported architecture")
+        };
 
-        var platformIdentifier = EnvironmentInfo.Is64Bit ? "x64" : "x86";
-
-        return new[]
-            {
-                programDirectory / "Windows Kits" / "10" / "bin" / "10.0.15063.0",
-                programDirectory / "Windows Kits" / "10" / "App Certification Kit",
-                programDirectory / "Windows Kits" / "10" / "bin" / platformIdentifier,
-                programDirectory / "Windows Kits" / "8.1" / "bin" / platformIdentifier,
-                programDirectory / "Windows Kits" / "8.0" / "bin" / platformIdentifier,
-                programDirectory / "Microsoft SDKs" / "Windows" / "v7.1A" / "Bin"
-            }
-            .Select(x => x / "signtool.exe")
-            .WhereFileExists()
-            .FirstOrDefault();
+        return NuGetToolPathResolver.GetPackageExecutable(
+            packageId: PackageId,
+            packageExecutable: PackageExecutable,
+            framework: architecture);
     }
 }


### PR DESCRIPTION
<!-- Keep it terse: one-line summary, then short "what changed" bullets. -->
<!-- Link the issue and summarize it — don't recite it. See docs/agents/issue-and-pr-style.md. -->
<!-- Or let Copilot draft one, then trim it. -->
From: https://github.com/nuke-build/nuke/pull/1558

Fixes: https://github.com/nuke-build/nuke/issues/1186

Thanks: @gpailler
<!-- This repo merges via rebase only (linear history). Curate your commits into a -->
<!-- clean sequence before final approval — see CONTRIBUTING.md → Merging. -->
