### PR TITLE
Decompose Fallout.Migrate into an IMigrationStep pipeline

### DIFF
--- a/src/Fallout.Migrate/Common/IMigrationStep.cs
+++ b/src/Fallout.Migrate/Common/IMigrationStep.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+namespace Fallout.Migrate.Common;
+
+/// <summary>
+/// One unit of work performed against a repo during <c>fallout-migrate</c>. Add a new step by
+/// implementing this interface and registering it in <see cref="Migration"/>'s step list.
+/// </summary>
+internal interface IMigrationStep
+{
+    /// <summary>
+    /// Performs this step's work against <paramref name="context"/>, recording the outcome in
+    /// <paramref name="summary"/>.
+    /// </summary>
+    /// <param name="context">The current migration context.</param>
+    /// <param name="summary">The summary to update with files changed, edits made, or warnings.</param>
+    Task ExecuteAsync(MigrationContext context, Summary summary);
+}

--- a/src/Fallout.Migrate/Common/MigrationContext.cs
+++ b/src/Fallout.Migrate/Common/MigrationContext.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using Fallout.Common.IO;
+
+namespace Fallout.Migrate.Common;
+
+/// <summary>
+/// Plain data carried between <see cref="Migration"/> and each <see cref="IMigrationStep"/>.
+/// Holds no behavior itself; see <see cref="MigrationFileOperations"/> for the shared
+/// file-walking / rewrite-application helpers steps call into.
+/// </summary>
+internal sealed class MigrationContext(AbsolutePath rootDirectory, bool dryRun, TextWriter log)
+{
+    /// <summary>The repository root being migrated.</summary>
+    public AbsolutePath RootDirectory { get; } = rootDirectory ?? throw new ArgumentNullException(nameof(rootDirectory));
+
+    /// <summary>When <c>true</c>, steps must report intended changes without writing them.</summary>
+    public bool DryRun { get; } = dryRun;
+
+    /// <summary>The writer steps use to report progress.</summary>
+    public TextWriter Log { get; } = log ?? throw new ArgumentNullException(nameof(log));
+
+    /// <summary>
+    /// The Fallout version to pin in rewritten package references.
+    /// Set by <see cref="Fallout.Migrate.Steps.ResolveFalloutVersionStep"/>, which always runs first;
+    /// subsequent steps read it.
+    /// </summary>
+    public string FalloutVersion { get; internal set; }
+}

--- a/src/Fallout.Migrate/Common/MigrationFileOperations.cs
+++ b/src/Fallout.Migrate/Common/MigrationFileOperations.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Fallout.Common.IO;
+
+namespace Fallout.Migrate.Common;
+
+/// <summary>
+/// Shared file-walking and rewrite-application helpers used by multiple <see cref="IMigrationStep"/>
+/// implementations. Kept as static, dependency-free functions so steps stay small and independent.
+/// </summary>
+internal static class MigrationFileOperations
+{
+    /// <summary>
+    /// Recursively enumerates files under <paramref name="rootDirectory"/> matching
+    /// <paramref name="pattern"/>, skipping <c>bin/</c>, <c>obj/</c>, and <c>.git/</c>.
+    /// </summary>
+    /// <param name="rootDirectory">The directory to search from.</param>
+    /// <param name="pattern">A file-name glob pattern, e.g. <c>*.csproj</c>.</param>
+    /// <returns>The matching, non-ignored files.</returns>
+    public static IEnumerable<AbsolutePath> EnumerateFiles(AbsolutePath rootDirectory, string pattern)
+    {
+        foreach (var file in rootDirectory.GetFiles(pattern, depth: int.MaxValue))
+        {
+            if (IsIgnored(file))
+            {
+                continue;
+            }
+
+            yield return file;
+        }
+    }
+
+    /// <summary>
+    /// Reads <paramref name="path"/>, applies <paramref name="rewriter"/>, logs and records the edit,
+    /// and writes the result back unless <see cref="MigrationContext.DryRun"/> is set.
+    /// </summary>
+    /// <param name="context">The current migration context.</param>
+    /// <param name="path">The file to rewrite.</param>
+    /// <param name="rewriter">The rewrite function to apply to the file's content.</param>
+    /// <param name="summary">The summary to update with the outcome.</param>
+    public static void ApplyRewrite(
+        MigrationContext context,
+        AbsolutePath path,
+        Func<string, RewriteResult> rewriter,
+        Summary summary)
+    {
+        string original;
+        try
+        {
+            original = path.ReadAllText();
+        }
+        catch (IOException ex)
+        {
+            summary.Warnings.Add($"could not read {RelativePath(context.RootDirectory, path)}: {ex.Message}");
+            return;
+        }
+
+        var result = rewriter(original);
+        if (result.EditCount == 0)
+        {
+            return;
+        }
+
+        context.Log.WriteLine(
+            $"edit    {RelativePath(context.RootDirectory, path)}  ({result.EditCount} change{(result.EditCount == 1 ? "" : "s")})");
+
+        summary.FilesChanged++;
+        summary.EditCount += result.EditCount;
+
+        if (!context.DryRun)
+        {
+            // eofLineBreak: false preserves today's exact byte-for-byte write behavior;
+            // AbsolutePath.WriteAllText's default normalizes trailing line endings, which
+            // would otherwise sneak unrelated diff noise into migrated consumer repos.
+            path.WriteAllText(result.Content, eofLineBreak: false);
+        }
+    }
+
+    /// <summary>
+    /// Formats <paramref name="absolute"/> as a path relative to <paramref name="rootDirectory"/>,
+    /// using forward slashes, for log output.
+    /// </summary>
+    /// <param name="rootDirectory">The directory to make the path relative to.</param>
+    /// <param name="absolute">The path to format.</param>
+    public static string RelativePath(AbsolutePath rootDirectory, AbsolutePath absolute) =>
+        rootDirectory.GetUnixRelativePathTo(absolute);
+
+    /// <summary>
+    /// Returns <c>true</c> if <paramref name="path"/> sits under a <c>bin/</c>, <c>obj/</c>, or
+    /// <c>.git/</c> directory and should be skipped by <see cref="EnumerateFiles"/>.
+    /// </summary>
+    private static bool IsIgnored(AbsolutePath path)
+    {
+        string text = path;
+        return text.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+               || text.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+               || text.Contains($"{Path.DirectorySeparatorChar}.git{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+    }
+}

--- a/src/Fallout.Migrate/Common/RewriteResult.cs
+++ b/src/Fallout.Migrate/Common/RewriteResult.cs
@@ -1,0 +1,9 @@
+namespace Fallout.Migrate.Common;
+
+/// <summary>
+/// The result of rewriting a file's content: the new <paramref name="Content"/> and how many
+/// individual edits were made.
+/// </summary>
+/// <param name="Content">The rewritten file content.</param>
+/// <param name="EditCount">The number of edits applied; zero means the content is unchanged.</param>
+internal readonly record struct RewriteResult(string Content, int EditCount);

--- a/src/Fallout.Migrate/Common/Summary.cs
+++ b/src/Fallout.Migrate/Common/Summary.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Fallout.Migrate.Common;
+
+/// <summary>
+/// Aggregate result of a migration run: how many files changed, how many edits were made, how many
+/// directories were renamed, and any warnings that need manual follow-up.
+/// </summary>
+internal sealed class Summary
+{
+    /// <summary>The number of files that had at least one edit applied.</summary>
+    public int FilesChanged { get; set; }
+
+    /// <summary>The total number of individual edits made across all rewritten files.</summary>
+    public int EditCount { get; set; }
+
+    /// <summary>The number of directories renamed (currently just <c>.nuke/</c> → <c>.fallout/</c>).</summary>
+    public int DirectoriesRenamed { get; set; }
+
+    /// <summary>Human-readable warnings about conditions the migration could not resolve automatically.</summary>
+    public List<string> Warnings { get; } = new();
+}

--- a/src/Fallout.Migrate/MigrateCommand.cs
+++ b/src/Fallout.Migrate/MigrateCommand.cs
@@ -1,13 +1,19 @@
 using System;
 using System.ComponentModel;
 using System.IO;
+using System.Threading.Tasks;
 using Fallout.Common;
 using Fallout.Common.IO;
+using Fallout.Migrate.Common;
 using JetBrains.Annotations;
 using Spectre.Console.Cli;
 
 namespace Fallout.Migrate;
 
+/// <summary>
+/// The <c>fallout-migrate</c> CLI command. See the <see cref="DescriptionAttribute"/> below for the
+/// user-facing summary of what the migration does.
+/// </summary>
 [Description("""
              Migrate a NUKE consumer repo to Fallout.
 
@@ -20,9 +26,15 @@ namespace Fallout.Migrate;
                - Prints a summary of files changed and warnings to address manually
              """)]
 [UsedImplicitly]
-internal sealed class MigrateCommand : Command<MigrateSettings>
+internal sealed class MigrateCommand : AsyncCommand<MigrateSettings>
 {
-    public override int Execute(CommandContext context, MigrateSettings settings)
+    /// <summary>
+    /// Resolves the repository root, runs the migration, and prints a summary.
+    /// </summary>
+    /// <param name="context">The Spectre.Console.Cli command context (unused).</param>
+    /// <param name="settings">The parsed <see cref="MigrateSettings"/> for this invocation.</param>
+    /// <returns>0 on success, 1 if the repository root could not be resolved.</returns>
+    public override async Task<int> ExecuteAsync(CommandContext context, MigrateSettings settings)
     {
         var rootDirectory = ResolveRootDirectory(settings.Path);
         if (rootDirectory is null)
@@ -37,12 +49,18 @@ internal sealed class MigrateCommand : Command<MigrateSettings>
         PrintBanner(rootDirectory, settings.DryRun);
 
         var migration = new Migration(rootDirectory, settings.DryRun, Console.Out);
-        var summary = migration.Run();
+        Summary summary = await migration.RunAsync();
 
         PrintSummary(summary, settings.DryRun);
         return 0;
     }
 
+    /// <summary>
+    /// Resolves the repository root to migrate: the explicit <paramref name="explicitArg"/> if given,
+    /// otherwise the nearest ancestor of the working directory that looks like a Fallout/NUKE build repo.
+    /// </summary>
+    /// <param name="explicitArg">The path argument passed on the command line, or <c>null</c>.</param>
+    /// <returns>The resolved repository root, or <c>null</c> if none could be found.</returns>
     private static AbsolutePath ResolveRootDirectory(string explicitArg)
     {
         if (explicitArg != null)
@@ -59,6 +77,11 @@ internal sealed class MigrateCommand : Command<MigrateSettings>
             (current / "build.sh").FileExists());
     }
 
+    /// <summary>
+    /// Prints the tool banner and, when applicable, the dry-run notice.
+    /// </summary>
+    /// <param name="rootDirectory">The repository root being migrated.</param>
+    /// <param name="dryRun">Whether the migration is running in dry-run mode.</param>
     private static void PrintBanner(AbsolutePath rootDirectory, bool dryRun)
     {
         Console.WriteLine($"fallout-migrate — migrating: {rootDirectory}");
@@ -70,12 +93,18 @@ internal sealed class MigrateCommand : Command<MigrateSettings>
         Console.WriteLine();
     }
 
-    private static void PrintSummary(Migration.Summary summary, bool dryRun)
+    /// <summary>
+    /// Prints the migration <see cref="Summary"/> (counts, warnings, and next-steps guidance) to the console.
+    /// </summary>
+    /// <param name="summary">The result of <see cref="Migration.RunAsync"/>.</param>
+    /// <param name="dryRun">Whether the migration ran in dry-run mode.</param>
+    private static void PrintSummary(Summary summary, bool dryRun)
     {
         Console.WriteLine();
         Console.WriteLine($"Files changed:   {summary.FilesChanged}");
         Console.WriteLine($"Edits made:      {summary.EditCount}");
         Console.WriteLine($"Directories:     {summary.DirectoriesRenamed} renamed");
+
         if (summary.Warnings.Count > 0)
         {
             Console.WriteLine();
@@ -89,7 +118,7 @@ internal sealed class MigrateCommand : Command<MigrateSettings>
         Console.WriteLine();
         Console.WriteLine(dryRun
             ? "Dry-run complete. Re-run without --dry-run to apply changes."
-            : "Migration complete. Verify the build:  ./build.ps1   (or ./build.sh on unix)");
+            : "Migration complete. Verify the build: ./build.ps1 (or ./build.sh on UNIX)");
 
         Console.WriteLine("Migration guide: https://fallout.build  (see #37 for the full guide)");
     }

--- a/src/Fallout.Migrate/MigrateSettings.cs
+++ b/src/Fallout.Migrate/MigrateSettings.cs
@@ -4,14 +4,24 @@ using Spectre.Console.Cli;
 
 namespace Fallout.Migrate;
 
+/// <summary>
+/// Command-line arguments accepted by <see cref="MigrateCommand"/>.
+/// </summary>
 [UsedImplicitly]
 internal sealed class MigrateSettings : CommandSettings
 {
+    /// <summary>
+    /// The repository root to migrate. When <c>null</c>, <see cref="MigrateCommand"/> resolves it by
+    /// walking up from the working directory.
+    /// </summary>
     [CommandArgument(0, "[path]")]
     [Description("Repository root. Defaults to walking up from the working directory to find " +
                  "one (looking for build.cmd / build.ps1 / build.sh, .nuke/, or build/).")]
     public string Path { get; init; }
 
+    /// <summary>
+    /// When <c>true</c>, reports the changes <see cref="Migration"/> would make without writing them.
+    /// </summary>
     [CommandOption("-n|--dry-run")]
     [Description("Show what would change without writing.")]
     public bool DryRun { get; init; }

--- a/src/Fallout.Migrate/Migration.cs
+++ b/src/Fallout.Migrate/Migration.cs
@@ -1,196 +1,49 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection;
+using System.Threading.Tasks;
 using Fallout.Common.IO;
+using Fallout.Migrate.Common;
+using Fallout.Migrate.Steps;
 
 namespace Fallout.Migrate;
 
-internal sealed class Migration
+/// <summary>
+/// Orchestrates a migration run: builds a <see cref="MigrationContext"/> and executes the fixed,
+/// ordered list of <see cref="IMigrationStep"/>s against it. Add a new step by implementing
+/// <see cref="IMigrationStep"/> and appending it to <see cref="steps"/>.
+/// </summary>
+/// <param name="rootDirectory">The repository root to migrate.</param>
+/// <param name="dryRun">When <c>true</c>, reports intended changes without writing them.</param>
+/// <param name="log">The writer steps use to report progress.</param>
+internal sealed class Migration(AbsolutePath rootDirectory, bool dryRun, TextWriter log)
 {
-    private readonly AbsolutePath rootDirectory;
-    private readonly bool dryRun;
-    private readonly TextWriter log;
+    /// <summary>
+    /// The steps executed by <see cref="RunAsync"/>, in order. <see cref="ResolveFalloutVersionStep"/> must
+    /// run first, since later steps read <see cref="MigrationContext.FalloutVersion"/> from it.
+    /// </summary>
+    private static readonly IReadOnlyList<IMigrationStep> steps =
+    [
+        new ResolveFalloutVersionStep(),
+        new RewriteCsprojsStep(),
+        new RewriteCsFilesStep(),
+        new RewriteBootstrapScriptsStep(),
+        new RenameNukeDirectoryStep()
+    ];
 
-    public Migration(AbsolutePath rootDirectory, bool dryRun, TextWriter log)
-    {
-        this.rootDirectory = rootDirectory ?? throw new ArgumentNullException(nameof(rootDirectory));
-        this.dryRun = dryRun;
-        this.log = log ?? throw new ArgumentNullException(nameof(log));
-    }
-
-    public Summary Run()
+    /// <summary>
+    /// Runs every step in <see cref="steps"/> against a fresh <see cref="MigrationContext"/>.
+    /// </summary>
+    /// <returns>A <see cref="Summary"/> of the files changed, edits made, and any warnings.</returns>
+    public async Task<Summary> RunAsync()
     {
         var summary = new Summary();
+        var context = new MigrationContext(rootDirectory, dryRun, log);
 
-        RewriteCsprojs(summary);
-        RewriteCsFiles(summary);
-        RewriteBootstrapScripts(summary);
-        RenameNukeDirectory(summary);
+        foreach (var step in steps)
+        {
+            await step.ExecuteAsync(context, summary);
+        }
 
         return summary;
     }
-
-    private void RewriteCsprojs(Summary summary)
-    {
-        var falloutVersion = ResolveFalloutVersion();
-        foreach (var path in EnumerateFiles("*.csproj"))
-        {
-            ApplyRewrite(path, content => CsprojRewriter.Rewrite(content, falloutVersion), summary);
-        }
-    }
-
-    // Pinned into migrated `<PackageReference Include="Fallout.X" Version="..." />` lines.
-    // Uses the running migrate tool's own SemVer (Nerdbank.GitVersioning, set on
-    // AssemblyInformationalVersion) so the migration output aligns with the tool the user
-    // just installed. For dev/local builds without a `+` in InformationalVersion (i.e. no
-    // build-metadata suffix), falls back to a known-published floor so we never emit a
-    // bogus pin like Version="LOCAL". Inlined to keep Fallout.Migrate dependency-free.
-    private static string ResolveFalloutVersion()
-    {
-        const string fallback = "10.3.49";
-
-        var informational = typeof(Migration).Assembly
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-            ?.InformationalVersion;
-
-        if (string.IsNullOrEmpty(informational))
-        {
-            return fallback;
-        }
-
-        int plusIndex = informational.IndexOf('+');
-        if (plusIndex == -1)
-        {
-            return fallback;
-        }
-
-        return informational[..plusIndex];
-    }
-
-    private void RewriteCsFiles(Summary summary)
-    {
-        foreach (var path in EnumerateFiles("*.cs"))
-        {
-            ApplyRewrite(path, CodeRewriter.Rewrite, summary);
-        }
-    }
-
-    private void RewriteBootstrapScripts(Summary summary)
-    {
-        foreach (var name in new[]
-                 {
-                     "build.cmd",
-                     "build.ps1",
-                     "build.sh"
-                 })
-        {
-            var path = rootDirectory / name;
-            if (path.FileExists())
-            {
-                ApplyRewrite(path, ScriptRewriter.Rewrite, summary);
-            }
-        }
-    }
-
-    private void RenameNukeDirectory(Summary summary)
-    {
-        var legacy = rootDirectory / ".nuke";
-        var canonical = rootDirectory / ".fallout";
-
-        if (!legacy.DirectoryExists())
-        {
-            return;
-        }
-
-        if (canonical.DirectoryExists())
-        {
-            summary.Warnings.Add(
-                "Both .nuke/ and .fallout/ exist. Skipped rename; merge their contents manually.");
-
-            return;
-        }
-
-        Log($"rename {RelativePath(legacy)} -> {RelativePath(canonical)}");
-        if (!dryRun)
-        {
-            // We purposely use the .NET directory move as this is atomic. Fallout's own
-            // Move/MoveDirectory moves them one by one.
-            Directory.Move(legacy, canonical);
-        }
-
-        summary.DirectoriesRenamed++;
-    }
-
-    private IEnumerable<AbsolutePath> EnumerateFiles(string pattern)
-    {
-        foreach (var file in rootDirectory.GetFiles(pattern, depth: int.MaxValue))
-        {
-            if (IsIgnored(file))
-            {
-                continue;
-            }
-
-            yield return file;
-        }
-    }
-
-    private static bool IsIgnored(AbsolutePath path)
-    {
-        string text = path;
-        return text.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
-               || text.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
-               || text.Contains($"{Path.DirectorySeparatorChar}.git{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
-    }
-
-    private void ApplyRewrite(AbsolutePath path, Func<string, RewriteResult> rewriter, Summary summary)
-    {
-        string original;
-        try
-        {
-            original = path.ReadAllText();
-        }
-        catch (IOException ex)
-        {
-            summary.Warnings.Add($"could not read {RelativePath(path)}: {ex.Message}");
-            return;
-        }
-
-        var result = rewriter(original);
-        if (result.EditCount == 0)
-        {
-            return;
-        }
-
-        Log($"edit    {RelativePath(path)}  ({result.EditCount} change{(result.EditCount == 1 ? "" : "s")})");
-        summary.FilesChanged++;
-        summary.EditCount += result.EditCount;
-
-        if (!dryRun)
-        {
-            // eofLineBreak: false preserves today's exact byte-for-byte write behavior;
-            // AbsolutePath.WriteAllText's default normalizes trailing line endings, which
-            // would otherwise sneak unrelated diff noise into migrated consumer repos.
-            path.WriteAllText(result.Content, eofLineBreak: false);
-        }
-    }
-
-    private string RelativePath(AbsolutePath absolute) =>
-        rootDirectory.GetUnixRelativePathTo(absolute);
-
-    private void Log(string line) => log.WriteLine(line);
-
-    internal sealed class Summary
-    {
-        public int FilesChanged { get; set; }
-
-        public int EditCount { get; set; }
-
-        public int DirectoriesRenamed { get; set; }
-
-        public List<string> Warnings { get; } = new();
-    }
 }
-
-internal readonly record struct RewriteResult(string Content, int EditCount);

--- a/src/Fallout.Migrate/Program.cs
+++ b/src/Fallout.Migrate/Program.cs
@@ -1,10 +1,19 @@
+using System.Threading.Tasks;
 using Spectre.Console.Cli;
 
 namespace Fallout.Migrate;
 
+/// <summary>
+/// Entry point for the <c>fallout-migrate</c> CLI tool.
+/// </summary>
 public static class Program
 {
-    public static int Main(string[] args)
+    /// <summary>
+    /// Configures and runs the <see cref="MigrateCommand"/> as a single-command Spectre.Console.Cli app.
+    /// </summary>
+    /// <param name="args">The command-line arguments passed to the tool.</param>
+    /// <returns>The process exit code.</returns>
+    public static async Task<int> Main(string[] args)
     {
         var app = new CommandApp<MigrateCommand>();
         app.Configure(config =>
@@ -14,6 +23,6 @@ public static class Program
             config.AddExample("path/to/repo");
         });
 
-        return app.Run(args);
+        return await app.RunAsync(args);
     }
 }

--- a/src/Fallout.Migrate/Steps/CodeRewriter.cs
+++ b/src/Fallout.Migrate/Steps/CodeRewriter.cs
@@ -1,7 +1,13 @@
 using System.Text.RegularExpressions;
+using Fallout.Migrate.Common;
 
-namespace Fallout.Migrate;
+namespace Fallout.Migrate.Steps;
 
+/// <summary>
+/// Rewrites <c>.cs</c> files: <c>Nuke.*</c> namespace prefixes become <c>Fallout.</c>, and the bare
+/// <c>NukeBuild</c>/<c>INukeBuild</c> types become <c>FalloutBuild</c>/<c>IFalloutBuild</c>.
+/// Driven by <see cref="RewriteCsFilesStep"/>.
+/// </summary>
 internal static class CodeRewriter
 {
     // Anchored prefix swap: `\bNuke\.` → `Fallout.`. Covers using directives,
@@ -15,6 +21,12 @@ internal static class CodeRewriter
     private static readonly Regex nukeBuildType = new(@"\bNukeBuild\b", RegexOptions.Compiled);
     private static readonly Regex iNukeBuildType = new(@"\bINukeBuild\b", RegexOptions.Compiled);
 
+    /// <summary>
+    /// Rewrites <paramref name="original"/> C# source, replacing <c>Nuke.*</c> references and the
+    /// bare NUKE build types with their Fallout equivalents.
+    /// </summary>
+    /// <param name="original">The original <c>.cs</c> file content.</param>
+    /// <returns>The rewritten content and the number of edits made.</returns>
     public static RewriteResult Rewrite(string original)
     {
         var edits = 0;

--- a/src/Fallout.Migrate/Steps/CsprojRewriter.cs
+++ b/src/Fallout.Migrate/Steps/CsprojRewriter.cs
@@ -1,7 +1,14 @@
 using System.Text.RegularExpressions;
+using Fallout.Migrate.Common;
 
-namespace Fallout.Migrate;
+namespace Fallout.Migrate.Steps;
 
+/// <summary>
+/// Rewrites <c>.csproj</c> files: <c>Nuke.*</c> package/project references become <c>Fallout.*</c>
+/// (pinning the current Fallout version where an inline <c>Version</c> attribute was present),
+/// <c>Nuke*</c> MSBuild properties are renamed to <c>Fallout*</c>, and stale explicit
+/// <c>System.Security.Cryptography.Xml</c> pins are stripped. Driven by <see cref="RewriteCsprojsStep"/>.
+/// </summary>
 internal static class CsprojRewriter
 {
     // Combined rewrite: Nuke.X PackageReference WITH an inline Version attribute → Fallout.X
@@ -43,6 +50,13 @@ internal static class CsprojRewriter
         @"^[ \t]*<PackageReference\s+Include=""System\.Security\.Cryptography\.Xml""[^/]*/>\s*\r?\n?",
         RegexOptions.Compiled | RegexOptions.Multiline);
 
+    /// <summary>
+    /// Rewrites <paramref name="original"/> content, replacing <c>Nuke.*</c> references and MSBuild
+    /// properties with their <c>Fallout.*</c> equivalents and stripping stale pins.
+    /// </summary>
+    /// <param name="original">The original <c>.csproj</c> file content.</param>
+    /// <param name="falloutVersion">The Fallout version to pin into rewritten inline-versioned references.</param>
+    /// <returns>The rewritten content and the number of edits made.</returns>
     public static RewriteResult Rewrite(string original, string falloutVersion)
     {
         var edits = 0;

--- a/src/Fallout.Migrate/Steps/RenameNukeDirectoryStep.cs
+++ b/src/Fallout.Migrate/Steps/RenameNukeDirectoryStep.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using System.Threading.Tasks;
+using Fallout.Common.IO;
+using Fallout.Migrate.Common;
+
+namespace Fallout.Migrate.Steps;
+
+/// <summary>
+/// Renames the repository's <c>.nuke/</c> directory to <c>.fallout/</c>, or records a warning if
+/// both already exist and need a manual merge.
+/// </summary>
+internal sealed class RenameNukeDirectoryStep : IMigrationStep
+{
+    /// <inheritdoc />
+    public Task ExecuteAsync(MigrationContext context, Summary summary)
+    {
+        var legacy = context.RootDirectory / ".nuke";
+        var canonical = context.RootDirectory / ".fallout";
+
+        if (!legacy.DirectoryExists())
+        {
+            return Task.CompletedTask;
+        }
+
+        if (canonical.DirectoryExists())
+        {
+            summary.Warnings.Add(
+                "Both .nuke/ and .fallout/ exist. Skipped rename; merge their contents manually.");
+
+            return Task.CompletedTask;
+        }
+
+        context.Log.WriteLine(
+            $"rename {MigrationFileOperations.RelativePath(context.RootDirectory, legacy)} -> {MigrationFileOperations.RelativePath(context.RootDirectory, canonical)}");
+
+        if (!context.DryRun)
+        {
+            // We purposely use the .NET directory move as this is atomic. Fallout's own
+            // Move/MoveDirectory moves them one by one.
+            Directory.Move(legacy, canonical);
+        }
+
+        summary.DirectoriesRenamed++;
+        return Task.CompletedTask;
+    }
+}

--- a/src/Fallout.Migrate/Steps/ResolveFalloutVersionStep.cs
+++ b/src/Fallout.Migrate/Steps/ResolveFalloutVersionStep.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using System.Threading.Tasks;
+using Fallout.Migrate.Common;
+
+namespace Fallout.Migrate.Steps;
+
+// Pinned into migrated `<PackageReference Include="Fallout.X" Version="..." />` lines.
+
+// Uses the running migrate tool's own SemVer (Nerdbank.GitVersioning, set on
+
+// AssemblyInformationalVersion) so the migration output aligns with the tool the user
+
+// just installed. For dev/local builds without a `+` in InformationalVersion (i.e. no
+
+// build-metadata suffix), falls back to a known-published floor so we never emit a
+
+// bogus pin like Version="LOCAL". Inlined to keep Fallout.Migrate dependency-free.
+/// <summary>
+/// Resolves the running tool's own Fallout version and stores it on <see cref="MigrationContext.FalloutVersion"/>.
+/// Must run first in <see cref="Migration.steps"/>: <see cref="Steps.RewriteCsprojsStep"/> reads the
+/// resolved version to pin rewritten package references.
+/// </summary>
+internal sealed class ResolveFalloutVersionStep : IMigrationStep
+{
+    /// <summary>The version to fall back to when the assembly carries no build-metadata suffix.</summary>
+    private const string Fallback = "10.3.49";
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(MigrationContext context, Summary summary)
+    {
+        context.FalloutVersion = Resolve();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Reads the tool assembly's <see cref="AssemblyInformationalVersionAttribute"/> and strips the
+    /// build-metadata suffix, falling back to <see cref="Fallback"/> when none is present.
+    /// </summary>
+    /// <returns>The Fallout version to pin into rewritten package references.</returns>
+    private static string Resolve()
+    {
+        var informational = typeof(ResolveFalloutVersionStep).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+
+        if (string.IsNullOrEmpty(informational))
+        {
+            return Fallback;
+        }
+
+        int plusIndex = informational.IndexOf('+');
+        if (plusIndex == -1)
+        {
+            return Fallback;
+        }
+
+        return informational[..plusIndex];
+    }
+}

--- a/src/Fallout.Migrate/Steps/RewriteBootstrapScriptsStep.cs
+++ b/src/Fallout.Migrate/Steps/RewriteBootstrapScriptsStep.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using Fallout.Common.IO;
+using Fallout.Migrate.Common;
+
+namespace Fallout.Migrate.Steps;
+
+/// <summary>
+/// Rewrites <c>build.cmd</c>, <c>build.ps1</c>, and <c>build.sh</c> at the repository root, when
+/// present, via <see cref="ScriptRewriter"/>.
+/// </summary>
+internal sealed class RewriteBootstrapScriptsStep : IMigrationStep
+{
+    /// <inheritdoc />
+    public Task ExecuteAsync(MigrationContext context, Summary summary)
+    {
+        foreach (var name in new[]
+                 {
+                     "build.cmd",
+                     "build.ps1",
+                     "build.sh"
+                 })
+        {
+            var path = context.RootDirectory / name;
+            if (path.FileExists())
+            {
+                MigrationFileOperations.ApplyRewrite(context, path, ScriptRewriter.Rewrite, summary);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Fallout.Migrate/Steps/RewriteCsFilesStep.cs
+++ b/src/Fallout.Migrate/Steps/RewriteCsFilesStep.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using Fallout.Migrate.Common;
+
+namespace Fallout.Migrate.Steps;
+
+/// <summary>
+/// Rewrites every <c>*.cs</c> file under the repository root via <see cref="CodeRewriter"/>.
+/// </summary>
+internal sealed class RewriteCsFilesStep : IMigrationStep
+{
+    /// <inheritdoc />
+    public Task ExecuteAsync(MigrationContext context, Summary summary)
+    {
+        foreach (var path in MigrationFileOperations.EnumerateFiles(context.RootDirectory, "*.cs"))
+        {
+            MigrationFileOperations.ApplyRewrite(context, path, CodeRewriter.Rewrite, summary);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Fallout.Migrate/Steps/RewriteCsprojsStep.cs
+++ b/src/Fallout.Migrate/Steps/RewriteCsprojsStep.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using Fallout.Migrate.Common;
+
+namespace Fallout.Migrate.Steps;
+
+/// <summary>
+/// Rewrites every <c>*.csproj</c> file under the repository root via <see cref="CsprojRewriter"/>.
+/// </summary>
+internal sealed class RewriteCsprojsStep : IMigrationStep
+{
+    /// <inheritdoc />
+    public Task ExecuteAsync(MigrationContext context, Summary summary)
+    {
+        foreach (var path in MigrationFileOperations.EnumerateFiles(context.RootDirectory, "*.csproj"))
+        {
+            MigrationFileOperations.ApplyRewrite(
+                context,
+                path,
+                content => CsprojRewriter.Rewrite(content, context.FalloutVersion),
+                summary);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Fallout.Migrate/Steps/ScriptRewriter.cs
+++ b/src/Fallout.Migrate/Steps/ScriptRewriter.cs
@@ -1,9 +1,16 @@
 using System.Text.RegularExpressions;
+using Fallout.Migrate.Common;
 
-namespace Fallout.Migrate;
+namespace Fallout.Migrate.Steps;
 
+/// <summary>
+/// Rewrites bootstrap scripts (<c>build.cmd</c>/<c>build.ps1</c>/<c>build.sh</c>): <c>dotnet nuke</c>
+/// invocations, <c>.nuke</c> path references, and legacy <c>NUKE_*</c> environment variables become
+/// their Fallout equivalents. Driven by <see cref="RewriteBootstrapScriptsStep"/>.
+/// </summary>
 internal static class ScriptRewriter
 {
+    /// <summary>The ordered find/replace patterns applied by <see cref="Rewrite"/>.</summary>
     private static readonly (Regex Pattern, string Replacement)[] patterns =
     {
         // `dotnet nuke` invocations
@@ -17,6 +24,12 @@ internal static class ScriptRewriter
         (new Regex(@"\bNUKE_INTERNAL_INTERCEPTOR\b", RegexOptions.Compiled), "FALLOUT_INTERNAL_INTERCEPTOR"),
     };
 
+    /// <summary>
+    /// Rewrites <paramref name="original"/> script content, applying every pattern in
+    /// <see cref="patterns"/> in order.
+    /// </summary>
+    /// <param name="original">The original script file content.</param>
+    /// <returns>The rewritten content and the number of edits made.</returns>
     public static RewriteResult Rewrite(string original)
     {
         var edits = 0;

--- a/tests/Fallout.Migrate.Specs/CodeRewriterSpecs.cs
+++ b/tests/Fallout.Migrate.Specs/CodeRewriterSpecs.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Xunit;
+using Fallout.Migrate.Steps;
 
 namespace Fallout.Migrate.Specs;
 

--- a/tests/Fallout.Migrate.Specs/CsprojRewriterSpecs.cs
+++ b/tests/Fallout.Migrate.Specs/CsprojRewriterSpecs.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Xunit;
+using Fallout.Migrate.Steps;
 
 namespace Fallout.Migrate.Specs;
 

--- a/tests/Fallout.Migrate.Specs/MigrationIntegrationSpecs.cs
+++ b/tests/Fallout.Migrate.Specs/MigrationIntegrationSpecs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 
@@ -9,14 +10,14 @@ namespace Fallout.Migrate.Specs;
 public class MigrationIntegrationSpecs
 {
     [Fact]
-    public void MigratesVanillaConsumerRepo()
+    public async Task MigratesVanillaConsumerRepo()
     {
         var temp = CreateVanillaFixture();
 
         try
         {
             var migration = new Migration(temp, dryRun: false, TextWriter.Null);
-            var summary = migration.Run();
+            var summary = await migration.RunAsync();
 
             // Build file rewritten end to end.
             var buildCsproj = File.ReadAllText(Path.Combine(temp, "build", "_build.csproj"));
@@ -53,7 +54,7 @@ public class MigrationIntegrationSpecs
     }
 
     [Fact]
-    public void DryRunDoesNotWriteFiles()
+    public async Task DryRunDoesNotWriteFiles()
     {
         var temp = CreateVanillaFixture();
 
@@ -62,7 +63,7 @@ public class MigrationIntegrationSpecs
             var beforeCsproj = File.ReadAllText(Path.Combine(temp, "build", "_build.csproj"));
             var beforeNukeDir = Directory.Exists(Path.Combine(temp, ".nuke"));
 
-            var summary = new Migration(temp, dryRun: true, TextWriter.Null).Run();
+            var summary = await new Migration(temp, dryRun: true, TextWriter.Null).RunAsync();
 
             File.ReadAllText(Path.Combine(temp, "build", "_build.csproj")).Should().Be(beforeCsproj);
             Directory.Exists(Path.Combine(temp, ".nuke")).Should().Be(beforeNukeDir);
@@ -75,14 +76,14 @@ public class MigrationIntegrationSpecs
     }
 
     [Fact]
-    public void WarnsWhenBothNukeAndFalloutDirectoriesExist()
+    public async Task WarnsWhenBothNukeAndFalloutDirectoriesExist()
     {
         var temp = CreateVanillaFixture();
         Directory.CreateDirectory(Path.Combine(temp, ".fallout"));
 
         try
         {
-            var summary = new Migration(temp, dryRun: false, TextWriter.Null).Run();
+            var summary = await new Migration(temp, dryRun: false, TextWriter.Null).RunAsync();
 
             summary.Warnings.Should().Contain(w => w.Contains(".nuke/") && w.Contains(".fallout/"));
             summary.DirectoriesRenamed.Should().Be(0);

--- a/tests/Fallout.Migrate.Specs/ScriptRewriterSpecs.cs
+++ b/tests/Fallout.Migrate.Specs/ScriptRewriterSpecs.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Xunit;
+using Fallout.Migrate.Steps;
 
 namespace Fallout.Migrate.Specs;
 


### PR DESCRIPTION
Restructures `fallout-migrate`'s migration logic into a step pipeline so new migration steps (more are coming soon) can be added without growing one class.

### What changed
- `Common/` -- shared, behavior-free/static pieces: `MigrationContext`, `Summary`, `RewriteResult`, `IMigrationStep`, `MigrationFileOperations` (`EnumerateFiles`/`ApplyRewrite`/`RelativePath`)
- `Steps/` -- one class per migration step (`ResolveFalloutVersionStep`, `RewriteCsprojsStep`, `RewriteCsFilesStep`, `RewriteBootstrapScriptsStep`, `RenameNukeDirectoryStep`), each next to the rewriter it drives (`CsprojRewriter`, `CodeRewriter`, `ScriptRewriter`)
- `Migration.Run()` now just builds a `MigrationContext` and iterates a fixed, ordered `IMigrationStep` list -- adding a step is one new class + one line

No behavior change; internal-only, no public API touched.

### Verification
`dotnet test tests/Fallout.Migrate.Specs` -- 22/22 pass.