### PR TITLE
Fix crash when git branch config has a duplicate key

### DIFF
--- a/src/Fallout.Build/VCS/GitRepository.cs
+++ b/src/Fallout.Build/VCS/GitRepository.cs
@@ -154,13 +154,23 @@ public class GitRepository
             return (null, null);
 
         var configFileContent = configFile.ReadAllLines();
-        var data = configFileContent
+
+        // Git config files are INI-style: sections are denoted by a [header] line, with
+        // indented key = value pairs beneath them. To find the remote and merge ref for
+        // the given branch, we locate the matching [branch "..."] section, read all
+        // key-value lines until the next section begins, and project them into a dictionary.
+        // GroupBy + Last() handles the (uncommon) case of a duplicated key, keeping the
+        // final value as git itself would.
+        Dictionary<string, string> data = configFileContent
             .Select(x => x.Trim())
             .SkipWhile(x => x != $"[branch {branch.DoubleQuote()}]")
             .Skip(1)
             .TakeWhile(x => !x.StartsWith("["))
-            .Select(x => x.Split('='))
-            .ToDictionary(x => x.ElementAt(0).Trim(), x => x.ElementAt(1).Trim());
+            .Where(x => x.Contains('='))
+            .Select(x => x.Split('=', 2))
+            .GroupBy(x => x[0].Trim(), x => x[1].Trim())
+            .ToDictionary(x => x.Key, x => x.Last());
+
         return data.TryGetValue("remote", out var remote) && data.TryGetValue("merge", out var merge)
             ? (remote, merge.TrimStart("refs/heads/"))
             : (null, null);

--- a/tests/Fallout.Build.Specs/GitRepositorySpecs.cs
+++ b/tests/Fallout.Build.Specs/GitRepositorySpecs.cs
@@ -74,4 +74,71 @@ public class GitRepositorySpecs
                 Directory.Delete(tempDir, recursive: true);
         }
     }
+
+    /// <summary>
+    /// VS Code's Git extension is known to append a duplicate `vscode-merge-base` line to the
+    /// `[branch "name"]` section instead of updating it in place, which used to crash
+    /// GetRemoteNameAndBranch's ToDictionary call.
+    /// </summary>
+    [Fact]
+    public void Handles_duplicate_config_keys_caused_by_vs_code()
+    {
+        // Arrange
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            RunGit(directory, "init --quiet --initial-branch=main");
+            RunGit(directory, "config user.email test@example.com");
+            RunGit(directory, "config user.name Test");
+            File.WriteAllText(Path.Combine(directory, "file.txt"), "content");
+            RunGit(directory, "add file.txt");
+            RunGit(directory, "commit --quiet -m initial");
+            // Deliberately not a real Fallout-build/Fallout URL: some CI environments rewrite
+            // that org's URLs (e.g. to a canary mirror) via a global git `insteadOf` config,
+            // which would silently change the identifier this test asserts on.
+            RunGit(directory, "remote add origin https://github.com/octocat/hello-world.git");
+            RunGit(directory, "config branch.main.remote origin");
+            RunGit(directory, "config branch.main.merge refs/heads/main");
+
+            var configPath = Path.Combine(directory, ".git", "config");
+            File.AppendAllText(
+                configPath,
+                "\tvscode-merge-base = origin/main" + Environment.NewLine +
+                "\tvscode-merge-base = origin/main" + Environment.NewLine);
+
+            // Act
+            var repository = GitRepository.FromLocalDirectory(directory);
+
+            // Assert
+            repository.Branch.Should().Be("main");
+            repository.Identifier.Should().Be("octocat/hello-world");
+        }
+        finally
+        {
+            // Git marks object files read-only, which trips up Directory.Delete on Windows.
+            foreach (var file in Directory.GetFiles(directory, "*", SearchOption.AllDirectories))
+            {
+                File.SetAttributes(file, FileAttributes.Normal);
+            }
+
+            Directory.Delete(directory, true);
+        }
+    }
+
+    private static void RunGit(string workingDirectory, string arguments)
+    {
+        var startInfo = new System.Diagnostics.ProcessStartInfo("git", arguments)
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        using var process = System.Diagnostics.Process.Start(startInfo).NotNull();
+        process.WaitForExit();
+        process.ExitCode.Should().Be(0, process.StandardError.ReadToEnd());
+    }
 }


### PR DESCRIPTION
Fixes a crash in `GitRepository.GetRemoteNameAndBranch` when the git branch config section contains a duplicate key.

## Problem
VS Code's Git extension appends a `vscode-merge-base` entry to `[branch "..."]` instead of updating it in place, sometimes leaving it duplicated. Parsing that section built a `Dictionary` with `ToDictionary`, which throws:

```
System.ArgumentException: An item with the same key has already been added. Key: vscode-merge-base
```

This breaks `GitRepository.FromLocalDirectory`, and therefore `[GitVersion]` parameter injection, for any consumer whose `.git/config` has this duplicate.

## Fix
Group config lines by key and take the last value (matches git's own last-value-wins semantics) instead of `ToDictionary`. Also skip lines without `=` instead of crashing with `IndexOutOfRangeException`.

## Testing
Added a regression test that reproduces the exact reported exception against a real temp git repo with a duplicated `vscode-merge-base` line, and confirmed it fails without the fix and passes with it. Ran the full `Fallout.Build.Tests` suite (only the pre-existing, unrelated `FromDirectoryTest` worktree limitation fails, confirmed to fail identically on `main`).
