### PR TITLE
Style fallout-migrate's banner and summary output with AnsiConsole

### DIFF
--- a/src/Fallout.Migrate/MigrateCommand.cs
+++ b/src/Fallout.Migrate/MigrateCommand.cs
@@ -6,6 +6,7 @@ using Fallout.Common;
 using Fallout.Common.IO;
 using Fallout.Migrate.Common;
 using JetBrains.Annotations;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Fallout.Migrate;
@@ -84,13 +85,13 @@ internal sealed class MigrateCommand : AsyncCommand<MigrateSettings>
     /// <param name="dryRun">Whether the migration is running in dry-run mode.</param>
     private static void PrintBanner(AbsolutePath rootDirectory, bool dryRun)
     {
-        Console.WriteLine($"fallout-migrate — migrating: {rootDirectory}");
+        AnsiConsole.MarkupLineInterpolated($"[bold]fallout-migrate[/] — migrating: [blue]{rootDirectory}[/]");
         if (dryRun)
         {
-            Console.WriteLine("(dry-run — no files will be modified)");
+            AnsiConsole.MarkupLine("[yellow](dry-run — no files will be modified)[/]");
         }
 
-        Console.WriteLine();
+        AnsiConsole.WriteLine();
     }
 
     /// <summary>
@@ -100,26 +101,26 @@ internal sealed class MigrateCommand : AsyncCommand<MigrateSettings>
     /// <param name="dryRun">Whether the migration ran in dry-run mode.</param>
     private static void PrintSummary(Summary summary, bool dryRun)
     {
-        Console.WriteLine();
-        Console.WriteLine($"Files changed:   {summary.FilesChanged}");
-        Console.WriteLine($"Edits made:      {summary.EditCount}");
-        Console.WriteLine($"Directories:     {summary.DirectoriesRenamed} renamed");
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLineInterpolated($"Files changed:   [bold]{summary.FilesChanged}[/]");
+        AnsiConsole.MarkupLineInterpolated($"Edits made:      [bold]{summary.EditCount}[/]");
+        AnsiConsole.MarkupLineInterpolated($"Directories:     [bold]{summary.DirectoriesRenamed}[/] renamed");
 
         if (summary.Warnings.Count > 0)
         {
-            Console.WriteLine();
-            Console.WriteLine("Warnings:");
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine("[yellow]Warnings:[/]");
             foreach (var w in summary.Warnings)
             {
-                Console.WriteLine($"  - {w}");
+                AnsiConsole.MarkupLineInterpolated($"[yellow]  - {w}[/]");
             }
         }
 
-        Console.WriteLine();
-        Console.WriteLine(dryRun
-            ? "Dry-run complete. Re-run without --dry-run to apply changes."
-            : "Migration complete. Verify the build: ./build.ps1 (or ./build.sh on UNIX)");
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine(dryRun
+            ? "[green]Dry-run complete.[/] Re-run without --dry-run to apply changes."
+            : "[green]Migration complete.[/] Verify the build: ./build.ps1 (or ./build.sh on UNIX)");
 
-        Console.WriteLine("Migration guide: https://fallout.build  (see #37 for the full guide)");
+        AnsiConsole.MarkupLine("[grey]Migration guide: https://fallout.build  (see #37 for the full guide)[/]");
     }
 }


### PR DESCRIPTION
Stacked on #507. Replaces the plain Console.WriteLine calls in MigrateCommand's banner and summary printing with Spectre.Console's AnsiConsole.

<img width="1352" height="471" alt="image" src="https://github.com/user-attachments/assets/57b6d484-2296-44d9-8721-398f846453fe" />

### What changed
- Bold banner text, yellow dry-run notice
- Bold counts, yellow warnings, green completion message, dimmed guide link in the summary
- Interpolated values (paths, warning text) go through MarkupLineInterpolated so user-controlled content can't be misread as markup

Left untouched:
- Console.Error.WriteLine for the two error messages -- stderr semantics matter for piping/exit codes
- The TextWriter-based per-file/per-rename logging in Steps/Common -- stays plain text so MigrationIntegrationSpecs can keep capturing it via TextWriter.Null without a console

No behavior change; internal-only, no public API touched.

### Verification
dotnet test tests/Fallout.Migrate.Specs -- 22/22 pass.