### PR TITLE
Rename legacy prefixed private fields to camelCase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -73,9 +73,7 @@ dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 # name private fields (instance and static) using camelCase, with no _ / m_ / g_ / s_ prefix
 # CSharpGuidelines AV1702 (camelCase private fields) + AV1705 (no field prefixes).
 # Ordered after constant_fields so private const still resolves to PascalCase above.
-# Severity is suggestion for now: the repo still carries ~100 s_-prefixed fields, so a
-# warning/error flip is gated on the one-time migration sweep (see PR description).
-dotnet_naming_rule.private_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = warning
 dotnet_naming_rule.private_fields_should_be_camel_case.symbols  = private_fields
 dotnet_naming_rule.private_fields_should_be_camel_case.style    = camel_case_style
 
@@ -175,3 +173,6 @@ resharper_redundant_anonymous_type_property_name_highlighting = none
 # read this key, so a silent severity stops either from flagging build scripts.
 [build/**.cs]
 dotnet_style_require_accessibility_modifiers = omit_if_default:silent
+
+[tests/**/*.cs]
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = suggestion

--- a/src/Fallout.Build.Shared/Notifications.cs
+++ b/src/Fallout.Build.Shared/Notifications.cs
@@ -28,12 +28,12 @@ internal class NotificationFetcher
     private const string NotificationEndpoint = Constants.FalloutNotificationsUrl;
     private const string UtmMedium = "development";
 
-    private readonly AbsolutePath _notificationDirectory = Constants.GlobalFalloutDirectory / "received-notifications";
-    private readonly string _utmSource;
+    private readonly AbsolutePath notificationDirectory = Constants.GlobalFalloutDirectory / "received-notifications";
+    private readonly string utmSource;
 
     public NotificationFetcher(string utmSource)
     {
-        _utmSource = utmSource;
+        this.utmSource = utmSource;
     }
 
     public async Task<Notification> GetNotificationAsync()
@@ -60,7 +60,7 @@ internal class NotificationFetcher
 
         var notification = json.EnumerateArray()
             .Where(IsApplicable)
-            .Select(x => (Json: x, File: _notificationDirectory / x.ToString().GetMD5Hash()))
+            .Select(x => (Json: x, File: notificationDirectory / x.ToString().GetMD5Hash()))
             .FirstOrDefault(x => !x.File.Exists());
         if (notification.File == null)
             return null;
@@ -74,14 +74,14 @@ internal class NotificationFetcher
 
         bool IsApplicable(JsonElement element)
             => !element.TryGetProperty("exclude", out var exclusions) ||
-               !exclusions.EnumerateArray().Select(x => x.GetString()).Contains(_utmSource);
+               !exclusions.EnumerateArray().Select(x => x.GetString()).Contains(utmSource);
 
         Link GetLink(JsonElement obj)
         {
             var originalUrl = new Uri(obj.GetProperty("url").GetString().NotNullOrEmpty())
                 .WithUtmValues(
                     medium: UtmMedium,
-                    source: _utmSource,
+                    source: utmSource,
                     campaign: obj.GetProperty("campaign").GetString());
             return new Link(
                 Text: obj.GetProperty("title").GetString(),

--- a/src/Fallout.Build/Attributes/VerbosityMappingAttribute.cs
+++ b/src/Fallout.Build/Attributes/VerbosityMappingAttribute.cs
@@ -8,11 +8,11 @@ namespace Fallout.Common.Tooling;
 
 public class VerbosityMappingAttribute : BuildExtensionAttributeBase, IOnBuildInitialized
 {
-    private readonly Type _targetType;
+    private readonly Type targetType;
 
     public VerbosityMappingAttribute(Type targetType)
     {
-        _targetType = targetType;
+        this.targetType = targetType;
     }
 
     public string Quiet { get; set; }
@@ -25,19 +25,19 @@ public class VerbosityMappingAttribute : BuildExtensionAttributeBase, IOnBuildIn
         IReadOnlyCollection<ExecutableTarget> executionPlan)
     {
         object GetMappedValue(string name)
-            => _targetType
+            => targetType
                 .GetField(name)
-                .NotNull($"Type {_targetType} doesn't have a field {name}.")
+                .NotNull($"Type {targetType} doesn't have a field {name}.")
                 .GetValue(obj: null);
 
         if (Quiet != null)
-            VerbosityMapping.Mappings.Add(_targetType, (Verbosity.Quiet, GetMappedValue(Quiet)));
+            VerbosityMapping.Mappings.Add(targetType, (Verbosity.Quiet, GetMappedValue(Quiet)));
         if (Minimal != null)
-            VerbosityMapping.Mappings.Add(_targetType, (Verbosity.Minimal, GetMappedValue(Minimal)));
+            VerbosityMapping.Mappings.Add(targetType, (Verbosity.Minimal, GetMappedValue(Minimal)));
         if (Normal != null)
-            VerbosityMapping.Mappings.Add(_targetType, (Verbosity.Normal, GetMappedValue(Normal)));
+            VerbosityMapping.Mappings.Add(targetType, (Verbosity.Normal, GetMappedValue(Normal)));
         if (Verbose != null)
-            VerbosityMapping.Mappings.Add(_targetType, (Verbosity.Verbose, GetMappedValue(Verbose)));
+            VerbosityMapping.Mappings.Add(targetType, (Verbosity.Verbose, GetMappedValue(Verbose)));
     }
 }
 

--- a/src/Fallout.Build/CICD/CustomFileWriter.cs
+++ b/src/Fallout.Build/CICD/CustomFileWriter.cs
@@ -6,29 +6,29 @@ namespace Fallout.Common.Utilities;
 
 public class CustomFileWriter
 {
-    private readonly StreamWriter _streamWriter;
-    private readonly int _indentationFactor;
-    private readonly string _commentPrefix;
-    private int _indentation;
+    private readonly StreamWriter streamWriter;
+    private readonly int indentationFactor;
+    private readonly string commentPrefix;
+    private int indentation;
 
     public CustomFileWriter(StreamWriter streamWriter, int indentationFactor, string commentPrefix)
     {
-        _streamWriter = streamWriter;
-        _indentationFactor = indentationFactor;
-        _commentPrefix = commentPrefix;
+        this.streamWriter = streamWriter;
+        this.indentationFactor = indentationFactor;
+        this.commentPrefix = commentPrefix;
     }
 
     public void WriteLine(string text = null)
     {
-        _streamWriter.WriteLine(
+        streamWriter.WriteLine(
             text != null
-                ? $"{' '.Repeat(_indentation * _indentationFactor)}{text}"
+                ? $"{' '.Repeat(indentation * indentationFactor)}{text}"
                 : string.Empty);
     }
 
     public void WriteComment(string text = null)
     {
-        WriteLine($"{_commentPrefix} {text}".TrimEnd());
+        WriteLine($"{commentPrefix} {text}".TrimEnd());
     }
 
     public void Write(Action<CustomFileWriter> writer)
@@ -39,7 +39,7 @@ public class CustomFileWriter
     public IDisposable Indent()
     {
         return DelegateDisposable.CreateBracket(
-            () => _indentation++,
-            () => _indentation--);
+            () => indentation++,
+            () => indentation--);
     }
 }

--- a/src/Fallout.Build/Execution/ParameterService.cs
+++ b/src/Fallout.Build/Execution/ParameterService.cs
@@ -16,19 +16,19 @@ internal partial class ParameterService
     internal Func<string, Type, object> ArgumentsFromFilesService;
     internal ArgumentParser ArgumentsFromCommitMessageService;
 
-    private readonly Func<ArgumentParser> _argumentParserProvider;
-    private readonly Func<IReadOnlyDictionary<string, string>> _environmentVariablesProvider;
+    private readonly Func<ArgumentParser> argumentParserProvider;
+    private readonly Func<IReadOnlyDictionary<string, string>> environmentVariablesProvider;
 
     public ParameterService(
         Func<ArgumentParser> argumentParserProvider,
         Func<IReadOnlyDictionary<string, string>> environmentVariablesProvider)
     {
-        _argumentParserProvider = argumentParserProvider;
-        _environmentVariablesProvider = environmentVariablesProvider;
+        this.argumentParserProvider = argumentParserProvider;
+        this.environmentVariablesProvider = environmentVariablesProvider;
     }
 
-    private ArgumentParser ArgumentsParser => _argumentParserProvider.Invoke();
-    private IReadOnlyDictionary<string, string> Variables => _environmentVariablesProvider.Invoke();
+    private ArgumentParser ArgumentsParser => argumentParserProvider.Invoke();
+    private IReadOnlyDictionary<string, string> Variables => environmentVariablesProvider.Invoke();
 
     public static bool IsParameter(string value)
     {

--- a/src/Fallout.Build/Execution/TargetDefinition.cs
+++ b/src/Fallout.Build/Execution/TargetDefinition.cs
@@ -12,13 +12,13 @@ namespace Fallout.Common.Execution;
 
 internal class TargetDefinition : ITargetDefinition
 {
-    private readonly Stack<PropertyInfo> _baseMembers;
+    private readonly Stack<PropertyInfo> baseMembers;
 
     public TargetDefinition(PropertyInfo target, IFalloutBuild build, Stack<PropertyInfo> baseMembers)
     {
         Target = target;
         Build = build;
-        _baseMembers = baseMembers;
+        this.baseMembers = baseMembers;
     }
 
     public PropertyInfo Target { get; }
@@ -247,10 +247,10 @@ internal class TargetDefinition : ITargetDefinition
 
     public ITargetDefinition Base()
     {
-        Assert.True(_baseMembers.Count > 0,
+        Assert.True(baseMembers.Count > 0,
             $"Target '{Target.DeclaringType}.{Target.Name}' does not have any base members."
             + $" To inherit from an interface default implementation, use {nameof(Inherit)}<T> instead.");
-        Inherit(_baseMembers.Pop().GetValueNonVirtual<Target>(Build));
+        Inherit(baseMembers.Pop().GetValueNonVirtual<Target>(Build));
         return this;
     }
 

--- a/src/Fallout.Build/Execution/ValueInjectionUtility.cs
+++ b/src/Fallout.Build/Execution/ValueInjectionUtility.cs
@@ -10,10 +10,10 @@ namespace Fallout.Common.ValueInjection;
 
 internal static class ValueInjectionUtility
 {
-    private static readonly Dictionary<MemberInfo, object> s_valueCache = new();
+    private static readonly Dictionary<MemberInfo, object> valueCache = new();
 
     /// <summary>Clears the per-run injected-value cache so a subsequent build in the same process re-injects. FT-1 / #306.</summary>
-    internal static void ClearCache() => s_valueCache.Clear();
+    internal static void ClearCache() => valueCache.Clear();
 
     public static T TryGetValue<T>(Expression<Func<T>> parameterExpression)
         where T : class
@@ -38,7 +38,7 @@ internal static class ValueInjectionUtility
             return attribute.TryGetValue(parameter, instance);
         }
 
-        return (T) (s_valueCache[parameter] = s_valueCache.GetValueOrDefault(parameter) ?? GetValue());
+        return (T) (valueCache[parameter] = valueCache.GetValueOrDefault(parameter) ?? GetValue());
     }
 
     public static void InjectValues<T>(T instance = default, Func<MemberInfo, Attribute, bool> filter = null)

--- a/src/Fallout.Build/Host.cs
+++ b/src/Fallout.Build/Host.cs
@@ -189,19 +189,19 @@ public partial class Host
 
     internal class LogEventSink : ILogEventSink
     {
-        private readonly Host _host;
+        private readonly Host host;
 
         public LogEventSink(Host host)
         {
-            _host = host;
+            this.host = host;
         }
 
         public void Emit(LogEvent logEvent)
         {
             if (logEvent.Level is LogEventLevel.Warning)
-                _host.ReportWarning(logEvent.RenderMessage(), logEvent.Exception?.ToString());
+                host.ReportWarning(logEvent.RenderMessage(), logEvent.Exception?.ToString());
             else if (logEvent.Level is LogEventLevel.Error or LogEventLevel.Fatal)
-                _host.ReportError(logEvent.RenderMessage(), logEvent.Exception?.ToString());
+                host.ReportError(logEvent.RenderMessage(), logEvent.Exception?.ToString());
         }
     }
 }

--- a/src/Fallout.Build/Logging.cs
+++ b/src/Fallout.Build/Logging.cs
@@ -213,25 +213,25 @@ public static class Logging
     {
         public static InMemorySink Instance { get; } = new();
 
-        private readonly List<LogEvent> _logEvents;
+        private readonly List<LogEvent> logEvents;
 
         private InMemorySink()
         {
-            _logEvents = new List<LogEvent>();
+            logEvents = new List<LogEvent>();
         }
 
-        public IReadOnlyCollection<LogEvent> LogEvents => _logEvents.AsReadOnly();
+        public IReadOnlyCollection<LogEvent> LogEvents => logEvents.AsReadOnly();
 
         public void Emit(LogEvent logEvent)
         {
             logEvent.AddOrUpdateProperty(ExecutingTargetLogEventEnricher.Current);
-            _logEvents.Add(logEvent);
+            logEvents.Add(logEvent);
         }
 
         /// <summary>Drops accumulated events so a subsequent build in the same process starts clean. FT-1 / #306.</summary>
         public void Clear()
         {
-            _logEvents.Clear();
+            logEvents.Clear();
         }
 
         public void Dispose()
@@ -242,16 +242,16 @@ public static class Logging
 
     internal class ExecutingTargetLogEventEnricher : ILogEventEnricher
     {
-        public static LogEventProperty Current => s_property ?? s_defaultProperty;
+        public static LogEventProperty Current => property ?? defaultProperty;
 
-        private static readonly LogEventProperty s_defaultProperty = GetTargetEventProperty(string.Empty);
+        private static readonly LogEventProperty defaultProperty = GetTargetEventProperty(string.Empty);
 #pragma warning disable CS0649
-        private static LogEventProperty s_property;
+        private static LogEventProperty property;
 #pragma warning restore CS0649
 
         public static IDisposable SetTargetEventProperty(string name)
         {
-            return DelegateDisposable.SetAndRestore(() => s_property, GetTargetEventProperty(name));
+            return DelegateDisposable.SetAndRestore(() => property, GetTargetEventProperty(name));
         }
 
         private static LogEventProperty GetTargetEventProperty(string name)

--- a/src/Fallout.Build/Telemetry/Telemetry.Events.cs
+++ b/src/Fallout.Build/Telemetry/Telemetry.Events.cs
@@ -21,7 +21,7 @@ internal partial class Telemetry
 
     public static void TargetSucceeded(ExecutableTarget target, IFalloutBuild build)
     {
-        if (!target.Name.EqualsAnyOrdinalIgnoreCase(s_knownTargets) ||
+        if (!target.Name.EqualsAnyOrdinalIgnoreCase(knownTargets) ||
             target.Status != ExecutionStatus.Succeeded)
             return;
 

--- a/src/Fallout.Build/Telemetry/Telemetry.Properties.cs
+++ b/src/Fallout.Build/Telemetry/Telemetry.Properties.cs
@@ -15,7 +15,7 @@ namespace Fallout.Common.Execution;
 
 internal partial class Telemetry
 {
-    private static readonly string[] s_knownTargets = { "Restore", "Compile", "Test" };
+    private static readonly string[] knownTargets = { "Restore", "Compile", "Test" };
 
     private static Dictionary<string, string> GetCommonProperties(IFalloutBuild build = null)
     {

--- a/src/Fallout.Build/Telemetry/Telemetry.cs
+++ b/src/Fallout.Build/Telemetry/Telemetry.cs
@@ -27,7 +27,7 @@ internal static partial class Telemetry
     private const string VersionPropertyName = "FalloutTelemetryVersion";
     private const string LegacyVersionPropertyName = "NukeTelemetryVersion";
 
-    private static readonly int? s_confirmedVersion;
+    private static readonly int? confirmedVersion;
 
     static Telemetry()
     {

--- a/src/Fallout.Build/Theming/AnsiConsoleHostTheme.cs
+++ b/src/Fallout.Build/Theming/AnsiConsoleHostTheme.cs
@@ -30,8 +30,8 @@ public class AnsiConsoleHostTheme : AnsiConsoleTheme, IHostTheme
             [ConsoleThemeStyle.LevelFatal] = "\u001B[38;5;231;1m\u001B[48;5;196m"
         });
 
-    private readonly string _successCode;
-    private readonly IReadOnlyDictionary<ConsoleThemeStyle, string> _styles;
+    private readonly string successCode;
+    private readonly IReadOnlyDictionary<ConsoleThemeStyle, string> styles;
     private const string AnsiStyleReset = "\u001B[0m";
 
     public AnsiConsoleHostTheme(
@@ -39,68 +39,68 @@ public class AnsiConsoleHostTheme : AnsiConsoleTheme, IHostTheme
         IReadOnlyDictionary<ConsoleThemeStyle, string> styles)
         : base(styles)
     {
-        _successCode = successCode;
-        _styles = styles;
+        this.successCode = successCode;
+        this.styles = styles;
     }
 
     public void WriteSuccess(string text)
     {
-        Write(text, _successCode);
+        Write(text, successCode);
     }
 
     public void WriteVerbose(string text = null)
     {
-        Write(text, _styles[ConsoleThemeStyle.LevelVerbose]);
+        Write(text, styles[ConsoleThemeStyle.LevelVerbose]);
     }
 
     public void WriteDebug(string text)
     {
-        Write(text, _styles[ConsoleThemeStyle.LevelDebug]);
+        Write(text, styles[ConsoleThemeStyle.LevelDebug]);
     }
 
     public void WriteInformation(string text)
     {
-        Write(text, _styles[ConsoleThemeStyle.LevelInformation]);
+        Write(text, styles[ConsoleThemeStyle.LevelInformation]);
     }
 
     public void WriteWarning(string text)
     {
-        Write(text, _styles[ConsoleThemeStyle.LevelWarning]);
+        Write(text, styles[ConsoleThemeStyle.LevelWarning]);
     }
 
     public void WriteError(string text)
     {
-        Write(text, _styles[ConsoleThemeStyle.LevelError]);
+        Write(text, styles[ConsoleThemeStyle.LevelError]);
     }
 
     string IHostTheme.FormatSuccess(string text)
     {
-        return Format(text, _successCode);
+        return Format(text, successCode);
     }
 
     string IHostTheme.FormatVerbose(string text)
     {
-        return Format(text, _styles[ConsoleThemeStyle.LevelVerbose]);
+        return Format(text, styles[ConsoleThemeStyle.LevelVerbose]);
     }
 
     string IHostTheme.FormatDebug(string text)
     {
-        return Format(text, _styles[ConsoleThemeStyle.LevelDebug]);
+        return Format(text, styles[ConsoleThemeStyle.LevelDebug]);
     }
 
     string IHostTheme.FormatInformation(string text)
     {
-        return Format(text, _styles[ConsoleThemeStyle.LevelInformation]);
+        return Format(text, styles[ConsoleThemeStyle.LevelInformation]);
     }
 
     string IHostTheme.FormatWarning(string text)
     {
-        return Format(text, _styles[ConsoleThemeStyle.LevelWarning]);
+        return Format(text, styles[ConsoleThemeStyle.LevelWarning]);
     }
 
     string IHostTheme.FormatError(string text)
     {
-        return Format(text, _styles[ConsoleThemeStyle.LevelError]);
+        return Format(text, styles[ConsoleThemeStyle.LevelError]);
     }
 
     private void Write(string text, string code)

--- a/src/Fallout.Build/Theming/SystemConsoleHostTheme.cs
+++ b/src/Fallout.Build/Theming/SystemConsoleHostTheme.cs
@@ -30,46 +30,46 @@ public class SystemConsoleHostTheme : SystemConsoleTheme, IHostTheme
             [ConsoleThemeStyle.LevelFatal] = new() { Foreground = ConsoleColor.White, Background = ConsoleColor.Red }
         });
 
-    private readonly SystemConsoleThemeStyle _successStyle;
-    private readonly IReadOnlyDictionary<ConsoleThemeStyle, SystemConsoleThemeStyle> _styles;
+    private readonly SystemConsoleThemeStyle successStyle;
+    private readonly IReadOnlyDictionary<ConsoleThemeStyle, SystemConsoleThemeStyle> styles;
 
     public SystemConsoleHostTheme(
         SystemConsoleThemeStyle successStyle,
         IReadOnlyDictionary<ConsoleThemeStyle, SystemConsoleThemeStyle> styles)
         : base(styles)
     {
-        _successStyle = successStyle;
-        _styles = styles;
+        this.successStyle = successStyle;
+        this.styles = styles;
     }
 
     public void WriteSuccess(string text)
     {
-        Write(text, _successStyle);
+        Write(text, successStyle);
     }
 
     public void WriteVerbose(string text = null)
     {
-        Write(text, _styles[ConsoleThemeStyle.LevelVerbose]);
+        Write(text, styles[ConsoleThemeStyle.LevelVerbose]);
     }
 
     public void WriteDebug(string text)
     {
-        Write(text, _styles[ConsoleThemeStyle.LevelDebug]);
+        Write(text, styles[ConsoleThemeStyle.LevelDebug]);
     }
 
     public void WriteInformation(string text)
     {
-        Write(text, _styles[ConsoleThemeStyle.LevelInformation]);
+        Write(text, styles[ConsoleThemeStyle.LevelInformation]);
     }
 
     public void WriteWarning(string text)
     {
-        Write(text, _styles[ConsoleThemeStyle.LevelWarning]);
+        Write(text, styles[ConsoleThemeStyle.LevelWarning]);
     }
 
     public void WriteError(string text)
     {
-        Write(text, _styles[ConsoleThemeStyle.LevelError]);
+        Write(text, styles[ConsoleThemeStyle.LevelError]);
     }
 
     string IHostTheme.FormatSuccess(string text)

--- a/src/Fallout.Build/Utilities/SchemaUtility.cs
+++ b/src/Fallout.Build/Utilities/SchemaUtility.cs
@@ -26,7 +26,7 @@ public static class SchemaUtility
     private const string DraftSchema = "http://json-schema.org/draft-04/schema#";
     private const string DefinitionsPrefix = "#/definitions/";
 
-    private static readonly JsonSerializerOptions s_writeOptions = new()
+    private static readonly JsonSerializerOptions writeOptions = new()
     {
         WriteIndented = true,
         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
@@ -35,7 +35,7 @@ public static class SchemaUtility
     public static string GetJsonString(IFalloutBuild build)
     {
         // Trailing newline matches the legacy NJsonSchema output that consumer-side tooling expects.
-        return BuildSchema(build).ToJsonString(s_writeOptions) + "\n";
+        return BuildSchema(build).ToJsonString(writeOptions) + "\n";
     }
 
     public static JsonDocument GetJsonDocument(IFalloutBuild build)

--- a/src/Fallout.Cli/Commands/AddPackageCommand.cs
+++ b/src/Fallout.Cli/Commands/AddPackageCommand.cs
@@ -14,13 +14,13 @@ namespace Fallout.Cli.Commands;
 /// </summary>
 internal sealed class AddPackageCommand : IFalloutCommand
 {
-    private readonly IConfigurationReader _configuration;
-    private readonly IPackageManager _packages;
+    private readonly IConfigurationReader configuration;
+    private readonly IPackageManager packages;
 
     public AddPackageCommand(IConfigurationReader configuration, IPackageManager packages)
     {
-        _configuration = configuration;
-        _packages = packages;
+        this.configuration = configuration;
+        this.packages = packages;
     }
 
     public string Name => "add-package";
@@ -40,17 +40,17 @@ internal sealed class AddPackageCommand : IFalloutCommand
              NuGetPackageResolver.GetGlobalInstalledPackage(packageId, version: null, packagesConfigFile: null)?.Version.ToString())
             .NotNull("packageVersion != null");
 
-        var configuration = _configuration.Read(buildScript, evaluate: true);
+        var configuration = this.configuration.Read(buildScript, evaluate: true);
         var buildProjectFile = configuration[ConfigurationReader.BuildProjectFileKey];
         Host.Information($"Installing {packageId}/{packageVersion} to {buildProjectFile} ...");
-        _packages.AddOrReplacePackage(packageId, packageVersion, PackageManager.DownloadType, buildProjectFile);
+        packages.AddOrReplacePackage(packageId, packageVersion, PackageManager.DownloadType, buildProjectFile);
         DotNetTasks.DotNet($"restore {buildProjectFile}");
 
         var installedPackage = NuGetPackageResolver.GetGlobalInstalledPackage(packageId, packageVersion, packagesConfigFile: null)
             .NotNull("installedPackage != null");
         var hasToolsDirectory = installedPackage.Directory.GlobDirectories("tools").Any();
         if (!hasToolsDirectory)
-            _packages.AddOrReplacePackage(packageId, packageVersion, PackageManager.ReferenceType, buildProjectFile);
+            packages.AddOrReplacePackage(packageId, packageVersion, PackageManager.ReferenceType, buildProjectFile);
 
         Host.Information($"Done installing {packageId}/{packageVersion} to {buildProjectFile}");
         return 0;

--- a/src/Fallout.Cli/Commands/CakeCleanCommand.cs
+++ b/src/Fallout.Cli/Commands/CakeCleanCommand.cs
@@ -11,9 +11,9 @@ namespace Fallout.Cli.Commands;
 /// </summary>
 internal sealed class CakeCleanCommand : IFalloutCommand
 {
-    private readonly IConsolePrompts _prompts;
+    private readonly IConsolePrompts prompts;
 
-    public CakeCleanCommand(IConsolePrompts prompts) => _prompts = prompts;
+    public CakeCleanCommand(IConsolePrompts prompts) => this.prompts = prompts;
 
     public string Name => "cake-clean";
 
@@ -26,7 +26,7 @@ internal sealed class CakeCleanCommand : IFalloutCommand
         Host.Information("Found .cake files:");
         cakeFiles.ForEach(x => Host.Debug($"  - {x}"));
 
-        if (_prompts.PromptForConfirmation("Delete?"))
+        if (prompts.PromptForConfirmation("Delete?"))
             cakeFiles.ForEach(x => x.DeleteFile());
 
         return 0;

--- a/src/Fallout.Cli/Commands/CakeConvertCommand.cs
+++ b/src/Fallout.Cli/Commands/CakeConvertCommand.cs
@@ -16,10 +16,10 @@ namespace Fallout.Cli.Commands;
 /// </summary>
 internal sealed class CakeConvertCommand : IFalloutCommand
 {
-    private readonly IConsolePrompts _prompts;
-    private readonly IConfigurationReader _configuration;
-    private readonly IPackageManager _packages;
-    private readonly SetupCommand _setup;
+    private readonly IConsolePrompts prompts;
+    private readonly IConfigurationReader configuration;
+    private readonly IPackageManager packages;
+    private readonly SetupCommand setup;
 
     public CakeConvertCommand(
         IConsolePrompts prompts,
@@ -27,10 +27,10 @@ internal sealed class CakeConvertCommand : IFalloutCommand
         IPackageManager packages,
         SetupCommand setup)
     {
-        _prompts = prompts;
-        _configuration = configuration;
-        _packages = packages;
-        _setup = setup;
+        this.prompts = prompts;
+        this.configuration = configuration;
+        this.packages = packages;
+        this.setup = setup;
     }
 
     public string Name => "cake-convert";
@@ -57,19 +57,19 @@ internal sealed class CakeConvertCommand : IFalloutCommand
             }.JoinNewLine());
 
         Host.Debug();
-        if (!_prompts.PromptForConfirmation("Continue?"))
+        if (!prompts.PromptForConfirmation("Continue?"))
             return 0;
         Host.Debug();
 
         if (buildScript == null &&
-            _prompts.PromptForConfirmation("Should a NUKE project be created for better results?"))
+            prompts.PromptForConfirmation("Should a NUKE project be created for better results?"))
         {
-            await _setup.ExecuteAsync(args, rootDirectory: null, buildScript: null);
+            await setup.ExecuteAsync(args, rootDirectory: null, buildScript: null);
         }
 
         var buildScriptFile = WorkingDirectory / CliConventions.CurrentBuildScriptName;
         var buildProjectFile = buildScriptFile.Exists()
-            ? _configuration.Read(buildScriptFile, evaluate: true)
+            ? configuration.Read(buildScriptFile, evaluate: true)
                 .GetValueOrDefault(ConfigurationReader.BuildProjectFileKey, defaultValue: null)
             : null;
 
@@ -84,7 +84,7 @@ internal sealed class CakeConvertCommand : IFalloutCommand
         {
             var packages = CakeConverter.GetCakeFiles().SelectMany(x => CakeConverter.GetPackages(x.ReadAllText()));
             foreach (var package in packages)
-                _packages.AddOrReplacePackage(package.Id, package.Version, package.Type, buildProjectFile);
+                this.packages.AddOrReplacePackage(package.Id, package.Version, package.Type, buildProjectFile);
         }
 
         return 0;

--- a/src/Fallout.Cli/Commands/GetConfigurationCommand.cs
+++ b/src/Fallout.Cli/Commands/GetConfigurationCommand.cs
@@ -12,9 +12,9 @@ namespace Fallout.Cli.Commands;
 /// </summary>
 internal sealed class GetConfigurationCommand : IFalloutCommand
 {
-    private readonly IConfigurationReader _configuration;
+    private readonly IConfigurationReader configuration;
 
-    public GetConfigurationCommand(IConfigurationReader configuration) => _configuration = configuration;
+    public GetConfigurationCommand(IConfigurationReader configuration) => this.configuration = configuration;
 
     public string Name => "get-configuration";
 
@@ -23,7 +23,7 @@ internal sealed class GetConfigurationCommand : IFalloutCommand
 
     private int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
     {
-        var configuration = _configuration.Read(buildScript.NotNull(), evaluate: false);
+        var configuration = this.configuration.Read(buildScript.NotNull(), evaluate: false);
 
         Host.Information($"Configuration from {buildScript}:");
         configuration.ForEach(x => Console.WriteLine($"{x.Key} = {x.Value}"));

--- a/src/Fallout.Cli/Commands/Navigation/PushWithChosenRootDirectoryCommand.cs
+++ b/src/Fallout.Cli/Commands/Navigation/PushWithChosenRootDirectoryCommand.cs
@@ -12,9 +12,9 @@ namespace Fallout.Cli.Commands.Navigation;
 /// </summary>
 internal sealed class PushWithChosenRootDirectoryCommand : IFalloutCommand
 {
-    private readonly IConsolePrompts _prompts;
+    private readonly IConsolePrompts prompts;
 
-    public PushWithChosenRootDirectoryCommand(IConsolePrompts prompts) => _prompts = prompts;
+    public PushWithChosenRootDirectoryCommand(IConsolePrompts prompts) => this.prompts = prompts;
 
     public string Name => "PushWithChosenRootDirectory";
 
@@ -32,7 +32,7 @@ internal sealed class PushWithChosenRootDirectoryCommand : IFalloutCommand
                 .Select(x => (x, EnvironmentInfo.WorkingDirectory.GetRelativePathTo(x).ToString()))
                 .OrderBy(x => x.Item2).ToArray();
 
-            return _prompts.PromptForChoice("Where to go next?", directories);
+            return prompts.PromptForChoice("Where to go next?", directories);
         });
     }
 }

--- a/src/Fallout.Cli/Commands/SecretsCommand.cs
+++ b/src/Fallout.Cli/Commands/SecretsCommand.cs
@@ -26,9 +26,9 @@ internal sealed class SecretsCommand : IFalloutCommand
     private const string DiscardAndExit = "<Discard & Exit>";
     private const string DeletePasswordAndExit = "<Delete Password & Exit>";
 
-    private readonly IConsolePrompts _prompts;
+    private readonly IConsolePrompts prompts;
 
-    public SecretsCommand(IConsolePrompts prompts) => _prompts = prompts;
+    public SecretsCommand(IConsolePrompts prompts) => this.prompts = prompts;
 
     public string Name => "secrets";
 
@@ -76,7 +76,7 @@ internal sealed class SecretsCommand : IFalloutCommand
 
         if (EnvironmentInfo.IsOsx && existingSecrets.Count == 0 && !fromCredentialStore)
         {
-            if (generatedPassword || _prompts.PromptForConfirmation($"Save password to keychain? (associated with '{rootDirectory}')"))
+            if (generatedPassword || prompts.PromptForConfirmation($"Save password to keychain? (associated with '{rootDirectory}')"))
                 CredentialStore.SavePassword(credentialStoreName, password);
         }
         else if (fromLegacyCredentialStore)
@@ -92,13 +92,13 @@ internal sealed class SecretsCommand : IFalloutCommand
         var addedSecrets = new Dictionary<string, string>();
         while (true)
         {
-            var choice = _prompts.PromptForChoice(
+            var choice = prompts.PromptForChoice(
                 "Choose secret parameter to enter value:",
                 options.Select(x => (x, addedSecrets.ContainsKey(x) || existingSecrets.ContainsKey(x) ? $"* {x}" : x)).ToArray());
 
             if (!choice.EqualsAnyOrdinalIgnoreCase(SaveAndExit, DiscardAndExit, DeletePasswordAndExit))
             {
-                addedSecrets[choice] = _prompts.PromptForSecret(choice);
+                addedSecrets[choice] = prompts.PromptForSecret(choice);
             }
             else
             {

--- a/src/Fallout.Cli/Commands/SetupCommand.cs
+++ b/src/Fallout.Cli/Commands/SetupCommand.cs
@@ -27,13 +27,13 @@ internal sealed class SetupCommand : IFalloutCommand
 {
     private const string TARGET_FRAMEWORK = "net10.0";
 
-    private readonly IConsolePrompts _prompts;
-    private readonly IBuildScaffolder _scaffolder;
+    private readonly IConsolePrompts prompts;
+    private readonly IBuildScaffolder scaffolder;
 
     public SetupCommand(IConsolePrompts prompts, IBuildScaffolder scaffolder)
     {
-        _prompts = prompts;
-        _scaffolder = scaffolder;
+        this.prompts = prompts;
+        this.scaffolder = scaffolder;
     }
 
     public string Name => "setup";
@@ -63,17 +63,17 @@ internal sealed class SetupCommand : IFalloutCommand
             Host.Warning("Could not find root directory. Falling back to working directory ...");
             rootDirectory = WorkingDirectory;
         }
-        _prompts.ShowInput("deciduous_tree", "Root directory", rootDirectory);
+        prompts.ShowInput("deciduous_tree", "Root directory", rootDirectory);
 
-        var buildProjectName = _prompts.PromptForInput("How should the project be named?", "_build");
-        _prompts.ClearPreviousLine();
-        _prompts.ShowInput("bookmark", "Build project name", buildProjectName);
+        var buildProjectName = prompts.PromptForInput("How should the project be named?", "_build");
+        prompts.ClearPreviousLine();
+        prompts.ShowInput("bookmark", "Build project name", buildProjectName);
 
-        var buildProjectRelativeDirectory = _prompts.PromptForInput("Where should the project be located?", "./build");
-        _prompts.ClearPreviousLine();
-        _prompts.ShowInput("round_pushpin", "Build project location", buildProjectRelativeDirectory);
+        var buildProjectRelativeDirectory = prompts.PromptForInput("Where should the project be located?", "./build");
+        prompts.ClearPreviousLine();
+        prompts.ShowInput("round_pushpin", "Build project location", buildProjectRelativeDirectory);
 
-        var falloutVersion = _prompts.PromptForChoice("Which Fallout.Common version should be used?",
+        var falloutVersion = prompts.PromptForChoice("Which Fallout.Common version should be used?",
             new[]
                 {
                     ("latest release", await falloutLatestReleaseVersion),
@@ -84,9 +84,9 @@ internal sealed class SetupCommand : IFalloutCommand
                 .Where(x => x.Item2 != null)
                 .Distinct(x => x.Item2)
                 .Select(x => (x.Item2, $"{x.Item2} ({x.Item1})")).ToArray());
-        _prompts.ShowInput("gem_stone", "Fallout.Common version", falloutVersion);
+        prompts.ShowInput("gem_stone", "Fallout.Common version", falloutVersion);
 
-        var solutionFile = (AbsolutePath) _prompts.PromptForChoice(
+        var solutionFile = (AbsolutePath) prompts.PromptForChoice(
             "Which solution should be the default?",
             choices: new DirectoryInfo(rootDirectory)
                 .EnumerateFiles("*", SearchOption.AllDirectories)
@@ -94,7 +94,7 @@ internal sealed class SetupCommand : IFalloutCommand
                 .OrderByDescending(x => x.FullName)
                 .Select(x => (x, rootDirectory.GetRelativePathTo(x.FullName).ToString()))
                 .Concat((null, "None")).ToArray())?.FullName;
-        _prompts.ShowInput("toolbox", "Default solution", solutionFile != null ? rootDirectory.GetRelativePathTo(solutionFile) : "<none>");
+        prompts.ShowInput("toolbox", "Default solution", solutionFile != null ? rootDirectory.GetRelativePathTo(solutionFile) : "<none>");
 
         #endregion
 
@@ -106,11 +106,11 @@ internal sealed class SetupCommand : IFalloutCommand
 
         (rootDirectory / FalloutDirectoryName).CreateDirectory();
 
-        _scaffolder.WriteBuildScripts(
+        scaffolder.WriteBuildScripts(
             scriptDirectory: WorkingDirectory,
             rootDirectory);
 
-        _scaffolder.WriteConfigurationFile(rootDirectory, solutionFile);
+        scaffolder.WriteConfigurationFile(rootDirectory, solutionFile);
 
         if (solutionFile != null)
         {
@@ -118,7 +118,7 @@ internal sealed class SetupCommand : IFalloutCommand
             if (solutionFile.Extension.EqualsOrdinalIgnoreCase(".slnx"))
             {
                 var solutionDocument = XDocument.Load(solutionFile);
-                _scaffolder.UpdateSolutionXmlFileContent(solutionDocument, buildProjectFileRelative);
+                scaffolder.UpdateSolutionXmlFileContent(solutionDocument, buildProjectFileRelative);
 
                 var settings = new XmlWriterSettings { OmitXmlDeclaration = true, Indent = true };
                 using var writer = XmlWriter.Create(solutionFile, settings);
@@ -127,14 +127,14 @@ internal sealed class SetupCommand : IFalloutCommand
             else
             {
                 var solutionFileContent = solutionFile.ReadAllLines().ToList();
-                _scaffolder.UpdateSolutionFileContent(solutionFileContent, buildProjectFileRelative, buildProjectGuid, buildProjectName);
+                scaffolder.UpdateSolutionFileContent(solutionFileContent, buildProjectFileRelative, buildProjectGuid, buildProjectName);
                 solutionFile.WriteAllLines(solutionFileContent, Encoding.UTF8);
             }
         }
 
         buildProjectFile.WriteAllLines(
             FillTemplate(
-                _scaffolder.GetTemplate("_build.csproj"),
+                scaffolder.GetTemplate("_build.csproj"),
                 GetDictionary(
                     new
                     {
@@ -145,14 +145,14 @@ internal sealed class SetupCommand : IFalloutCommand
                         FalloutVersion = falloutVersion,
                     })));
 
-        (buildDirectory / "Directory.Build.props").WriteAllLines(_scaffolder.GetTemplate("Directory.Build.props"));
-        (buildDirectory / "Directory.Build.targets").WriteAllLines(_scaffolder.GetTemplate("Directory.Build.targets"));
-        (buildDirectory / "Build.cs").WriteAllLines(FillTemplate(_scaffolder.GetTemplate("Build.cs")));
-        (buildDirectory / "Configuration.cs").WriteAllLines(_scaffolder.GetTemplate("Configuration.cs"));
+        (buildDirectory / "Directory.Build.props").WriteAllLines(scaffolder.GetTemplate("Directory.Build.props"));
+        (buildDirectory / "Directory.Build.targets").WriteAllLines(scaffolder.GetTemplate("Directory.Build.targets"));
+        (buildDirectory / "Build.cs").WriteAllLines(FillTemplate(scaffolder.GetTemplate("Build.cs")));
+        (buildDirectory / "Configuration.cs").WriteAllLines(scaffolder.GetTemplate("Configuration.cs"));
 
         #endregion
 
-        _prompts.ShowCompletion("Setup");
+        prompts.ShowCompletion("Setup");
 
         return 0;
     }

--- a/src/Fallout.Cli/Commands/UpdateCommand.cs
+++ b/src/Fallout.Cli/Commands/UpdateCommand.cs
@@ -20,15 +20,15 @@ namespace Fallout.Cli.Commands;
 /// </summary>
 internal sealed class UpdateCommand : IFalloutCommand
 {
-    private readonly IConsolePrompts _prompts;
-    private readonly IConfigurationReader _configuration;
-    private readonly IBuildScaffolder _scaffolder;
+    private readonly IConsolePrompts prompts;
+    private readonly IConfigurationReader configuration;
+    private readonly IBuildScaffolder scaffolder;
 
     public UpdateCommand(IConsolePrompts prompts, IConfigurationReader configuration, IBuildScaffolder scaffolder)
     {
-        _prompts = prompts;
-        _configuration = configuration;
-        _scaffolder = scaffolder;
+        this.prompts = prompts;
+        this.configuration = configuration;
+        this.scaffolder = scaffolder;
     }
 
     public string Name => "update";
@@ -42,28 +42,28 @@ internal sealed class UpdateCommand : IFalloutCommand
 
         if (buildScript != null)
         {
-            _prompts.ConfirmExecution("Update build scripts", () => UpdateBuildScripts(rootDirectory, buildScript));
-            await _prompts.ConfirmExecutionAsync("Update build project", () => UpdateBuildProjectAsync(buildScript));
+            prompts.ConfirmExecution("Update build scripts", () => UpdateBuildScripts(rootDirectory, buildScript));
+            await prompts.ConfirmExecutionAsync("Update build project", () => UpdateBuildProjectAsync(buildScript));
         }
 
-        _prompts.ConfirmExecution("Update configuration file", () => UpdateConfigurationFile(rootDirectory));
-        _prompts.ConfirmExecution("Update global.json", () => UpdateGlobalJsonFile(rootDirectory));
+        prompts.ConfirmExecution("Update configuration file", () => UpdateConfigurationFile(rootDirectory));
+        prompts.ConfirmExecution("Update global.json", () => UpdateGlobalJsonFile(rootDirectory));
 
-        _prompts.ShowCompletion("Updates");
+        prompts.ShowCompletion("Updates");
 
         return 0;
     }
 
     private void UpdateBuildScripts(AbsolutePath rootDirectory, AbsolutePath buildScript)
     {
-        _scaffolder.WriteBuildScripts(
+        scaffolder.WriteBuildScripts(
             scriptDirectory: buildScript.Parent,
             rootDirectory);
     }
 
     private async Task UpdateBuildProjectAsync(AbsolutePath buildScript)
     {
-        var configuration = _configuration.Read(buildScript, evaluate: true);
+        var configuration = this.configuration.Read(buildScript, evaluate: true);
         var projectFile = configuration[ConfigurationReader.BuildProjectFileKey];
 
         ProjectModelTasks.Initialize();
@@ -135,7 +135,7 @@ internal sealed class UpdateCommand : IFalloutCommand
         var solutionFile = rootDirectory / configurationFile.ReadAllLines().FirstOrDefault(x => !x.IsNullOrEmpty());
         configurationFile.DeleteFile();
 
-        _scaffolder.WriteConfigurationFile(rootDirectory, solutionFile);
+        scaffolder.WriteConfigurationFile(rootDirectory, solutionFile);
         Host.Warning($"The previous {FalloutFileName} file was transformed to a {FalloutDirectoryName} directory.");
         Host.Warning($"The .tmp directory can be cleared, as it is moved to {FalloutDirectoryName}/temp as well.");
         if (solutionFile != null)

--- a/src/Fallout.Cli/Rewriting/Cake/ClassRewriter.cs
+++ b/src/Fallout.Cli/Rewriting/Cake/ClassRewriter.cs
@@ -52,15 +52,15 @@ internal class ClassRewriter : SafeSyntaxRewriter
             typeof(EnvironmentInfo),
         };
 
-    private string _defaultTargetFieldName;
-    private string _defaultTargetName;
+    private string defaultTargetFieldName;
+    private string defaultTargetName;
 
     public override SyntaxNode VisitCompilationUnit(CompilationUnitSyntax node)
     {
         node = (CompilationUnitSyntax) base.VisitCompilationUnit(node).NotNull();
 
         var defaultTargetField = node.Members.OfType<FieldDeclarationSyntax>()
-            .SingleOrDefault(x => x.GetSingleDeclarator().Identifier.Text == _defaultTargetFieldName);
+            .SingleOrDefault(x => x.GetSingleDeclarator().Identifier.Text == defaultTargetFieldName);
         if (defaultTargetField != null)
         {
             var literalExpression = defaultTargetField.GetSingleDeclarator().Initializer?.Value as LiteralExpressionSyntax;
@@ -68,9 +68,9 @@ internal class ClassRewriter : SafeSyntaxRewriter
             var mainMethodDeclaration = ParseMemberDeclaration($"public static int Main() => Execute<Build>(x => x.{defaultTarget});");
             node = node.WithMembers(List(new[] { mainMethodDeclaration }.Concat(node.Members.Except(new[] { defaultTargetField }))));
         }
-        else if (_defaultTargetName != null)
+        else if (defaultTargetName != null)
         {
-            var mainMethodDeclaration = ParseMemberDeclaration($"public static int Main() => Execute<Build>(x => x.{_defaultTargetName});");
+            var mainMethodDeclaration = ParseMemberDeclaration($"public static int Main() => Execute<Build>(x => x.{defaultTargetName});");
             node = node.WithMembers(List(new[] { mainMethodDeclaration }.Concat(node.Members)));
         }
 
@@ -117,9 +117,9 @@ internal class ClassRewriter : SafeSyntaxRewriter
         {
             var expression = invocationExpression.GetSingleArgument<ExpressionSyntax>();
             if (expression is IdentifierNameSyntax targetIdentifier)
-                _defaultTargetFieldName = targetIdentifier.Identifier.Text;
+                defaultTargetFieldName = targetIdentifier.Identifier.Text;
             if (expression is LiteralExpressionSyntax literalExpression)
-                _defaultTargetName = literalExpression.GetConstantValue<string>();
+                defaultTargetName = literalExpression.GetConstantValue<string>();
             return null;
         }
 

--- a/src/Fallout.Cli/Rewriting/Cake/RenameFieldIdentifierRewriter.cs
+++ b/src/Fallout.Cli/Rewriting/Cake/RenameFieldIdentifierRewriter.cs
@@ -10,7 +10,7 @@ namespace Fallout.Cli.Rewriting.Cake;
 
 internal class RenameFieldIdentifierRewriter : SafeSyntaxRewriter
 {
-    private readonly Dictionary<string, string> _renames = new();
+    private readonly Dictionary<string, string> renames = new();
 
     public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
     {
@@ -18,7 +18,7 @@ internal class RenameFieldIdentifierRewriter : SafeSyntaxRewriter
             return node;
 
         string CreateRename(string name)
-            => _renames[name] = name.Capitalize().ReplaceKnownWords();
+            => renames[name] = name.Capitalize().ReplaceKnownWords();
 
         var renamedVariables = node.Declaration.Variables
             .Select(x => x.WithIdentifier(Identifier(CreateRename(x.Identifier.Text))));
@@ -30,7 +30,7 @@ internal class RenameFieldIdentifierRewriter : SafeSyntaxRewriter
 
     public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
     {
-        return _renames.TryGetValue(node.Identifier.Text, out var rename)
+        return renames.TryGetValue(node.Identifier.Text, out var rename)
             ? IdentifierName(rename)
             : node;
     }

--- a/src/Fallout.Common/Attributes/FileSystemGlobbingAttributeBase.cs
+++ b/src/Fallout.Common/Attributes/FileSystemGlobbingAttributeBase.cs
@@ -29,15 +29,15 @@ public class DirectoryGlobbingAttribute : FileSystemGlobbingAttributeBase
 
 public abstract class FileSystemGlobbingAttributeBase : ParameterAttribute
 {
-    private readonly string[] _patterns;
-    private readonly Func<AbsolutePath, string[], IEnumerable<AbsolutePath>> _globber;
+    private readonly string[] patterns;
+    private readonly Func<AbsolutePath, string[], IEnumerable<AbsolutePath>> globber;
 
     protected FileSystemGlobbingAttributeBase(
         string[] patterns,
         Func<AbsolutePath, string[], IEnumerable<AbsolutePath>> globber)
     {
-        _patterns = patterns;
-        _globber = globber;
+        this.patterns = patterns;
+        this.globber = globber;
     }
 
     public override object GetValue(MemberInfo member, object instance)
@@ -54,7 +54,7 @@ public abstract class FileSystemGlobbingAttributeBase : ParameterAttribute
             parameterValue.ForEach(x =>
                 Assert.True(
                     globbedElements.Contains(x),
-                    $"Value '{x}' for member '{member.Name}' is not contained any pattern '{_patterns.JoinCommaSpace()}'"));
+                    $"Value '{x}' for member '{member.Name}' is not contained any pattern '{patterns.JoinCommaSpace()}'"));
             Assert.True(parameterValue.Length == 1 || memberType == typeof(AbsolutePath[]),
                 $"Member '{member.Name}' can only accept a single value but got:"
                     .Concat(parameterValue.Select(x => x.ToString()))
@@ -79,7 +79,7 @@ public abstract class FileSystemGlobbingAttributeBase : ParameterAttribute
 
     private AbsolutePath[] GetGlobbedElements(MemberInfo member)
     {
-        Assert.NotEmpty(_patterns, $"Member '{member.Name}' has no globbing patterns defined");
-        return _globber(Build.RootDirectory, _patterns).ToArray();
+        Assert.NotEmpty(patterns, $"Member '{member.Name}' has no globbing patterns defined");
+        return globber(Build.RootDirectory, patterns).ToArray();
     }
 }

--- a/src/Fallout.Common/Attributes/GlobbingOptionsAttribute.cs
+++ b/src/Fallout.Common/Attributes/GlobbingOptionsAttribute.cs
@@ -10,15 +10,15 @@ namespace Fallout.Common.IO;
 /// </summary>
 public class GlobbingOptionsAttribute : BuildExtensionAttributeBase, IOnBuildCreated
 {
-    private readonly GlobbingCaseSensitivity _caseSensitivity;
+    private readonly GlobbingCaseSensitivity caseSensitivity;
 
     public GlobbingOptionsAttribute(GlobbingCaseSensitivity caseSensitivity)
     {
-        _caseSensitivity = caseSensitivity;
+        this.caseSensitivity = caseSensitivity;
     }
 
     public void OnBuildCreated(IReadOnlyCollection<ExecutableTarget> executableTargets)
     {
-        Globbing.GlobbingCaseSensitivity = _caseSensitivity;
+        Globbing.GlobbingCaseSensitivity = caseSensitivity;
     }
 }

--- a/src/Fallout.Common/Attributes/LatestGitHubReleaseAttribute.cs
+++ b/src/Fallout.Common/Attributes/LatestGitHubReleaseAttribute.cs
@@ -12,11 +12,11 @@ namespace Fallout.Common.Tooling;
 
 public class LatestGitHubReleaseAttribute : ValueInjectionAttributeBase
 {
-    private readonly string _identifier;
+    private readonly string identifier;
 
     public LatestGitHubReleaseAttribute(string identifier)
     {
-        _identifier = identifier;
+        this.identifier = identifier;
     }
 
     public bool IncludePrerelease { get; set; }
@@ -26,7 +26,7 @@ public class LatestGitHubReleaseAttribute : ValueInjectionAttributeBase
 
     public override object GetValue(MemberInfo member, object instance)
     {
-        var repository = GitRepository.FromUrl($"https://github.com/{_identifier}");
+        var repository = GitRepository.FromUrl($"https://github.com/{identifier}");
         var releases = GitHubTasks.GitHubClient.Repository.Release
             .GetAll(repository.GetGitHubOwner(), repository.GetGitHubName()).GetAwaiter().GetResult();
         var versions = releases

--- a/src/Fallout.Common/Attributes/LatestMavenVersionAttribute.cs
+++ b/src/Fallout.Common/Attributes/LatestMavenVersionAttribute.cs
@@ -10,23 +10,23 @@ namespace Fallout.Common.Tooling;
 
 public class LatestMavenVersionAttribute : ValueInjectionAttributeBase
 {
-    private readonly string _repository;
-    private readonly string _groupId;
-    private readonly string _artifactId;
+    private readonly string repository;
+    private readonly string groupId;
+    private readonly string artifactId;
 
     public LatestMavenVersionAttribute(string repository, string groupId, string artifactId = null)
     {
-        _repository = repository;
-        _groupId = groupId;
-        _artifactId = artifactId;
+        this.repository = repository;
+        this.groupId = groupId;
+        this.artifactId = artifactId;
     }
 
     public bool IncludePrerelease { get; set; }
 
     public override object GetValue(MemberInfo member, object instance)
     {
-        var endpoint = _repository.TrimStart("https").TrimStart("http").TrimStart("://").TrimEnd("/");
-        var uri = $"https://{endpoint}/{_groupId.Replace(".", "/")}/{_artifactId ?? _groupId}/maven-metadata.xml";
+        var endpoint = repository.TrimStart("https").TrimStart("http").TrimStart("://").TrimEnd("/");
+        var uri = $"https://{endpoint}/{groupId.Replace(".", "/")}/{artifactId ?? groupId}/maven-metadata.xml";
         var content = HttpTasks.HttpDownloadString(uri);
         var versions = XmlTasks.XmlPeekFromString(content, ".//version").ToList();
         var version = versions

--- a/src/Fallout.Common/Attributes/LatestMyGetVersionAttribute.cs
+++ b/src/Fallout.Common/Attributes/LatestMyGetVersionAttribute.cs
@@ -9,21 +9,21 @@ namespace Fallout.Common.Tooling;
 
 public class LatestMyGetVersionAttribute : ValueInjectionAttributeBase
 {
-    private readonly string _feed;
-    private readonly string _package;
+    private readonly string feed;
+    private readonly string package;
 
     public LatestMyGetVersionAttribute(string feed, string package)
     {
-        _feed = feed;
-        _package = package;
+        this.feed = feed;
+        this.package = package;
     }
 
     public override object GetValue(MemberInfo member, object instance)
     {
-        var content = HttpTasks.HttpDownloadString($"https://www.myget.org/RSS/{_feed}");
+        var content = HttpTasks.HttpDownloadString($"https://www.myget.org/RSS/{feed}");
         return XmlTasks.XmlPeekFromString(content, ".//title")
             // TODO: regex?
-            .First(x => x.Contains($"/{_package} "))
+            .First(x => x.Contains($"/{package} "))
             .Split('(').Last()
             .Split(')').First()
             .TrimStart("version ");

--- a/src/Fallout.Common/Attributes/LatestNpmVersionAttribute.cs
+++ b/src/Fallout.Common/Attributes/LatestNpmVersionAttribute.cs
@@ -9,16 +9,16 @@ namespace Fallout.Common.Tooling;
 
 public class LatestNpmVersionAttribute : ValueInjectionAttributeBase
 {
-    private readonly string _packageId;
+    private readonly string packageId;
 
     public LatestNpmVersionAttribute(string packageId)
     {
-        _packageId = packageId;
+        this.packageId = packageId;
     }
 
     public override object GetValue(MemberInfo member, object instance)
     {
-        var version = NpmVersionResolver.GetLatestVersion(_packageId).GetAwaiter().GetResult();
+        var version = NpmVersionResolver.GetLatestVersion(packageId).GetAwaiter().GetResult();
         return member.GetMemberType() == typeof(string)
             ? version
             : SemanticVersion.Parse(version);

--- a/src/Fallout.Common/Attributes/LatestNuGetVersionAttribute.cs
+++ b/src/Fallout.Common/Attributes/LatestNuGetVersionAttribute.cs
@@ -9,11 +9,11 @@ namespace Fallout.Common.Tooling;
 
 public class LatestNuGetVersionAttribute : ValueInjectionAttributeBase
 {
-    private readonly string _packageId;
+    private readonly string packageId;
 
     public LatestNuGetVersionAttribute(string packageId)
     {
-        _packageId = packageId;
+        this.packageId = packageId;
     }
 
     public bool IncludePrerelease { get; set; }
@@ -21,7 +21,7 @@ public class LatestNuGetVersionAttribute : ValueInjectionAttributeBase
 
     public override object GetValue(MemberInfo member, object instance)
     {
-        var version = NuGetVersionResolver.GetLatestVersion(_packageId, IncludePrerelease, IncludeUnlisted).GetAwaiter().GetResult();
+        var version = NuGetVersionResolver.GetLatestVersion(packageId, IncludePrerelease, IncludeUnlisted).GetAwaiter().GetResult();
         return member.GetMemberType() == typeof(string)
             ? version
             : NuGetVersion.Parse(version);

--- a/src/Fallout.Common/Attributes/LocalPathAttribute.cs
+++ b/src/Fallout.Common/Attributes/LocalPathAttribute.cs
@@ -22,16 +22,16 @@ namespace Fallout.Common.Tooling;
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public class LocalPathAttribute : ToolInjectionAttributeBase
 {
-    private readonly string _absoluteOrRelativePath;
+    private readonly string absoluteOrRelativePath;
 
     public LocalPathAttribute(string absoluteOrRelativePath)
     {
-        _absoluteOrRelativePath = absoluteOrRelativePath;
+        this.absoluteOrRelativePath = absoluteOrRelativePath;
     }
 
     public LocalPathAttribute(string windowsPath, string unixPath)
     {
-        _absoluteOrRelativePath = EnvironmentInfo.IsWin ? windowsPath : unixPath;
+        absoluteOrRelativePath = EnvironmentInfo.IsWin ? windowsPath : unixPath;
     }
 
     public override ToolRequirement GetRequirement(MemberInfo member)
@@ -41,9 +41,9 @@ public class LocalPathAttribute : ToolInjectionAttributeBase
 
     public override object GetValue(MemberInfo member, object instance)
     {
-        var toolPath = PathConstruction.HasPathRoot(_absoluteOrRelativePath)
-            ? _absoluteOrRelativePath
-            : Path.Combine(Build.RootDirectory, _absoluteOrRelativePath);
+        var toolPath = PathConstruction.HasPathRoot(absoluteOrRelativePath)
+            ? absoluteOrRelativePath
+            : Path.Combine(Build.RootDirectory, absoluteOrRelativePath);
         return ToolResolver.GetTool(toolPath);
     }
 }

--- a/src/Fallout.Common/Attributes/NpmPackageAttribute.cs
+++ b/src/Fallout.Common/Attributes/NpmPackageAttribute.cs
@@ -6,25 +6,25 @@ namespace Fallout.Common.Tooling;
 
 public class NpmPackageAttribute : ToolInjectionAttributeBase
 {
-    private readonly string _packageId;
-    private readonly string _packageExecutable;
+    private readonly string packageId;
+    private readonly string packageExecutable;
 
     public NpmPackageAttribute(string packageId, string packageExecutable = null)
     {
-        _packageId = packageId;
-        _packageExecutable = packageExecutable;
+        this.packageId = packageId;
+        this.packageExecutable = packageExecutable;
     }
 
     public string Version { get; set; }
 
     public override ToolRequirement GetRequirement(MemberInfo member)
     {
-        return new NpmPackageRequirement(_packageId, Version);
+        return new NpmPackageRequirement(packageId, Version);
     }
 
     public override object GetValue(MemberInfo member, object instance)
     {
-        var name = _packageExecutable ?? member.Name.ToLowerInvariant();
+        var name = packageExecutable ?? member.Name.ToLowerInvariant();
         return ToolResolver.TryGetEnvironmentTool(name) ??
                ToolResolver.GetNpmTool(name);
     }

--- a/src/Fallout.Common/Attributes/NuGetPackageAttribute.cs
+++ b/src/Fallout.Common/Attributes/NuGetPackageAttribute.cs
@@ -27,8 +27,8 @@ namespace Fallout.Common.Tooling;
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public class NuGetPackageAttribute : ToolInjectionAttributeBase
 {
-    private readonly string _packageId;
-    private readonly string _packageExecutable;
+    private readonly string packageId;
+    private readonly string packageExecutable;
 
     public string Framework { get; set; }
 
@@ -41,18 +41,18 @@ public class NuGetPackageAttribute : ToolInjectionAttributeBase
 
     public NuGetPackageAttribute(string packageId, string packageExecutable32, string packageExecutable64)
     {
-        _packageId = packageId;
-        _packageExecutable = EnvironmentInfo.Is32Bit ? packageExecutable32 : packageExecutable64;
+        this.packageId = packageId;
+        packageExecutable = EnvironmentInfo.Is32Bit ? packageExecutable32 : packageExecutable64;
     }
 
     public override ToolRequirement GetRequirement(MemberInfo member)
     {
-        return new NuGetPackageRequirement(_packageId, Version);
+        return new NuGetPackageRequirement(packageId, Version);
     }
 
     public override object GetValue(MemberInfo member, object instance)
     {
         return ToolResolver.TryGetEnvironmentTool(member.Name) ??
-               ToolResolver.GetNuGetTool(_packageId, _packageExecutable, Version, Framework);
+               ToolResolver.GetNuGetTool(packageId, packageExecutable, Version, Framework);
     }
 }

--- a/src/Fallout.Common/Attributes/PathVariableAttribute.cs
+++ b/src/Fallout.Common/Attributes/PathVariableAttribute.cs
@@ -25,22 +25,22 @@ namespace Fallout.Common.Tooling;
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public class PathVariableAttribute : ToolInjectionAttributeBase
 {
-    private readonly string _pathExecutable;
+    private readonly string pathExecutable;
 
     public PathVariableAttribute(string pathExecutable = null)
     {
-        _pathExecutable = pathExecutable;
+        this.pathExecutable = pathExecutable;
     }
 
     public override ToolRequirement GetRequirement(MemberInfo member)
     {
-        var name = _pathExecutable ?? member.Name.ToLowerInvariant();
+        var name = pathExecutable ?? member.Name.ToLowerInvariant();
         return new PathToolRequirement(name);
     }
 
     public override object GetValue(MemberInfo member, object instance)
     {
-        var name = _pathExecutable ?? member.Name.ToLowerInvariant();
+        var name = pathExecutable ?? member.Name.ToLowerInvariant();
         return ToolResolver.TryGetEnvironmentTool(name) ??
                ToolResolver.GetPathTool(name);
     }

--- a/src/Fallout.Common/CI/AppVeyor/AppVeyor.cs
+++ b/src/Fallout.Common/CI/AppVeyor/AppVeyor.cs
@@ -34,8 +34,8 @@ public partial class AppVeyor : Host, IBuildServer
 
     internal static bool IsRunningAppVeyor => EnvironmentInfo.HasVariable("APPVEYOR");
 
-    private readonly Lazy<Tool> _cli = Lazy.Create(() => IsRunningAppVeyor ? ToolResolver.GetEnvironmentOrPathTool("appveyor") : null);
-    private int _messageCount;
+    private readonly Lazy<Tool> cli = Lazy.Create(() => IsRunningAppVeyor ? ToolResolver.GetEnvironmentOrPathTool("appveyor") : null);
+    private int messageCount;
 
     internal AppVeyor()
     {
@@ -44,7 +44,7 @@ public partial class AppVeyor : Host, IBuildServer
     string IBuildServer.Branch => RepositoryBranch;
     string IBuildServer.Commit => RepositoryCommitSha;
 
-    public Tool Cli => _cli.Value;
+    public Tool Cli => cli.Value;
 
     public string Url => EnvironmentInfo.GetVariable("APPVEYOR_URL");
     public string ApiUrl => EnvironmentInfo.GetVariable("APPVEYOR_API_URL");
@@ -112,7 +112,7 @@ public partial class AppVeyor : Host, IBuildServer
 
     private void WriteMessage(AppVeyorMessageCategory category, string message, string details)
     {
-        if (_messageCount == MessageLimit)
+        if (messageCount == MessageLimit)
         {
             Theme.WriteWarning(
                 $"AppVeyor has a default limit of {MessageLimit} messages. " +
@@ -120,7 +120,7 @@ public partial class AppVeyor : Host, IBuildServer
                 "contact https://appveyor.com/support to resolve this issue for your account.");
         }
 
-        _messageCount++;
+        messageCount++;
         Cli?.Invoke($"AddMessage {message.DoubleQuote()} -Category {category} -Details {details.DoubleQuote()}",
             logInvocation: false,
             logOutput: false);

--- a/src/Fallout.Common/CI/AppVeyor/AppVeyorAttribute.cs
+++ b/src/Fallout.Common/CI/AppVeyor/AppVeyorAttribute.cs
@@ -17,8 +17,8 @@ namespace Fallout.Common.CI.AppVeyor;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 public class AppVeyorAttribute : ConfigurationAttributeBase
 {
-    private readonly string _suffix;
-    private readonly AppVeyorImage[] _images;
+    private readonly string suffix;
+    private readonly AppVeyorImage[] images;
 
     public AppVeyorAttribute(
         AppVeyorImage image,
@@ -32,16 +32,16 @@ public class AppVeyorAttribute : ConfigurationAttributeBase
         AppVeyorImage image,
         params AppVeyorImage[] images)
     {
-        _suffix = suffix;
-        _images = new[] { image }.Concat(images).ToArray();
+        this.suffix = suffix;
+        this.images = new[] { image }.Concat(images).ToArray();
     }
 
-    public override string IdPostfix => _suffix;
+    public override string IdPostfix => suffix;
 
     public override Type HostType => typeof(AppVeyor);
     public override AbsolutePath ConfigurationFile => Build.RootDirectory / ConfigurationFileName;
     public override IEnumerable<AbsolutePath> GeneratedFiles => new[] { ConfigurationFile };
-    private string ConfigurationFileName => _suffix != null ? $"appveyor.{_suffix}.yml" : "appveyor.yml";
+    private string ConfigurationFileName => suffix != null ? $"appveyor.{suffix}.yml" : "appveyor.yml";
 
     public override IEnumerable<string> RelevantTargetNames => InvokedTargets;
     public override IEnumerable<string> IrrelevantTargetNames => new string[0];
@@ -70,7 +70,7 @@ public class AppVeyorAttribute : ConfigurationAttributeBase
     {
         return new AppVeyorConfiguration
                {
-                   Images = _images,
+                   Images = images,
                    BuildCmdPath = BuildCmdPath,
                    Services = Services,
                    Branches = GetBranches(),

--- a/src/Fallout.Common/CI/AzurePipelines/AzurePipelines.cs
+++ b/src/Fallout.Common/CI/AzurePipelines/AzurePipelines.cs
@@ -18,7 +18,7 @@ public partial class AzurePipelines : Host, IBuildServer
 
     internal static bool IsRunningAzurePipelines => EnvironmentInfo.HasVariable("TF_BUILD");
 
-    private readonly Action<string> _messageSink;
+    private readonly Action<string> messageSink;
 
     internal AzurePipelines()
         : this(messageSink: null)
@@ -27,7 +27,7 @@ public partial class AzurePipelines : Host, IBuildServer
 
     internal AzurePipelines(Action<string> messageSink)
     {
-        _messageSink = messageSink ?? Console.WriteLine;
+        this.messageSink = messageSink ?? Console.WriteLine;
     }
 
     string IBuildServer.Branch => SourceBranch;
@@ -89,12 +89,12 @@ public partial class AzurePipelines : Host, IBuildServer
 
     public void Group(string group)
     {
-        _messageSink($"##[group]{group}");
+        messageSink($"##[group]{group}");
     }
 
     public void EndGroup(string group)
     {
-        _messageSink($"##[endgroup]{group}");
+        messageSink($"##[endgroup]{group}");
     }
 
     public void UploadLog(string path)
@@ -237,7 +237,7 @@ public partial class AzurePipelines : Host, IBuildServer
 
     private void Write(string command, string[] escapedTokens, string message)
     {
-        _messageSink.Invoke($"##vso[{command} {escapedTokens.JoinSemicolon()}]{EscapeMessage(message)}");
+        messageSink.Invoke($"##vso[{command} {escapedTokens.JoinSemicolon()}]{EscapeMessage(message)}");
     }
 
     private string EscapeMessage(string data)

--- a/src/Fallout.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
+++ b/src/Fallout.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
@@ -15,15 +15,15 @@ namespace Fallout.Common.CI.AzurePipelines;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 public class AzurePipelinesAttribute : ChainedConfigurationAttributeBase
 {
-    private readonly string _suffix;
-    private readonly AzurePipelinesImage[] _images;
+    private readonly string suffix;
+    private readonly AzurePipelinesImage[] images;
 
-    private bool? _triggerBatch;
-    private bool? _pullRequestsAutoCancel;
-    private bool? _submodules;
-    private bool? _largeFileStorage;
-    private int? _fetchDepth;
-    private bool? _clean;
+    private bool? triggerBatch;
+    private bool? pullRequestsAutoCancel;
+    private bool? submodules;
+    private bool? largeFileStorage;
+    private int? fetchDepth;
+    private bool? clean;
 
     public AzurePipelinesAttribute(
         AzurePipelinesImage image,
@@ -37,17 +37,17 @@ public class AzurePipelinesAttribute : ChainedConfigurationAttributeBase
         AzurePipelinesImage image,
         params AzurePipelinesImage[] images)
     {
-        _suffix = suffix?.Replace(oldChar: ' ', newChar: '_');
-        _images = new[] { image }.Concat(images).ToArray();
+        this.suffix = suffix?.Replace(oldChar: ' ', newChar: '_');
+        this.images = new[] { image }.Concat(images).ToArray();
     }
 
-    public override string IdPostfix => _suffix;
+    public override string IdPostfix => suffix;
 
     public override Type HostType => typeof(AzurePipelines);
     public override AbsolutePath ConfigurationFile => ConfigurationDirectory / ConfigurationFileName;
     public override IEnumerable<AbsolutePath> GeneratedFiles => new[] { ConfigurationFile };
     protected virtual AbsolutePath ConfigurationDirectory => Build.RootDirectory;
-    private string ConfigurationFileName => _suffix != null ? $"azure-pipelines.{_suffix}.yml" : "azure-pipelines.yml";
+    private string ConfigurationFileName => suffix != null ? $"azure-pipelines.{suffix}.yml" : "azure-pipelines.yml";
 
     public override IEnumerable<string> RelevantTargetNames => InvokedTargets;
 
@@ -57,31 +57,31 @@ public class AzurePipelinesAttribute : ChainedConfigurationAttributeBase
 
     public bool Submodules
     {
-        set => _submodules = value;
+        set => submodules = value;
         get => throw new NotSupportedException();
     }
 
     public int FetchDepth
     {
-        set => _fetchDepth = value;
+        set => fetchDepth = value;
         get => throw new NotSupportedException();
     }
 
     public bool Clean
     {
-        set => _clean = value;
+        set => clean = value;
         get => throw new NotSupportedException();
     }
 
     public bool LargeFileStorage
     {
-        set => _largeFileStorage = value;
+        set => largeFileStorage = value;
         get => throw new NotSupportedException();
     }
 
     public bool TriggerBatch
     {
-        set => _triggerBatch = value;
+        set => triggerBatch = value;
         get => throw new NotSupportedException();
     }
 
@@ -96,7 +96,7 @@ public class AzurePipelinesAttribute : ChainedConfigurationAttributeBase
 
     public bool? PullRequestsAutoCancel
     {
-        set => _pullRequestsAutoCancel = value;
+        set => pullRequestsAutoCancel = value;
         get => throw new NotSupportedException();
     }
 
@@ -124,14 +124,14 @@ public class AzurePipelinesAttribute : ChainedConfigurationAttributeBase
                    VariableGroups = ImportVariableGroups,
                    VcsPushTrigger = GetVcsPushTrigger(),
                    VcsPullRequestTrigger = GetVcsPullRequestTrigger(),
-                   Stages = _images.Select(x => GetStage(x, relevantTargets)).ToArray()
+                   Stages = images.Select(x => GetStage(x, relevantTargets)).ToArray()
                };
     }
 
     protected AzurePipelinesVcsPushTrigger GetVcsPushTrigger()
     {
         if (!TriggerDisabled &&
-            _triggerBatch == null &&
+            triggerBatch == null &&
             TriggerBranchesInclude.Length == 0 &&
             TriggerBranchesExclude.Length == 0 &&
             TriggerTagsInclude.Length == 0 &&
@@ -143,7 +143,7 @@ public class AzurePipelinesAttribute : ChainedConfigurationAttributeBase
         return new AzurePipelinesVcsPushTrigger
                {
                    Disabled = TriggerDisabled,
-                   Batch = _triggerBatch,
+                   Batch = triggerBatch,
                    BranchesInclude = TriggerBranchesInclude,
                    BranchesExclude = TriggerBranchesExclude,
                    TagsInclude = TriggerTagsInclude,
@@ -156,7 +156,7 @@ public class AzurePipelinesAttribute : ChainedConfigurationAttributeBase
     protected AzurePipelinesVcsPushTrigger GetVcsPullRequestTrigger()
     {
         if (!PullRequestsDisabled &&
-            _pullRequestsAutoCancel == null &&
+            pullRequestsAutoCancel == null &&
             PullRequestsBranchesInclude.Length == 0 &&
             PullRequestsBranchesExclude.Length == 0 &&
             PullRequestsPathsInclude.Length == 0 &&
@@ -166,7 +166,7 @@ public class AzurePipelinesAttribute : ChainedConfigurationAttributeBase
         return new AzurePipelinesVcsPushTrigger
                {
                    Disabled = PullRequestsDisabled,
-                   AutoCancel = _pullRequestsAutoCancel,
+                   AutoCancel = pullRequestsAutoCancel,
                    BranchesInclude = PullRequestsBranchesInclude,
                    BranchesExclude = PullRequestsBranchesExclude,
                    TagsInclude = new string[0],
@@ -219,14 +219,14 @@ public class AzurePipelinesAttribute : ChainedConfigurationAttributeBase
         IReadOnlyCollection<ExecutableTarget> relevantTargets,
         AzurePipelinesImage image)
     {
-        if (_submodules.HasValue || _largeFileStorage.HasValue || _fetchDepth.HasValue || _clean.HasValue)
+        if (submodules.HasValue || largeFileStorage.HasValue || fetchDepth.HasValue || clean.HasValue)
         {
             yield return new AzurePipelineCheckoutStep
                          {
-                             InclueSubmodules = _submodules,
-                             IncludeLargeFileStorage = _largeFileStorage,
-                             FetchDepth = _fetchDepth,
-                             Clean = _clean
+                             InclueSubmodules = submodules,
+                             IncludeLargeFileStorage = largeFileStorage,
+                             FetchDepth = fetchDepth,
+                             Clean = clean
                          };
         }
 

--- a/src/Fallout.Common/CI/GitHubActions/Configuration/GitHubActionsStepPipeline.cs
+++ b/src/Fallout.Common/CI/GitHubActions/Configuration/GitHubActionsStepPipeline.cs
@@ -11,7 +11,7 @@ namespace Fallout.Common.CI.GitHubActions.Configuration;
 /// </summary>
 public class GitHubActionsStepPipeline
 {
-    private readonly Dictionary<GitHubActionsStepPosition, List<GitHubActionsCustomStep>> _inserts =
+    private readonly Dictionary<GitHubActionsStepPosition, List<GitHubActionsCustomStep>> inserts =
         new Dictionary<GitHubActionsStepPosition, List<GitHubActionsCustomStep>>();
 
     internal GitHubActionsStepPipeline(string workflowName, GitHubActionsImage image, IReadOnlyList<GitHubActionsStep> builtInSteps)
@@ -34,8 +34,8 @@ public class GitHubActionsStepPipeline
     public void Insert(GitHubActionsStepPosition position, GitHubActionsCustomStep step)
     {
         Assert.NotNull(step);
-        if (!_inserts.TryGetValue(position, out var list))
-            _inserts[position] = list = new List<GitHubActionsCustomStep>();
+        if (!inserts.TryGetValue(position, out var list))
+            inserts[position] = list = new List<GitHubActionsCustomStep>();
         list.Add(step);
     }
 
@@ -48,7 +48,7 @@ public class GitHubActionsStepPipeline
     }
 
     internal IReadOnlyList<GitHubActionsCustomStep> GetInserts(GitHubActionsStepPosition position)
-        => _inserts.TryGetValue(position, out var list) ? list : (IReadOnlyList<GitHubActionsCustomStep>)new GitHubActionsCustomStep[0];
+        => inserts.TryGetValue(position, out var list) ? list : (IReadOnlyList<GitHubActionsCustomStep>)new GitHubActionsCustomStep[0];
 
-    internal IEnumerable<GitHubActionsCustomStep> AllInserts => _inserts.Values.SelectMany(x => x);
+    internal IEnumerable<GitHubActionsCustomStep> AllInserts => inserts.Values.SelectMany(x => x);
 }

--- a/src/Fallout.Common/CI/GitHubActions/GitHubActions.Client.cs
+++ b/src/Fallout.Common/CI/GitHubActions/GitHubActions.Client.cs
@@ -11,7 +11,7 @@ public partial class GitHubActions
 {
     public async Task CreateComment(int issue, string text)
     {
-        await _httpClient.Value
+        await httpClient.Value
             .CreateRequest(HttpMethod.Post, $"repos/{Repository}/issues/{issue}/comments")
             .WithJsonContent(new { body = text })
             .GetResponseAsync();
@@ -19,7 +19,7 @@ public partial class GitHubActions
 
     private JsonObject GetJobDetails(long runId)
     {
-        var response = _httpClient.Value
+        var response = httpClient.Value
             .CreateRequest(HttpMethod.Get, $"repos/{Repository}/actions/runs/{runId}/jobs")
             .GetResponse()
             .AssertSuccessfulStatusCode();

--- a/src/Fallout.Common/CI/GitHubActions/GitHubActions.cs
+++ b/src/Fallout.Common/CI/GitHubActions/GitHubActions.cs
@@ -23,18 +23,18 @@ public partial class GitHubActions : Host, IBuildServer
 
     public new static GitHubActions Instance => Host.Instance as GitHubActions;
 
-    private readonly Lazy<JsonObject> _eventContext;
-    private readonly Lazy<HttpClient> _httpClient;
-    private readonly Lazy<long> _jobId;
+    private readonly Lazy<JsonObject> eventContext;
+    private readonly Lazy<HttpClient> httpClient;
+    private readonly Lazy<long> jobId;
 
     internal GitHubActions()
     {
-        _eventContext = Lazy.Create(() =>
+        eventContext = Lazy.Create(() =>
         {
             var content = File.ReadAllText(EventPath);
             return JsonNode.Parse(content)?.AsObject() ?? new JsonObject();
         });
-        _httpClient = Lazy.Create(() =>
+        httpClient = Lazy.Create(() =>
         {
             var base64Auth = Convert.ToBase64String(Encoding.ASCII.GetBytes($":{Token.NotNull()}"));
 
@@ -44,7 +44,7 @@ public partial class GitHubActions : Host, IBuildServer
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", base64Auth);
             return client;
         });
-        _jobId = Lazy.Create(GetJobId);
+        jobId = Lazy.Create(GetJobId);
     }
 
     string IBuildServer.Branch => Ref;
@@ -104,9 +104,9 @@ public partial class GitHubActions : Host, IBuildServer
     // https://github.com/actions/toolkit/tree/master/packages/core/src
 
     public string Token => EnvironmentInfo.GetVariable("GITHUB_TOKEN");
-    public long JobId => _jobId.Value;
+    public long JobId => jobId.Value;
 
-    public JsonObject GitHubEvent => _eventContext.Value;
+    public JsonObject GitHubEvent => eventContext.Value;
     public bool IsPullRequest => EventName == "pull_request";
     public int? PullRequestNumber => GitHubEvent["number"]?.GetValue<int>();
     public string PullRequestAction => GitHubEvent["action"]?.GetValue<string>();

--- a/src/Fallout.Common/CI/GitHubActions/GitHubActionsAttribute.cs
+++ b/src/Fallout.Common/CI/GitHubActions/GitHubActionsAttribute.cs
@@ -19,27 +19,27 @@ namespace Fallout.Common.CI.GitHubActions;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 public class GitHubActionsAttribute : ConfigurationAttributeBase
 {
-    private readonly string _name;
-    private readonly GitHubActionsImage[] _images;
-    private GitHubActionsSubmodules? _submodules;
-    private bool? _lfs;
-    private uint? _fetchDepth;
-    private bool? _progress;
-    private string _filter;
-    private string _ref;
+    private readonly string name;
+    private readonly GitHubActionsImage[] images;
+    private GitHubActionsSubmodules? submodules;
+    private bool? lfs;
+    private uint? fetchDepth;
+    private bool? progress;
+    private string filter;
+    private string reference;
 
     public GitHubActionsAttribute(
         string name,
         GitHubActionsImage image,
         params GitHubActionsImage[] images)
     {
-        _name = NormalizeWorkflowName(name);
-        _images = new[] { image }.Concat(images).ToArray();
+        this.name = NormalizeWorkflowName(name);
+        this.images = new[] { image }.Concat(images).ToArray();
     }
 
-    public override string IdPostfix => _name;
+    public override string IdPostfix => name;
     public override Type HostType => typeof(GitHubActions);
-    public override AbsolutePath ConfigurationFile => Build.RootDirectory / ".github" / "workflows" / $"{_name}.yml";
+    public override AbsolutePath ConfigurationFile => Build.RootDirectory / ".github" / "workflows" / $"{name}.yml";
     public override IEnumerable<AbsolutePath> GeneratedFiles => new[] { ConfigurationFile };
 
     public override IEnumerable<string> RelevantTargetNames => InvokedTargets;
@@ -122,31 +122,31 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
 
     public GitHubActionsSubmodules Submodules
     {
-        set => _submodules = value;
+        set => submodules = value;
         get => throw new NotSupportedException();
     }
 
     public bool Lfs
     {
-        set => _lfs = value;
+        set => lfs = value;
         get => throw new NotSupportedException();
     }
 
     public uint FetchDepth
     {
-        set => _fetchDepth = value;
+        set => fetchDepth = value;
         get => throw new NotSupportedException();
     }
 
     public bool Progress
     {
-        set => _progress = value;
+        set => progress = value;
         get => throw new NotSupportedException();
     }
 
     public string Filter
     {
-        set => _filter = value;
+        set => filter = value;
         get => throw new NotSupportedException();
     }
 
@@ -162,7 +162,7 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
     /// </summary>
     public string CheckoutRef
     {
-        set => _ref = value;
+        set => reference = value;
         get => throw new NotSupportedException();
     }
 
@@ -203,7 +203,7 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
 
         var configuration = new GitHubActionsConfiguration
                             {
-                                Name = _name,
+                                Name = name,
                                 ShortTriggers = On,
                                 DetailedTriggers = GetTriggers().ToArray(),
                                 Env = Env,
@@ -212,14 +212,14 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
                                 ConcurrencyGroup = ConcurrencyGroup,
                                 ConcurrencyCancelInProgress = ConcurrencyCancelInProgress,
                                 DefaultShell = DefaultShell,
-                                Jobs = _images.Select(x => GetJobs(x, relevantTargets)).ToArray()
+                                Jobs = images.Select(x => GetJobs(x, relevantTargets)).ToArray()
                             };
 
         Assert.True(configuration.ShortTriggers.Length == 0 || configuration.DetailedTriggers.Length == 0,
             $"Workflows can only define either shorthand '{nameof(On)}' or '{nameof(On)}*' triggers");
         Assert.True(configuration.ShortTriggers.Length > 0 || configuration.DetailedTriggers.Length > 0,
             $"Workflows must define either shorthand '{nameof(On)}' or '{nameof(On)}*' triggers");
-        Assert.True(RunsOnLabels.Length == 0 || _images.Length == 1,
+        Assert.True(RunsOnLabels.Length == 0 || images.Length == 1,
             $"Cannot use '{nameof(RunsOnLabels)}' with multiple images; labels resolve a single job's runner");
         Assert.True(RunsOnLabels.All(x => !x.IsNullOrWhiteSpace()),
             $"'{nameof(RunsOnLabels)}' entries must not be null, empty, or whitespace");
@@ -247,12 +247,12 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
     {
         var checkout = new GitHubActionsCheckoutStep
                        {
-                           Submodules = _submodules,
-                           Lfs = _lfs,
-                           FetchDepth = _fetchDepth,
-                           Progress = _progress,
-                           Filter = _filter,
-                           Ref = _ref,
+                           Submodules = submodules,
+                           Lfs = lfs,
+                           FetchDepth = fetchDepth,
+                           Progress = progress,
+                           Filter = filter,
+                           Ref = reference,
                            CheckoutWith = CheckoutWith
                        };
 
@@ -296,7 +296,7 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
         builtInSteps.Add(run);
         builtInSteps.AddRange(artifacts);
 
-        var pipeline = new GitHubActionsStepPipeline(_name, image, builtInSteps.AsReadOnly());
+        var pipeline = new GitHubActionsStepPipeline(name, image, builtInSteps.AsReadOnly());
         if (Build is IConfigureGitHubActions configure)
             configure.ConfigureSteps(pipeline);
         ValidateCustomSteps(pipeline);
@@ -322,11 +322,11 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
             var hasRun = step.Run is { } run && run.Any(x => !x.IsNullOrWhiteSpace());
 
             Assert.True(hasUses ^ hasRun,
-                $"Custom step '{id}' in workflow '{_name}' must set exactly one of '{nameof(GitHubActionsCustomStep.Uses)}' or '{nameof(GitHubActionsCustomStep.Run)}'");
+                $"Custom step '{id}' in workflow '{name}' must set exactly one of '{nameof(GitHubActionsCustomStep.Uses)}' or '{nameof(GitHubActionsCustomStep.Run)}'");
             Assert.True((step.With?.Count ?? 0) == 0 || hasUses,
-                $"Custom step '{id}' in workflow '{_name}' sets '{nameof(GitHubActionsCustomStep.With)}' but no '{nameof(GitHubActionsCustomStep.Uses)}'; 'with:' is only valid on a 'uses:' step");
+                $"Custom step '{id}' in workflow '{name}' sets '{nameof(GitHubActionsCustomStep.With)}' but no '{nameof(GitHubActionsCustomStep.Uses)}'; 'with:' is only valid on a 'uses:' step");
             Assert.True(step.Shell.IsNullOrWhiteSpace() || !hasUses,
-                $"Custom step '{id}' in workflow '{_name}' sets '{nameof(GitHubActionsCustomStep.Shell)}' on a 'uses:' step; shell applies only to run steps");
+                $"Custom step '{id}' in workflow '{name}' sets '{nameof(GitHubActionsCustomStep.Shell)}' on a 'uses:' step; shell applies only to run steps");
         }
     }
 
@@ -418,7 +418,7 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
 #pragma warning restore FALLOUTOBS001
 
         foreach (var input in DeclaredInputs.Where(x => x.Workflows.Length == 0 ||
-                     x.Workflows.Select(NormalizeWorkflowName).Contains(_name)))
+                     x.Workflows.Select(NormalizeWorkflowName).Contains(name)))
             yield return new GitHubActionsWorkflowDispatchInput
                          {
                              Name = input.Name,
@@ -464,10 +464,10 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
         var inputs = GetWorkflowDispatchInputs().ToList();
         foreach (var input in inputs)
             Assert.True(!input.Name.IsNullOrWhiteSpace(),
-                $"workflow_dispatch input names must be non-empty in workflow '{_name}'");
+                $"workflow_dispatch input names must be non-empty in workflow '{name}'");
 
         var names = inputs.Select(x => x.Name).ToList();
         Assert.True(names.Count == names.Distinct().Count(),
-            $"Duplicate workflow_dispatch input names in workflow '{_name}'");
+            $"Duplicate workflow_dispatch input names in workflow '{name}'");
     }
 }

--- a/src/Fallout.Common/CI/GitLab/GitLab.cs
+++ b/src/Fallout.Common/CI/GitLab/GitLab.cs
@@ -22,7 +22,7 @@ public partial class GitLab : Host, IBuildServer
 
     protected override string LogoDimmed => "[90m";
 
-    private readonly Action<string> _messageSink;
+    private readonly Action<string> messageSink;
 
     internal GitLab()
         : this(messageSink: null)
@@ -31,7 +31,7 @@ public partial class GitLab : Host, IBuildServer
 
     internal GitLab(Action<string> messageSink)
     {
-        _messageSink = messageSink ?? Console.WriteLine;
+        this.messageSink = messageSink ?? Console.WriteLine;
     }
 
     string IBuildServer.Branch => CommitRefName;
@@ -41,14 +41,14 @@ public partial class GitLab : Host, IBuildServer
     {
         var sectionId = GetSectionId(text);
         var unixTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-        _messageSink($"{SectionStartSequence}section_start:{unixTimestamp}:{sectionId}[collapsed={collapsed.ToString().ToLowerInvariant()}]{SectionResetSequence}{text}");
+        messageSink($"{SectionStartSequence}section_start:{unixTimestamp}:{sectionId}[collapsed={collapsed.ToString().ToLowerInvariant()}]{SectionResetSequence}{text}");
     }
 
     public void EndSection(string text)
     {
         var sectionId = GetSectionId(text);
         var unixTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-        _messageSink($"{SectionStartSequence}section_end:{unixTimestamp}:{sectionId}{SectionResetSequence}");
+        messageSink($"{SectionStartSequence}section_end:{unixTimestamp}:{sectionId}{SectionResetSequence}");
     }
 
     private string GetSectionId(string text)

--- a/src/Fallout.Common/CI/SpaceAutomation/SpaceAutomationAttribute.cs
+++ b/src/Fallout.Common/CI/SpaceAutomation/SpaceAutomationAttribute.cs
@@ -12,17 +12,17 @@ namespace Fallout.Common.CI.SpaceAutomation;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 public class SpaceAutomationAttribute : ConfigurationAttributeBase
 {
-    private readonly string _name;
-    private readonly string _image;
+    private readonly string name;
+    private readonly string image;
 
-    private bool _submodules;
-    private bool? _onPush;
-    private int? _timeoutInMinutes;
+    private bool submodules;
+    private bool? onPush;
+    private int? timeoutInMinutes;
 
     public SpaceAutomationAttribute(string name, string image)
     {
-        _name = name;
-        _image = image;
+        this.name = name;
+        this.image = image;
     }
 
     public override Type HostType => typeof(SpaceAutomation);
@@ -39,7 +39,7 @@ public class SpaceAutomationAttribute : ConfigurationAttributeBase
 
     public bool Submodules
     {
-        set => _submodules = value;
+        set => submodules = value;
         get => throw new NotSupportedException();
     }
 
@@ -47,7 +47,7 @@ public class SpaceAutomationAttribute : ConfigurationAttributeBase
 
     public bool OnPush
     {
-        set => _onPush = value;
+        set => onPush = value;
         get => throw new NotSupportedException();
     }
 
@@ -63,7 +63,7 @@ public class SpaceAutomationAttribute : ConfigurationAttributeBase
 
     public int TimeoutInMinutes
     {
-        set => _timeoutInMinutes = value;
+        set => timeoutInMinutes = value;
         get => throw new NotSupportedException();
     }
 
@@ -76,12 +76,12 @@ public class SpaceAutomationAttribute : ConfigurationAttributeBase
     {
         return new SpaceAutomationConfiguration
                {
-                   Name = _name,
+                   Name = name,
                    VolumeSize = VolumeSize,
                    RefSpec = RefSpec,
                    Container = GetContainer(),
                    Triggers = GetTriggers().ToArray(),
-                   TimeoutInMinutes = _timeoutInMinutes
+                   TimeoutInMinutes = timeoutInMinutes
                };
     }
 
@@ -89,10 +89,10 @@ public class SpaceAutomationAttribute : ConfigurationAttributeBase
     {
         return new SpaceAutomationContainer
                {
-                   Image = _image,
+                   Image = image,
                    Resources = GetResources(),
                    Imports = GetImports().ToDictionary(x => x.Key, x => x.Value),
-                   Submodules = _submodules,
+                   Submodules = submodules,
                    BuildScript = BuildCmdPath.Replace(".cmd", ".sh"),
                    InvokedTargets = InvokedTargets
                };
@@ -114,7 +114,7 @@ public class SpaceAutomationAttribute : ConfigurationAttributeBase
 
     protected virtual IEnumerable<SpaceAutomationTrigger> GetTriggers()
     {
-        if (_onPush != null ||
+        if (onPush != null ||
             OnPushBranchIncludes != null ||
             OnPushBranchExcludes != null ||
             OnPushBranchRegexIncludes != null ||
@@ -124,7 +124,7 @@ public class SpaceAutomationAttribute : ConfigurationAttributeBase
         {
             yield return new SpaceAutomationPushTrigger
                          {
-                             OnPush = _onPush,
+                             OnPush = onPush,
                              OnPushBranchIncludes = OnPushBranchIncludes,
                              OnPushBranchExcludes = OnPushBranchExcludes,
                              OnPushBranchRegexIncludes = OnPushBranchRegexIncludes,

--- a/src/Fallout.Common/CI/TeamCity/TeamCity.cs
+++ b/src/Fallout.Common/CI/TeamCity/TeamCity.cs
@@ -57,12 +57,12 @@ public partial class TeamCity : Host, IBuildServer
         }
     }
 
-    private readonly Action<string> _messageSink;
+    private readonly Action<string> messageSink;
 
-    private readonly Lazy<IReadOnlyDictionary<string, string>> _systemProperties;
-    private readonly Lazy<IReadOnlyDictionary<string, string>> _configurationProperties;
-    private readonly Lazy<IReadOnlyDictionary<string, string>> _runnerProperties;
-    private readonly Lazy<IReadOnlyCollection<string>> _recentlyFailedTests;
+    private readonly Lazy<IReadOnlyDictionary<string, string>> systemProperties;
+    private readonly Lazy<IReadOnlyDictionary<string, string>> configurationProperties;
+    private readonly Lazy<IReadOnlyDictionary<string, string>> runnerProperties;
+    private readonly Lazy<IReadOnlyCollection<string>> recentlyFailedTests;
 
     internal TeamCity()
         : this(messageSink: null)
@@ -71,12 +71,12 @@ public partial class TeamCity : Host, IBuildServer
 
     internal TeamCity(Action<string> messageSink)
     {
-        _messageSink = messageSink ?? Console.WriteLine;
+        this.messageSink = messageSink ?? Console.WriteLine;
 
-        _systemProperties = Lazy.Create(() => ParseDictionary(EnvironmentInfo.GetVariable("TEAMCITY_BUILD_PROPERTIES_FILE")));
-        _configurationProperties = Lazy.Create(() => ParseDictionary(SystemProperties?["teamcity.configuration.properties.file"]));
-        _runnerProperties = Lazy.Create(() => ParseDictionary(SystemProperties?["teamcity.runner.properties.file"]));
-        _recentlyFailedTests = Lazy.Create(() =>
+        systemProperties = Lazy.Create(() => ParseDictionary(EnvironmentInfo.GetVariable("TEAMCITY_BUILD_PROPERTIES_FILE")));
+        configurationProperties = Lazy.Create(() => ParseDictionary(SystemProperties?["teamcity.configuration.properties.file"]));
+        runnerProperties = Lazy.Create(() => ParseDictionary(SystemProperties?["teamcity.runner.properties.file"]));
+        recentlyFailedTests = Lazy.Create(() =>
         {
             var file = (AbsolutePath) SystemProperties?["teamcity.tests.recentlyFailedTests.file"];
             return file.FileExists()
@@ -88,10 +88,10 @@ public partial class TeamCity : Host, IBuildServer
     string IBuildServer.Branch => BranchName;
     string IBuildServer.Commit => BuildVcsNumber;
 
-    public IReadOnlyDictionary<string, string> ConfigurationProperties => _configurationProperties.Value;
-    public IReadOnlyDictionary<string, string> SystemProperties => _systemProperties.Value;
-    public IReadOnlyDictionary<string, string> RunnerProperties => _runnerProperties.Value;
-    public IReadOnlyCollection<string> RecentlyFailedTests => _recentlyFailedTests.Value;
+    public IReadOnlyDictionary<string, string> ConfigurationProperties => configurationProperties.Value;
+    public IReadOnlyDictionary<string, string> SystemProperties => systemProperties.Value;
+    public IReadOnlyDictionary<string, string> RunnerProperties => runnerProperties.Value;
+    public IReadOnlyCollection<string> RecentlyFailedTests => recentlyFailedTests.Value;
 
     public string BuildConfiguration => SystemProperties?["teamcity.buildConfName"];
     public string BuildTypeId => SystemProperties?["teamcity.buildType.id"];
@@ -292,7 +292,7 @@ public partial class TeamCity : Host, IBuildServer
 
     public void Write(string escapedMessage)
     {
-        _messageSink($"##teamcity[{escapedMessage}]");
+        messageSink($"##teamcity[{escapedMessage}]");
     }
 
     private string Escape(string str)

--- a/src/Fallout.Common/Gitter/GitterTasks.cs
+++ b/src/Fallout.Common/Gitter/GitterTasks.cs
@@ -15,7 +15,7 @@ namespace Fallout.Common.Gitter;
 
 public static class GitterTasks
 {
-    private static HttpClient s_client = new();
+    private static HttpClient client = new();
 
     public static void SendGitterMessage(string message, string roomId, string token)
     {
@@ -24,7 +24,7 @@ public static class GitterTasks
 
     public static async Task SendGitterMessageAsync(string message, string roomId, string token)
     {
-        var response = await s_client.CreateRequest(HttpMethod.Post, $"https://api.gitter.im/v1/rooms/{roomId}/chatMessages")
+        var response = await client.CreateRequest(HttpMethod.Post, $"https://api.gitter.im/v1/rooms/{roomId}/chatMessages")
             .WithBearerAuthentication(token)
             .GetResponseAsync();
 

--- a/src/Fallout.Common/Tools/AzureKeyVault/AzureKeyVault.cs
+++ b/src/Fallout.Common/Tools/AzureKeyVault/AzureKeyVault.cs
@@ -19,23 +19,23 @@ namespace Fallout.Common.Tools.AzureKeyVault
 
     public class AzureKeyVault
     {
-        private readonly Lazy<CertificateClient> _certificateClient;
-        private readonly Lazy<KeyClient> _keyClient;
-        private readonly Lazy<SecretClient> _secretClient;
+        private readonly Lazy<CertificateClient> certificateClient;
+        private readonly Lazy<KeyClient> keyClient;
+        private readonly Lazy<SecretClient> secretClient;
 
         internal AzureKeyVault(string tenantId, string clientId, string clientSecret, string baseUrl)
         {
             var credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
             var uri = new Uri(baseUrl);
 
-            _keyClient = new Lazy<KeyClient>(() => new KeyClient(uri, credential));
-            _secretClient = new Lazy<SecretClient>(() => new SecretClient(uri, credential));
-            _certificateClient = new Lazy<CertificateClient>(() => new CertificateClient(uri, credential));
+            keyClient = new Lazy<KeyClient>(() => new KeyClient(uri, credential));
+            secretClient = new Lazy<SecretClient>(() => new SecretClient(uri, credential));
+            certificateClient = new Lazy<CertificateClient>(() => new CertificateClient(uri, credential));
         }
 
-        public CertificateClient CertificateClient => _certificateClient.Value;
-        public KeyClient KeyClient => _keyClient.Value;
-        public SecretClient SecretClient => _secretClient.Value;
+        public CertificateClient CertificateClient => certificateClient.Value;
+        public KeyClient KeyClient => keyClient.Value;
+        public SecretClient SecretClient => secretClient.Value;
 
         public async Task<AzureKeyVaultKey> GetKey(string keyName, string secretName = null)
         {

--- a/src/Fallout.Common/Tools/AzureKeyVault/AzureKeyVaultCertificateAttribute.cs
+++ b/src/Fallout.Common/Tools/AzureKeyVault/AzureKeyVaultCertificateAttribute.cs
@@ -7,11 +7,11 @@ namespace Fallout.Common.Tools.AzureKeyVault
     /// <summary> Attribute to obtain a certificates from from the Azure KeyVault defined by <see cref="AzureKeyVaultConfigurationAttribute"/>.</summary>
     public class AzureKeyVaultCertificateAttribute : AzureKeyVaultAttributeBase
     {
-        private readonly string _certificateName;
+        private readonly string certificateName;
 
         public AzureKeyVaultCertificateAttribute(string certificateName = null)
         {
-            _certificateName = certificateName;
+            this.certificateName = certificateName;
         }
 
         /// <summary>If set to true, the key of the certificate is also obtained.</summary>
@@ -22,7 +22,7 @@ namespace Fallout.Common.Tools.AzureKeyVault
 
         protected override object GetValue(AzureKeyVaultConfiguration configuration, MemberInfo member)
         {
-            return AzureKeyVaultTasks.GetCertificateBundle(configuration, _certificateName, IncludeKey, IncludeSecret);
+            return AzureKeyVaultTasks.GetCertificateBundle(configuration, certificateName, IncludeKey, IncludeSecret);
         }
     }
 }

--- a/src/Fallout.Common/Tools/AzureKeyVault/AzureKeyVaultKeyAttribute.cs
+++ b/src/Fallout.Common/Tools/AzureKeyVault/AzureKeyVaultKeyAttribute.cs
@@ -7,16 +7,16 @@ namespace Fallout.Common.Tools.AzureKeyVault
     /// <summary>Attribute to obtain a key from from the Azure KeyVault defined by <see cref="AzureKeyVaultConfigurationAttribute"/>.</summary>
     public class AzureKeyVaultKeyAttribute : AzureKeyVaultAttributeBase
     {
-        private readonly string _keyName;
+        private readonly string keyName;
 
         public AzureKeyVaultKeyAttribute(string keyName = null)
         {
-            _keyName = keyName;
+            this.keyName = keyName;
         }
 
         protected override object GetValue(AzureKeyVaultConfiguration configuration, MemberInfo member)
         {
-            return AzureKeyVaultTasks.GetKeyBundle(configuration, _keyName ?? member.Name);
+            return AzureKeyVaultTasks.GetKeyBundle(configuration, keyName ?? member.Name);
         }
     }
 }

--- a/src/Fallout.Common/Tools/AzureKeyVault/AzureKeyVaultSecretAttribute.cs
+++ b/src/Fallout.Common/Tools/AzureKeyVault/AzureKeyVaultSecretAttribute.cs
@@ -7,17 +7,17 @@ namespace Fallout.Common.Tools.AzureKeyVault
     /// <summary>Attribute to obtain a secret from the Azure KeyVault defined by <see cref="AzureKeyVaultConfigurationAttribute"/>.</summary>
     public class AzureKeyVaultSecretAttribute : AzureKeyVaultAttributeBase
     {
-        private readonly string _secretName;
+        private readonly string secretName;
 
         public AzureKeyVaultSecretAttribute(string secretName = null)
         {
-            _secretName = secretName;
+            this.secretName = secretName;
         }
 
         protected override object GetValue(AzureKeyVaultConfiguration configuration, MemberInfo member)
         {
             return ParameterService.GetParameter<string>(member.Name) ??
-                   AzureKeyVaultTasks.GetSecret(configuration, _secretName ?? member.Name);
+                   AzureKeyVaultTasks.GetSecret(configuration, secretName ?? member.Name);
         }
     }
 }

--- a/src/Fallout.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
+++ b/src/Fallout.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
@@ -9,7 +9,7 @@ namespace Fallout.Common.Tools.MSBuild;
 
 public static class MSBuildToolPathResolver
 {
-    private static readonly MSBuildPlatform[] s_platforms = { MSBuildPlatform.x86, MSBuildPlatform.x64 };
+    private static readonly MSBuildPlatform[] platforms = { MSBuildPlatform.x86, MSBuildPlatform.x64 };
 
     public static string Resolve(MSBuildVersion? msBuildVersion = null, MSBuildPlatform? msBuildPlatform = null)
     {
@@ -36,14 +36,14 @@ public static class MSBuildToolPathResolver
 
         instances.AddRange(
             from version in new[] { MSBuildVersion.VS2026, MSBuildVersion.VS2022, MSBuildVersion.VS2019, MSBuildVersion.VS2017 }
-            from platform in s_platforms
+            from platform in platforms
             from edition in typeof(VisualStudioEdition).GetEnumValues<VisualStudioEdition>()
             let folder = GetProgramFilesFolder(version, edition)
             select GetFromVs2017Instance(version, platform, edition, folder));
 
         instances.AddRange(
             from version in new[] { MSBuildVersion.VS2015, MSBuildVersion.VS2013 }
-            from platform in s_platforms
+            from platform in platforms
             select GetVs2013To2015Instance(platform, version));
 
         var preferedPlatform = EnvironmentInfo.Is64Bit ? MSBuildPlatform.x64 : MSBuildPlatform.x86;

--- a/src/Fallout.Common/Tools/OctoVersion/OctoVersionAttribute.cs
+++ b/src/Fallout.Common/Tools/OctoVersion/OctoVersionAttribute.cs
@@ -17,10 +17,10 @@ namespace Fallout.Common.Tools.OctoVersion;
 /// </summary>
 public class OctoVersionAttribute : ValueInjectionAttributeBase
 {
-    private bool? _autoDetectBranch;
-    private int? _major;
-    private int? _minor;
-    private int? _patch;
+    private bool? autoDetectBranch;
+    private int? major;
+    private int? minor;
+    private int? patch;
 
     /// <summary>
     /// Framework to use when selecting the OctoVersion library from the package.
@@ -39,7 +39,7 @@ public class OctoVersionAttribute : ValueInjectionAttributeBase
     public bool AutoDetectBranch
     {
         get => throw new NotSupportedException();
-        set => _autoDetectBranch = value;
+        set => autoDetectBranch = value;
     }
 
     /// <summary>
@@ -76,7 +76,7 @@ public class OctoVersionAttribute : ValueInjectionAttributeBase
     public int Major
     {
         get => throw new NotSupportedException();
-        set => _major = value;
+        set => major = value;
     }
 
     /// <summary>
@@ -91,7 +91,7 @@ public class OctoVersionAttribute : ValueInjectionAttributeBase
     public int Minor
     {
         get => throw new NotSupportedException();
-        set => _minor = value;
+        set => minor = value;
     }
 
     /// <summary>
@@ -106,7 +106,7 @@ public class OctoVersionAttribute : ValueInjectionAttributeBase
     public int Patch
     {
         get => throw new NotSupportedException();
-        set => _patch = value;
+        set => patch = value;
     }
 
     /// <summary>
@@ -117,12 +117,12 @@ public class OctoVersionAttribute : ValueInjectionAttributeBase
 
     public override object GetValue(MemberInfo member, object instance)
     {
-        var autoDetectBranch = GetMemberValueOrNull<bool?>(AutoDetectBranchMember, instance) ?? _autoDetectBranch;
+        var autoDetectBranch = GetMemberValueOrNull<bool?>(AutoDetectBranchMember, instance) ?? this.autoDetectBranch;
         var branch = GetMemberValueOrNull<string>(BranchMember, instance) ?? Branch;
         var fullSemVer = GetMemberValueOrNull<string>(FullSemVerMember, instance) ?? FullSemVer;
-        var majorVersion = GetMemberValueOrNull<int?>(MajorMember, instance) ?? _major;
-        var minorVersion = GetMemberValueOrNull<int?>(MinorMember, instance) ?? _minor;
-        var patchVersion = GetMemberValueOrNull<int?>(PatchMember, instance) ?? _patch;
+        var majorVersion = GetMemberValueOrNull<int?>(MajorMember, instance) ?? major;
+        var minorVersion = GetMemberValueOrNull<int?>(MinorMember, instance) ?? minor;
+        var patchVersion = GetMemberValueOrNull<int?>(PatchMember, instance) ?? patch;
 
         Assert.False(autoDetectBranch.HasValue && autoDetectBranch.Value && !branch.IsNullOrEmpty(),
             $"Branch cannot be specified via {nameof(Branch)} or {nameof(BranchMember)} properties when {nameof(AutoDetectBranch)} is enabled");

--- a/src/Fallout.Common/Tools/Slack/SlackTasks.cs
+++ b/src/Fallout.Common/Tools/Slack/SlackTasks.cs
@@ -14,7 +14,7 @@ namespace Fallout.Common.Tools.Slack;
 
 public static class SlackTasks
 {
-    private static HttpClient s_client = new();
+    private static HttpClient client = new();
 
     public static void SendSlackMessage(Configure<SlackMessage> configurator, string webhook)
     {
@@ -26,7 +26,7 @@ public static class SlackTasks
         var message = configurator(new SlackMessage());
         var payload = JsonSerializer.Serialize(message);
 
-        var response = await s_client.CreateRequest(HttpMethod.Post, webhook)
+        var response = await client.CreateRequest(HttpMethod.Post, webhook)
             .WithFormUrlEncodedContent(new Dictionary<string, string> { ["payload"] = payload })
             .GetResponseAsync();
 
@@ -38,7 +38,7 @@ public static class SlackTasks
     {
         var message = configurator(new SlackMessage());
 
-        var response = await s_client.CreateRequest(
+        var response = await client.CreateRequest(
                 HttpMethod.Post,
                 message.Timestamp == null
                     ? "https://slack.com/api/chat.postMessage"

--- a/src/Fallout.Common/Tools/Unity/Logging/FileWatcher.cs
+++ b/src/Fallout.Common/Tools/Unity/Logging/FileWatcher.cs
@@ -8,48 +8,48 @@ namespace Fallout.Common.Tools.Unity.Logging;
 
 internal class FileWatcher
 {
-    private readonly string _file;
-    private readonly Action<string> _processLineAction;
-    private AutoResetEvent _logResetEvent;
-    private FileSystemWatcher _fileSystemWatcher;
-    private Thread _logReaderThread;
-    private CancellationTokenSource _cancellationTokenSource;
-    private readonly Encoding _encoding;
+    private readonly string file;
+    private readonly Action<string> processLineAction;
+    private AutoResetEvent logResetEvent;
+    private FileSystemWatcher fileSystemWatcher;
+    private Thread logReaderThread;
+    private CancellationTokenSource cancellationTokenSource;
+    private readonly Encoding encoding;
 
     public FileWatcher(string file, Action<string> processLineAction, Encoding encoding = null)
     {
-        _encoding = encoding ?? Encoding.UTF8;
-        _file = file;
-        _processLineAction = processLineAction;
+        this.encoding = encoding ?? Encoding.UTF8;
+        this.file = file;
+        this.processLineAction = processLineAction;
     }
 
     public void Start()
     {
-        _logResetEvent = new AutoResetEvent(initialState: false);
-        _fileSystemWatcher = new FileSystemWatcher(Path.GetPathRoot(_file).NotNull())
+        logResetEvent = new AutoResetEvent(initialState: false);
+        fileSystemWatcher = new FileSystemWatcher(Path.GetPathRoot(file).NotNull())
                              {
-                                 Filter = Path.GetFileName(_file),
+                                 Filter = Path.GetFileName(file),
                                  EnableRaisingEvents = true,
                                  NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite
                              };
 
-        _fileSystemWatcher.Changed += (_, _) => _logResetEvent.Set();
+        fileSystemWatcher.Changed += (_, _) => logResetEvent.Set();
 
-        _cancellationTokenSource = new CancellationTokenSource();
-        _logReaderThread = new Thread(ReadLogFile);
-        _logReaderThread.Start();
+        cancellationTokenSource = new CancellationTokenSource();
+        logReaderThread = new Thread(ReadLogFile);
+        logReaderThread.Start();
     }
 
     public void AssertStopped()
     {
-        _fileSystemWatcher.EnableRaisingEvents = false;
-        _fileSystemWatcher.Dispose();
-        _fileSystemWatcher = null;
-        _cancellationTokenSource.Cancel();
-        while (_logReaderThread != null)
+        fileSystemWatcher.EnableRaisingEvents = false;
+        fileSystemWatcher.Dispose();
+        fileSystemWatcher = null;
+        cancellationTokenSource.Cancel();
+        while (logReaderThread != null)
         {
-            if (!_logReaderThread.IsAlive)
-                _logReaderThread = null;
+            if (!logReaderThread.IsAlive)
+                logReaderThread = null;
             else
                 Thread.Sleep(millisecondsTimeout: 100);
         }
@@ -58,15 +58,15 @@ internal class FileWatcher
     // ReSharper disable once CognitiveComplexity
     private void ReadLogFile()
     {
-        while (!File.Exists(_file))
+        while (!File.Exists(file))
         {
-            if (_cancellationTokenSource.IsCancellationRequested)
+            if (cancellationTokenSource.IsCancellationRequested)
                 return;
-            _logResetEvent.WaitOne(millisecondsTimeout: 100);
+            logResetEvent.WaitOne(millisecondsTimeout: 100);
         }
 
-        using var stream = new FileStream(_file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        using var reader = new BinaryReader(stream, _encoding);
+        using var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new BinaryReader(stream, encoding);
 
         var currentLine = "";
         while (true)
@@ -77,16 +77,16 @@ internal class FileWatcher
 
                 if (currentChar == '\n')
                 {
-                    _processLineAction?.Invoke(currentLine);
+                    processLineAction?.Invoke(currentLine);
                     currentLine = "";
                 }
                 else
                     currentLine += currentChar;
             }
 
-            if (_cancellationTokenSource.IsCancellationRequested)
+            if (cancellationTokenSource.IsCancellationRequested)
                 break;
-            _logResetEvent.WaitOne(millisecondsTimeout: 100);
+            logResetEvent.WaitOne(millisecondsTimeout: 100);
         }
     }
 }

--- a/src/Fallout.Common/Tools/Unity/Logging/LogParser.cs
+++ b/src/Fallout.Common/Tools/Unity/Logging/LogParser.cs
@@ -6,12 +6,12 @@ namespace Fallout.Common.Tools.Unity.Logging;
 
 internal class LogParser
 {
-    private readonly Stack<MatchedBlock> _blockStack;
-    private readonly Action<string, LogLevel> _logLineAction;
-    private readonly Action<MatchedBlock> _logBlockStartAction;
-    private readonly Action<MatchedBlock> _logBlockEndAction;
+    private readonly Stack<MatchedBlock> blockStack;
+    private readonly Action<string, LogLevel> logLineAction;
+    private readonly Action<MatchedBlock> logBlockStartAction;
+    private readonly Action<MatchedBlock> logBlockEndAction;
 
-    private readonly IReadOnlyList<BlockMatcher> _blockMatchers =
+    private readonly IReadOnlyList<BlockMatcher> blockMatchers =
         new[]
         {
             new BlockMatcher("Player statistics", "\\*\\*\\*Player size statistics\\*\\*\\*", "Unloading.*", endMatchType: MatchType.Exclusive),
@@ -21,7 +21,7 @@ internal class LogParser
             new BlockMatcher("Prepare Build", "---- PrepareBuild Start ----", "---- PrepareBuild End ----")
         };
 
-    private readonly IReadOnlyList<LineMatcher> _lineMatchers =
+    private readonly IReadOnlyList<LineMatcher> lineMatchers =
         new[]
         {
             // Warnings
@@ -43,18 +43,18 @@ internal class LogParser
         Action<MatchedBlock> logBlockStartAction,
         Action<MatchedBlock> logBlockEndAction)
     {
-        _logLineAction = logLineAction ?? throw new ArgumentNullException(nameof(logLineAction));
-        _logBlockStartAction = logBlockStartAction ?? throw new ArgumentNullException(nameof(logBlockStartAction));
-        _logBlockEndAction = logBlockEndAction ?? throw new ArgumentNullException(nameof(logBlockEndAction));
+        this.logLineAction = logLineAction ?? throw new ArgumentNullException(nameof(logLineAction));
+        this.logBlockStartAction = logBlockStartAction ?? throw new ArgumentNullException(nameof(logBlockStartAction));
+        this.logBlockEndAction = logBlockEndAction ?? throw new ArgumentNullException(nameof(logBlockEndAction));
 
-        _blockStack = new Stack<MatchedBlock>();
+        blockStack = new Stack<MatchedBlock>();
     }
 
     public void Log(string message)
     {
-        if (_blockStack.Count != 0)
+        if (blockStack.Count != 0)
         {
-            var match = _blockStack.Peek().MatchesEnd(message);
+            var match = blockStack.Peek().MatchesEnd(message);
             switch (match)
             {
                 case MatchType.Inclusive:
@@ -67,7 +67,7 @@ internal class LogParser
             }
         }
 
-        var block = _blockMatchers.Select(x => x.MatchesBeginning(message)).FirstOrDefault(x => x != null);
+        var block = blockMatchers.Select(x => x.MatchesBeginning(message)).FirstOrDefault(x => x != null);
 
         if (block != null)
         {
@@ -88,25 +88,25 @@ internal class LogParser
 
     private void LogBlockStart(MatchedBlock block)
     {
-        _blockStack.Push(block);
-        _logBlockStartAction(block);
+        blockStack.Push(block);
+        logBlockStartAction(block);
     }
 
     private void LogLine(string message)
     {
-        var line = _lineMatchers.FirstOrDefault(x => x.Matches(message));
+        var line = lineMatchers.FirstOrDefault(x => x.Matches(message));
         Log(message, line?.LogLevel ?? LogLevel.Normal);
     }
 
     private void LogBlockEnd()
     {
-        var block = _blockStack.Pop();
-        _logBlockEndAction(block);
+        var block = blockStack.Pop();
+        logBlockEndAction(block);
     }
 
     private void Log(string message, LogLevel logLevel)
     {
         message = message.TrimEnd('\r', '\n');
-        _logLineAction(message, logLevel);
+        logLineAction(message, logLevel);
     }
 }

--- a/src/Fallout.Common/Tools/Unity/UnityTasks.cs
+++ b/src/Fallout.Common/Tools/Unity/UnityTasks.cs
@@ -16,12 +16,12 @@ namespace Fallout.Common.Tools.Unity;
 partial class UnityTasks
 {
     [ThreadStatic]
-    private static FileWatcher s_watcher;
+    private static FileWatcher watcher;
 
     [ThreadStatic]
-    private static LogParser s_logParser;
+    private static LogParser logParser;
 
-    private static bool s_minimalOutput;
+    private static bool minimalOutput;
 
     protected override string GetToolPath(ToolOptions options = null)
     {
@@ -62,10 +62,10 @@ partial class UnityTasks
         var logFile = (AbsolutePath)unityOptions.LogFile ?? FalloutBuild.TemporaryDirectory / "unity.log";
         logFile.DeleteFile();
 
-        s_minimalOutput = unityOptions.MinimalOutput ?? false;
-        s_logParser = new LogParser(LogLine, LogBlockStart, LogBlockEnd);
-        s_watcher = new FileWatcher(logFile, s_logParser.Log);
-        s_watcher.Start();
+        minimalOutput = unityOptions.MinimalOutput ?? false;
+        logParser = new LogParser(LogLine, LogBlockStart, LogBlockEnd);
+        watcher = new FileWatcher(logFile, logParser.Log);
+        watcher.Start();
 
         return options;
     }
@@ -108,8 +108,8 @@ partial class UnityTasks
 
     private static void AssertWatcherStopped()
     {
-        s_watcher?.AssertStopped();
-        s_watcher = null;
+        watcher?.AssertStopped();
+        watcher = null;
     }
 
     private static void LogLine(string message, Logging.LogLevel logLevel)

--- a/src/Fallout.Core/Planning/Graph/StronglyConnectedComponent.cs
+++ b/src/Fallout.Core/Planning/Graph/StronglyConnectedComponent.cs
@@ -5,29 +5,29 @@ namespace Fallout.Core.Planning;
 
 internal class StronglyConnectedComponent<T> : IEnumerable<Vertex<T>>
 {
-    private readonly LinkedList<Vertex<T>> _list;
+    private readonly LinkedList<Vertex<T>> list;
 
     public StronglyConnectedComponent()
     {
-        _list = new LinkedList<Vertex<T>>();
+        list = new LinkedList<Vertex<T>>();
     }
 
     public void Add(Vertex<T> vertex)
     {
-        _list.AddLast(vertex);
+        list.AddLast(vertex);
     }
 
-    public int Count => _list.Count;
+    public int Count => list.Count;
 
-    public bool IsCycle => _list.Count > 1;
+    public bool IsCycle => list.Count > 1;
 
     public IEnumerator<Vertex<T>> GetEnumerator()
     {
-        return _list.GetEnumerator();
+        return list.GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return _list.GetEnumerator();
+        return list.GetEnumerator();
     }
 }

--- a/src/Fallout.Core/Planning/Graph/StronglyConnectedComponentFinder.cs
+++ b/src/Fallout.Core/Planning/Graph/StronglyConnectedComponentFinder.cs
@@ -5,9 +5,9 @@ namespace Fallout.Core.Planning;
 
 internal class StronglyConnectedComponentFinder<T>
 {
-    private StronglyConnectedComponentList<T> _stronglyConnectedComponents;
-    private Stack<Vertex<T>> _stack;
-    private int _index;
+    private StronglyConnectedComponentList<T> stronglyConnectedComponents;
+    private Stack<Vertex<T>> stack;
+    private int index;
 
     /// <summary>
     /// Calculates the sets of strongly connected vertices.
@@ -16,24 +16,24 @@ internal class StronglyConnectedComponentFinder<T>
     /// <returns>Set of strongly connected components (sets of vertices)</returns>
     public StronglyConnectedComponentList<T> DetectCycle(IEnumerable<Vertex<T>> graph)
     {
-        _stronglyConnectedComponents = new StronglyConnectedComponentList<T>();
-        _index = 0;
-        _stack = new Stack<Vertex<T>>();
+        stronglyConnectedComponents = new StronglyConnectedComponentList<T>();
+        index = 0;
+        stack = new Stack<Vertex<T>>();
         foreach (var v in graph)
         {
             if (v.Index < 0)
                 StrongConnect(v);
         }
 
-        return _stronglyConnectedComponents;
+        return stronglyConnectedComponents;
     }
 
     private void StrongConnect(Vertex<T> v)
     {
-        v.Index = _index;
-        v.LowLink = _index;
-        _index++;
-        _stack.Push(v);
+        v.Index = index;
+        v.LowLink = index;
+        index++;
+        stack.Push(v);
 
         foreach (var w1 in v.Dependencies)
         {
@@ -42,7 +42,7 @@ internal class StronglyConnectedComponentFinder<T>
                 StrongConnect(w1);
                 v.LowLink = Math.Min(v.LowLink, w1.LowLink);
             }
-            else if (_stack.Contains(w1))
+            else if (stack.Contains(w1))
             {
                 v.LowLink = Math.Min(v.LowLink, w1.Index);
             }
@@ -55,10 +55,10 @@ internal class StronglyConnectedComponentFinder<T>
         Vertex<T> w2;
         do
         {
-            w2 = _stack.Pop();
+            w2 = stack.Pop();
             scc.Add(w2);
         } while (v != w2);
 
-        _stronglyConnectedComponents.Add(scc);
+        stronglyConnectedComponents.Add(scc);
     }
 }

--- a/src/Fallout.Core/Planning/Graph/StronglyConnectedComponentList.cs
+++ b/src/Fallout.Core/Planning/Graph/StronglyConnectedComponentList.cs
@@ -6,28 +6,28 @@ namespace Fallout.Core.Planning;
 
 internal class StronglyConnectedComponentList<T> : IEnumerable<StronglyConnectedComponent<T>>
 {
-    private readonly LinkedList<StronglyConnectedComponent<T>> _collection;
+    private readonly LinkedList<StronglyConnectedComponent<T>> collection;
 
     public StronglyConnectedComponentList()
     {
-        _collection = new LinkedList<StronglyConnectedComponent<T>>();
+        collection = new LinkedList<StronglyConnectedComponent<T>>();
     }
 
     public void Add(StronglyConnectedComponent<T> scc)
     {
-        _collection.AddLast(scc);
+        collection.AddLast(scc);
     }
 
-    public int Count => _collection.Count;
+    public int Count => collection.Count;
 
     public IEnumerator<StronglyConnectedComponent<T>> GetEnumerator()
     {
-        return _collection.GetEnumerator();
+        return collection.GetEnumerator();
     }
 
     IEnumerator IEnumerable.GetEnumerator()
     {
-        return _collection.GetEnumerator();
+        return collection.GetEnumerator();
     }
 
     public IEnumerable<StronglyConnectedComponent<T>> IndependentComponents()

--- a/src/Fallout.Tooling.Generator/Generators/StringExtensions.cs
+++ b/src/Fallout.Tooling.Generator/Generators/StringExtensions.cs
@@ -9,7 +9,7 @@ namespace Fallout.CodeGeneration.Generators;
 
 public static class StringExtensions
 {
-    private static readonly string[] s_reservedWords =
+    private static readonly string[] reservedWords =
     {
         "abstract",
         "as",
@@ -99,12 +99,12 @@ public static class StringExtensions
 
     public static string EscapeParameter(this string parameterName)
     {
-        return s_reservedWords.Contains(parameterName) ? "@" + parameterName : parameterName;
+        return reservedWords.Contains(parameterName) ? "@" + parameterName : parameterName;
     }
 
     public static string EscapeProperty(this string propertyName)
     {
-        return s_reservedWords.Contains(propertyName) ? propertyName + "_" : propertyName;
+        return reservedWords.Contains(propertyName) ? propertyName + "_" : propertyName;
     }
 
     public static string Paragraph(this string text)

--- a/src/Fallout.Tooling.Generator/Model/Property.cs
+++ b/src/Fallout.Tooling.Generator/Model/Property.cs
@@ -10,13 +10,13 @@ namespace Fallout.CodeGeneration.Model;
 [Serializable]
 public class Property : IDeprecatable
 {
-    [NonSerialized] private DataClass _dataClass;
+    [NonSerialized] private DataClass dataClass;
 
     [JsonIgnore]
     public DataClass DataClass
     {
-        get => _dataClass;
-        set => _dataClass = value;
+        get => dataClass;
+        set => dataClass = value;
     }
 
     [JsonIgnore]

--- a/src/Fallout.Tooling.Generator/ReferenceUpdater.cs
+++ b/src/Fallout.Tooling.Generator/ReferenceUpdater.cs
@@ -15,7 +15,7 @@ namespace Fallout.CodeGeneration;
 
 public static class ReferenceUpdater
 {
-    private static HttpClient s_client = new();
+    private static HttpClient client = new();
 
     public static void UpdateReferences(string specificationsDirectory, string referencesDirectory = null)
     {
@@ -56,7 +56,7 @@ public static class ReferenceUpdater
         var referenceValues = reference.Split('#');
         var tempFile = Path.GetTempFileName();
 
-        var response = await s_client.CreateRequest(HttpMethod.Get, referenceValues[0])
+        var response = await client.CreateRequest(HttpMethod.Get, referenceValues[0])
             .GetResponseAsync();
         await response.WriteToFile(tempFile);
 

--- a/src/Fallout.Tooling.Generator/ToolSerializer.cs
+++ b/src/Fallout.Tooling.Generator/ToolSerializer.cs
@@ -16,13 +16,13 @@ namespace Fallout.CodeGeneration;
 
 public static class ToolSerializer
 {
-    private static readonly JsonSerializerOptions s_readOptions = new()
+    private static readonly JsonSerializerOptions readOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         PropertyNameCaseInsensitive = true,
     };
 
-    private static readonly JsonSerializerOptions s_writeOptions = new()
+    private static readonly JsonSerializerOptions writeOptions = new()
     {
         WriteIndented = true,
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -40,7 +40,7 @@ public static class ToolSerializer
         try
         {
             var content = File.ReadAllText(file);
-            return JsonSerializer.Deserialize<Tool>(content, s_readOptions);
+            return JsonSerializer.Deserialize<Tool>(content, readOptions);
         }
         catch (Exception exception)
         {
@@ -52,7 +52,7 @@ public static class ToolSerializer
 
     public static void Save(Tool tool, AbsolutePath file)
     {
-        file.WriteAllText(JsonSerializer.Serialize(tool, s_writeOptions));
+        file.WriteAllText(JsonSerializer.Serialize(tool, writeOptions));
     }
 
     // Mirrors the legacy Newtonsoft CustomContractResolver. Two-pass shape:

--- a/src/Fallout.Tooling.Generator/Writers/ToolWriter.cs
+++ b/src/Fallout.Tooling.Generator/Writers/ToolWriter.cs
@@ -8,13 +8,13 @@ namespace Fallout.CodeGeneration.Writers;
 
 public class ToolWriter : IDisposable, IWriter, IWriterWrapper
 {
-    private readonly StreamWriter _streamWriter;
-    private int _indention;
+    private readonly StreamWriter streamWriter;
+    private int indention;
 
     public ToolWriter(Tool tool, StreamWriter streamWriter)
     {
         Tool = tool;
-        _streamWriter = streamWriter;
+        this.streamWriter = streamWriter;
     }
 
     public Tool Tool { get; }
@@ -22,20 +22,20 @@ public class ToolWriter : IDisposable, IWriter, IWriterWrapper
 
     public void Dispose()
     {
-        _streamWriter.Dispose();
+        streamWriter.Dispose();
     }
 
     void IWriter.WriteLine(string text)
     {
-        _streamWriter.WriteLine($"{' '.Repeat(_indention * 4)}{text}");
+        streamWriter.WriteLine($"{' '.Repeat(indention * 4)}{text}");
     }
 
     void IWriter.WriteBlock(Action action)
     {
         this.WriteLine("{");
-        _indention++;
+        indention++;
         action();
-        _indention--;
+        indention--;
         this.WriteLine("}");
     }
 }

--- a/src/Fallout.Tooling/ArgumentStringHandler.cs
+++ b/src/Fallout.Tooling/ArgumentStringHandler.cs
@@ -12,16 +12,16 @@ namespace Fallout.Common.Tooling;
 [InterpolatedStringHandler]
 public ref struct ArgumentStringHandler
 {
-    private DefaultInterpolatedStringHandler _builder;
-    private readonly List<string> _secretValues;
+    private DefaultInterpolatedStringHandler builder;
+    private readonly List<string> secretValues;
 
     public ArgumentStringHandler(
         int literalLength,
         int formattedCount,
         out bool handlerIsValid)
     {
-        _builder = new(literalLength, formattedCount);
-        _secretValues = new List<string>();
+        builder = new(literalLength, formattedCount);
+        secretValues = new List<string>();
         handlerIsValid = true;
     }
 
@@ -32,7 +32,7 @@ public ref struct ArgumentStringHandler
 
     public void AppendLiteral(string value)
     {
-        _builder.AppendLiteral(value);
+        builder.AppendLiteral(value);
     }
 
     public void AppendFormatted(object obj, int alignment = 0, string format = null)
@@ -40,7 +40,7 @@ public ref struct ArgumentStringHandler
         if (obj is string value)
         {
             if (format == "r")
-                _secretValues.Add(value);
+                secretValues.Add(value);
             else if (!(value.IsDoubleQuoted() || value.IsSingleQuoted() || format == "nq"))
                 (value, format) = (value.DoubleQuoteIfNeeded(), null);
             AppendFormatted(value, alignment, format);
@@ -53,12 +53,12 @@ public ref struct ArgumentStringHandler
 
     private void AppendFormatted(string value, int alignment, string format)
     {
-        _builder.AppendFormatted(value, alignment, format);
+        builder.AppendFormatted(value, alignment, format);
     }
 
     private void AppendFormatted(IAbsolutePathHolder holder, int alignment, string format)
     {
-        _builder.AppendFormatted(holder.Path, alignment, format ?? AbsolutePath.DoubleQuoteIfNeeded);
+        builder.AppendFormatted(holder.Path, alignment, format ?? AbsolutePath.DoubleQuoteIfNeeded);
     }
 
     public void AppendFormatted(IEnumerable<IAbsolutePathHolder> paths, int alignment = 0, string format = null)
@@ -66,15 +66,15 @@ public ref struct ArgumentStringHandler
         var list = paths.ToList();
         for (var i = 0; i < list.Count; i++)
         {
-            _builder.AppendFormatted(list[i], alignment, format ?? AbsolutePath.DoubleQuoteIfNeeded);
+            builder.AppendFormatted(list[i], alignment, format ?? AbsolutePath.DoubleQuoteIfNeeded);
             if (i + 1 < list.Count)
-                _builder.AppendLiteral(" ");
+                builder.AppendLiteral(" ");
         }
     }
 
     public string ToStringAndClear()
     {
-        var value = _builder.ToStringAndClear();
+        var value = builder.ToStringAndClear();
         return value.Length > 1 &&  value.IndexOf(value: '"', startIndex: 1) == value.Length - 1
             ? value.TrimMatchingDoubleQuotes()
             : value;
@@ -82,7 +82,7 @@ public ref struct ArgumentStringHandler
 
     public Func<string, string> GetFilter()
     {
-        var secretValues = _secretValues;
+        var secretValues = this.secretValues;
         return x => secretValues.Aggregate(x, (arguments, value) => arguments.Replace(value, "[REDACTED]"));
     }
 }

--- a/src/Fallout.Tooling/NpmVersionResolver.cs
+++ b/src/Fallout.Tooling/NpmVersionResolver.cs
@@ -6,14 +6,14 @@ namespace Fallout.Common.Tooling;
 
 public static class NpmVersionResolver
 {
-    private static readonly HttpClient s_client = new();
+    private static readonly HttpClient client = new();
 
     public static async Task<string> GetLatestVersion(string packageId)
     {
         try
         {
             var url = $"https://registry.npmjs.org/{packageId}";
-            var jsonString = await s_client.GetStringAsync(url);
+            var jsonString = await client.GetStringAsync(url);
             var jsonObject = JsonNode.Parse(jsonString)?.AsObject();
             return jsonObject?["dist-tags"]?["latest"]?.GetValue<string>();
         }

--- a/src/Fallout.Tooling/NuGetPackageResolver.cs
+++ b/src/Fallout.Tooling/NuGetPackageResolver.cs
@@ -331,12 +331,12 @@ public static class NuGetPackageResolver
             }
         }
 
-        private readonly Lazy<NuspecReader> _metadata;
+        private readonly Lazy<NuspecReader> metadata;
 
         public InstalledPackage(AbsolutePath file)
         {
             File = file;
-            _metadata = new Lazy<NuspecReader>(() =>
+            metadata = new Lazy<NuspecReader>(() =>
             {
                 var directory = new DirectoryInfo(Path.GetDirectoryName(file));
                 return directory.GetFiles("*.nuspec").Length == 1
@@ -347,7 +347,7 @@ public static class NuGetPackageResolver
 
         public AbsolutePath File { get; }
         public AbsolutePath Directory => File.Parent.NotNull();
-        public NuspecReader Metadata => _metadata.Value;
+        public NuspecReader Metadata => metadata.Value;
         public string Id => Metadata.GetIdentity().Id;
         public NuGetVersion Version => Metadata.GetIdentity().Version;
 

--- a/src/Fallout.Tooling/NuGetVersionResolver.cs
+++ b/src/Fallout.Tooling/NuGetVersionResolver.cs
@@ -8,7 +8,7 @@ namespace Fallout.Common.Tooling;
 
 public static class NuGetVersionResolver
 {
-    private static readonly HttpClient s_client = new();
+    private static readonly HttpClient client = new();
 
     public static async Task<string> GetLatestVersion(string packageId, bool includePrereleases, bool includeUnlisted = false)
     {
@@ -17,7 +17,7 @@ public static class NuGetVersionResolver
             var url = includeUnlisted
                 ? $"https://api.nuget.org/v3/flatcontainer/{packageId.ToLowerInvariant()}/index.json"
                 : $"https://api-v2v3search-0.nuget.org/query?q=packageid:{packageId}&prerelease={includePrereleases}";
-            var jsonString = await s_client.GetStringAsync(url);
+            var jsonString = await client.GetStringAsync(url);
             var jsonObject = JsonNode.Parse(jsonString)?.AsObject().NotNull();
 
             if (includeUnlisted)

--- a/src/Fallout.Tooling/Options.cs
+++ b/src/Fallout.Tooling/Options.cs
@@ -77,7 +77,7 @@ public class Options : IOptions
         }
     }
 
-    internal static JsonConverter LookupTableConverter = new ObjectFromFieldConverter(typeof(LookupTable<,>), "_dictionary");
+    internal static JsonConverter LookupTableConverter = new ObjectFromFieldConverter(typeof(LookupTable<,>), "lookupDictionary");
 
     internal static JsonSerializerOptions SerializerOptions { get; } = CreateSerializerOptions();
 

--- a/src/Fallout.Tooling/Process2.cs
+++ b/src/Fallout.Tooling/Process2.cs
@@ -7,49 +7,49 @@ namespace Fallout.Common.Tooling;
 
 public class Process2 : IProcess
 {
-    private readonly Process _process;
-    private readonly Func<string, string> _outputFilter;
-    private readonly int? _timeout;
+    private readonly Process process;
+    private readonly Func<string, string> outputFilter;
+    private readonly int? timeout;
 
     public Process2(Process process, Func<string, string> outputFilter, int? timeout, IReadOnlyCollection<Output> output)
     {
-        _process = process;
-        _outputFilter = outputFilter;
-        _timeout = timeout;
+        this.process = process;
+        this.outputFilter = outputFilter;
+        this.timeout = timeout;
         Output = output;
     }
 
-    public string FileName => _process.StartInfo.FileName;
+    public string FileName => process.StartInfo.FileName;
 
-    public string Arguments => _outputFilter.Invoke(_process.StartInfo.Arguments);
+    public string Arguments => outputFilter.Invoke(process.StartInfo.Arguments);
 
-    public string WorkingDirectory => _process.StartInfo.WorkingDirectory;
+    public string WorkingDirectory => process.StartInfo.WorkingDirectory;
 
     public IReadOnlyCollection<Output> Output { get; private set; }
 
-    public int ExitCode => _process.ExitCode;
+    public int ExitCode => process.ExitCode;
 
-    public bool HasExited => _process.HasExited;
+    public bool HasExited => process.HasExited;
 
-    public int Id => _process.Id;
+    public int Id => process.Id;
 
     public void Dispose()
     {
-        _process.Dispose();
+        process.Dispose();
     }
 
     public void Kill()
     {
-        _process.Kill();
+        process.Kill();
     }
 
     public bool WaitForExit()
     {
         // TODO: we are assuming that this method is called directly after process creation
-        // use _process.StartTime
-        var hasExited = _process.WaitForExit(_timeout ?? -1);
+        // use process.StartTime
+        var hasExited = process.WaitForExit(timeout ?? -1);
         if (!hasExited)
-            _process.Kill();
+            process.Kill();
         return hasExited;
     }
 }

--- a/src/Fallout.Tooling/ProcessTasks.cs
+++ b/src/Fallout.Tooling/ProcessTasks.cs
@@ -19,8 +19,8 @@ public static class ProcessTasks
     public static bool LogWorkingDirectory = true;
     public static string DefaultWorkingDirectory = EnvironmentInfo.WorkingDirectory;
 
-    private static readonly char[] s_pathSeparators = { EnvironmentInfo.IsWin ? ';' : ':' };
-    private static readonly object s_lock = new();
+    private static readonly char[] pathSeparators = { EnvironmentInfo.IsWin ? ';' : ':' };
+    private static readonly object syncLock = new();
 
     public static IProcess StartShell(
         string command,
@@ -168,7 +168,7 @@ public static class ProcessTasks
 
     private static void LogInvocation(ProcessStartInfo startInfo, Func<string, string> outputFilter)
     {
-        lock (s_lock)
+        lock (syncLock)
         {
             // TODO: logging additional
             Log.Information("> {ToolPath} {Arguments}", startInfo.FileName.DoubleQuoteIfNeeded(), outputFilter(startInfo.Arguments));
@@ -237,7 +237,7 @@ public static class ProcessTasks
     {
         static IEnumerable<(string Key, string Value)> Split(KeyValuePair<string, string> pair)
         {
-            var values = pair.Value.Split(s_pathSeparators, StringSplitOptions.RemoveEmptyEntries);
+            var values = pair.Value.Split(pathSeparators, StringSplitOptions.RemoveEmptyEntries);
             var padding = values.Length.ToString().Length;
 
             return values.Length == 1
@@ -256,7 +256,7 @@ public static class ProcessTasks
     {
         EnvironmentInfo.Variables
             .SingleOrDefault(x => x.Key.EqualsOrdinalIgnoreCase("path"))
-            .Value.Split(s_pathSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .Value.Split(pathSeparators, StringSplitOptions.RemoveEmptyEntries)
             .Select(EnvironmentInfo.ExpandVariables)
             .Where(x => !Directory.Exists(x))
             .ForEach(x => Log.Warning("Path environment variable contains invalid or inaccessible path {Path}", x));

--- a/src/Fallout.Tooling/ToolExecutor.cs
+++ b/src/Fallout.Tooling/ToolExecutor.cs
@@ -6,11 +6,11 @@ namespace Fallout.Common.Tooling;
 
 internal class ToolExecutor
 {
-    private readonly string _toolPath;
+    private readonly string toolPath;
 
     public ToolExecutor(string toolPath)
     {
-        _toolPath = toolPath;
+        this.toolPath = toolPath;
     }
 
 #if NET6_0_OR_GREATER
@@ -25,7 +25,7 @@ internal class ToolExecutor
         Action<IProcess> exitHandler = null)
     {
         var process = ProcessTasks.StartProcess(
-            _toolPath,
+            toolPath,
             arguments,
             workingDirectory,
             environmentVariables,
@@ -46,7 +46,7 @@ internal class ToolExecutor
         Func<string, string> outputFilter = null)
     {
         var process = ProcessTasks.StartProcess(
-            _toolPath,
+            toolPath,
             arguments,
             workingDirectory,
             environmentVariables,

--- a/src/Fallout.Tooling/ToolOptions.Arguments.cs
+++ b/src/Fallout.Tooling/ToolOptions.Arguments.cs
@@ -56,7 +56,7 @@ partial class ToolOptions
 
         var escapeMethod = CreateEscape();
         var arguments = InternalOptions
-            .Select(kv => (Node: kv.Value, Property: _allProperties[kv.Key]))
+            .Select(kv => (Node: kv.Value, Property: allProperties[kv.Key]))
             .Select(x => (x.Node, x.Property, Attribute: x.Property.GetCustomAttribute<ArgumentAttribute>()))
             .Where(x => x.Attribute != null)
             .OrderByDescending(x => x.Attribute.Position.CompareTo(0))

--- a/src/Fallout.Tooling/ToolOptions.Secrets.cs
+++ b/src/Fallout.Tooling/ToolOptions.Secrets.cs
@@ -11,7 +11,7 @@ partial class ToolOptions
     {
         return (ProcessRedactedSecrets ?? [])
             .Concat(InternalOptions
-                .Select(kv => (Node: kv.Value, Property: _allProperties[kv.Key]))
+                .Select(kv => (Node: kv.Value, Property: allProperties[kv.Key]))
                 .Select(x => (x.Node, x.Property, Attribute: x.Property.GetCustomAttribute<ArgumentAttribute>()))
                 .Where(x => x.Attribute?.Secret ?? false)
                 .Select(x =>

--- a/src/Fallout.Tooling/ToolOptions.cs
+++ b/src/Fallout.Tooling/ToolOptions.cs
@@ -11,11 +11,11 @@ public abstract partial class ToolOptions : Options
 {
     internal static event EventHandler Created;
 
-    private readonly Dictionary<string, PropertyInfo> _allProperties;
+    private readonly Dictionary<string, PropertyInfo> allProperties;
 
     protected ToolOptions()
     {
-        _allProperties = GetType().GetAllMembers(x => x is PropertyInfo, ReflectionUtility.Instance, allowAmbiguity: true)
+        allProperties = GetType().GetAllMembers(x => x is PropertyInfo, ReflectionUtility.Instance, allowAmbiguity: true)
             .Cast<PropertyInfo>().ToDictionary(x => x.Name, x => x);
 
         Set(() => ProcessEnvironmentVariables, EnvironmentInfo.Variables);

--- a/src/Fallout.Utilities.Net/HttpRequest.Response.cs
+++ b/src/Fallout.Utilities.Net/HttpRequest.Response.cs
@@ -28,7 +28,7 @@ public static partial class HttpRequestExtensions
 
 public class HttpResponseInspector
 {
-    private string _body;
+    private string body;
 
     public HttpResponseInspector(HttpResponseMessage response)
     {
@@ -39,7 +39,7 @@ public class HttpResponseInspector
 
     public async Task<string> GetBodyAsync()
     {
-        _body ??= await Response.Content.ReadAsStringAsync();
-        return _body;
+        body ??= await Response.Content.ReadAsStringAsync();
+        return body;
     }
 }

--- a/src/Fallout.Utilities/ArgumentParser.cs
+++ b/src/Fallout.Utilities/ArgumentParser.cs
@@ -46,7 +46,7 @@ internal class ArgumentParser
             .ToArray();
     }
 
-    private readonly string[] _arguments;
+    private readonly string[] arguments;
 
     public ArgumentParser(string arguments)
         : this(Parse(arguments))
@@ -55,10 +55,10 @@ internal class ArgumentParser
 
     public ArgumentParser(IEnumerable<string> arguments)
     {
-        _arguments = arguments.ToArray();
+        this.arguments = arguments.ToArray();
     }
 
-    public IReadOnlyList<string> Arguments => _arguments;
+    public IReadOnlyList<string> Arguments => arguments;
 
     public bool HasArgument(string argumentName)
     {
@@ -71,13 +71,13 @@ internal class ArgumentParser
         if (index == -1)
             return destinationType.GetDefaultValue();
 
-        var values = _arguments.Skip(index + 1).TakeUntil(IsArgument).ToArray();
+        var values = arguments.Skip(index + 1).TakeUntil(IsArgument).ToArray();
         return ConvertArgument(argumentName, values, destinationType, separator);
     }
 
     public object GetPositionalArgument(int position, Type destinationType, char? separator = null)
     {
-        var positionalArgumentsCount = _arguments.TakeUntil(IsArgument).Count();
+        var positionalArgumentsCount = arguments.TakeUntil(IsArgument).Count();
         if (position < 0)
             position = positionalArgumentsCount + position % positionalArgumentsCount;
 
@@ -86,7 +86,7 @@ internal class ArgumentParser
 
         return ConvertArgument(
             $"$positional[{position}]",
-            new[] { _arguments[position] },
+            new[] { arguments[position] },
             destinationType,
             separator);
     }
@@ -107,7 +107,7 @@ internal class ArgumentParser
     private int GetArgumentIndex(string argumentName)
     {
         var argumentMemberName = GetArgumentMemberName(argumentName);
-        return Array.FindLastIndex(_arguments, x => IsArgument(x) && GetArgumentMemberName(x).EqualsOrdinalIgnoreCase(argumentMemberName));
+        return Array.FindLastIndex(arguments, x => IsArgument(x) && GetArgumentMemberName(x).EqualsOrdinalIgnoreCase(argumentMemberName));
     }
 
     private object ConvertArgument(
@@ -130,7 +130,7 @@ internal class ArgumentParser
         {
             Assert.Fail(
                 new[] { ex.Message, "Arguments were:" }
-                    .Concat(_arguments.Select((x, i) => $"  [{i}] = {x}"))
+                    .Concat(arguments.Select((x, i) => $"  [{i}] = {x}"))
                     .JoinNewLine());
             // ReSharper disable once HeuristicUnreachableCode
             return null;

--- a/src/Fallout.Utilities/AsyncHelper.cs
+++ b/src/Fallout.Utilities/AsyncHelper.cs
@@ -7,7 +7,7 @@ namespace Fallout.Common;
 
 internal static class AsyncHelper
 {
-    private static readonly TaskFactory s_taskFactory = new(
+    private static readonly TaskFactory taskFactory = new(
         CancellationToken.None,
         TaskCreationOptions.None,
         TaskContinuationOptions.None,
@@ -15,7 +15,7 @@ internal static class AsyncHelper
 
     public static TResult RunSync<TResult>(Func<Task<TResult>> func)
     {
-        return s_taskFactory
+        return taskFactory
             .StartNew(func)
             .Unwrap()
             .GetAwaiter()
@@ -24,7 +24,7 @@ internal static class AsyncHelper
 
     public static void RunSync(Func<Task> func)
     {
-        s_taskFactory
+        taskFactory
             .StartNew(func)
             .Unwrap()
             .GetAwaiter()

--- a/src/Fallout.Utilities/Collections/Enumerable.Distinct.cs
+++ b/src/Fallout.Utilities/Collections/Enumerable.Distinct.cs
@@ -16,11 +16,11 @@ public static partial class EnumerableExtensions
 
     private class DelegateEqualityComparer<TSource, TValue> : IEqualityComparer<TSource>
     {
-        private readonly Func<TSource, TValue> _selector;
+        private readonly Func<TSource, TValue> selector;
 
         public DelegateEqualityComparer(Func<TSource, TValue> selector)
         {
-            _selector = selector;
+            this.selector = selector;
         }
 
         public bool Equals(TSource x, TSource y)
@@ -33,12 +33,12 @@ public static partial class EnumerableExtensions
                 return false;
             if (x.GetType() != y.GetType())
                 return false;
-            return Equals(_selector(x), _selector(y));
+            return Equals(selector(x), selector(y));
         }
 
         public int GetHashCode(TSource obj)
         {
-            return _selector(obj).GetHashCode();
+            return selector(obj).GetHashCode();
         }
     }
 }

--- a/src/Fallout.Utilities/Collections/Enumerable.Random.cs
+++ b/src/Fallout.Utilities/Collections/Enumerable.Random.cs
@@ -6,12 +6,12 @@ namespace Fallout.Common.Utilities.Collections;
 
 partial class EnumerableExtensions
 {
-    private static readonly Random s_randomNumberGenerator = new Random();
+    private static readonly Random randomNumberGenerator = new Random();
 
     public static T Random<T>(this IEnumerable<T> collection)
     {
         var array = collection.ToArray();
-        return array[s_randomNumberGenerator.Next(array.Length)];
+        return array[randomNumberGenerator.Next(array.Length)];
     }
 
     public static ICollection<T> Randomize<T>(this ICollection<T> collection)
@@ -20,7 +20,7 @@ partial class EnumerableExtensions
         var count = list.Count;
         while (count > 1) {
             count--;
-            var k = s_randomNumberGenerator.Next(count + 1);
+            var k = randomNumberGenerator.Next(count + 1);
             (list[k], list[count]) = (list[count], list[k]);
         }
 

--- a/src/Fallout.Utilities/Collections/LookupTable.cs
+++ b/src/Fallout.Utilities/Collections/LookupTable.cs
@@ -8,7 +8,7 @@ namespace Fallout.Common.Utilities.Collections;
 [Serializable]
 public class LookupTable<TKey, TValue>(Dictionary<TKey, List<TValue>> dictionary) : ILookup<TKey, TValue>
 {
-    private readonly Dictionary<TKey, List<TValue>> _dictionary = dictionary;
+    private readonly Dictionary<TKey, List<TValue>> lookupDictionary = dictionary;
 
     public LookupTable()
         : this(new Dictionary<TKey, List<TValue>>())
@@ -26,7 +26,7 @@ public class LookupTable<TKey, TValue>(Dictionary<TKey, List<TValue>> dictionary
     }
 
     private ILookup<TKey, TValue> Lookup =>
-        _dictionary.SelectMany(x => x.Value.Select(y => new KeyValuePair<TKey, TValue>(x.Key, y)))
+        lookupDictionary.SelectMany(x => x.Value.Select(y => new KeyValuePair<TKey, TValue>(x.Key, y)))
             .ToLookup(x => x.Key, x => x.Value);
 
     public int Count => Lookup.Count;
@@ -34,35 +34,35 @@ public class LookupTable<TKey, TValue>(Dictionary<TKey, List<TValue>> dictionary
     public IEnumerable<TValue> this[TKey key]
     {
         get => Lookup[key];
-        set => _dictionary[key] = value.ToList();
+        set => lookupDictionary[key] = value.ToList();
     }
 
     public void Add(TKey key, TValue value)
     {
-        var list = (_dictionary[key] = _dictionary.GetValueOrDefault(key, new List<TValue>())).NotNull();
+        var list = (lookupDictionary[key] = lookupDictionary.GetValueOrDefault(key, new List<TValue>())).NotNull();
         list.Add(value);
     }
 
     public void AddRange(TKey key, IEnumerable<TValue> values)
     {
-        var list = (_dictionary[key] = _dictionary.GetValueOrDefault(key, new List<TValue>())).NotNull();
+        var list = (lookupDictionary[key] = lookupDictionary.GetValueOrDefault(key, new List<TValue>())).NotNull();
         foreach (var value in values)
             list.Add(value);
     }
 
     public void Remove(TKey key)
     {
-        _dictionary.Remove(key);
+        lookupDictionary.Remove(key);
     }
 
     public void Remove(TKey key, TValue value)
     {
-        _dictionary.GetValueOrDefault(key)?.Remove(value);
+        lookupDictionary.GetValueOrDefault(key)?.Remove(value);
     }
 
     public void Clear()
     {
-        _dictionary.Clear();
+        lookupDictionary.Clear();
     }
 
     public IEnumerator<IGrouping<TKey, TValue>> GetEnumerator()
@@ -77,7 +77,7 @@ public class LookupTable<TKey, TValue>(Dictionary<TKey, List<TValue>> dictionary
 
     public bool Contains(TKey key)
     {
-        return _dictionary.ContainsKey(key);
+        return lookupDictionary.ContainsKey(key);
     }
 
     public ILookup<TKey, TValue> AsReadOnly()

--- a/src/Fallout.Utilities/DelegateDisposable.cs
+++ b/src/Fallout.Utilities/DelegateDisposable.cs
@@ -36,15 +36,15 @@ public class DelegateDisposable : IDisposable
         return new DelegateDisposable(() => member.SetValue(target, previousValue));
     }
 
-    private readonly Action _cleanup;
+    private readonly Action cleanup;
 
     private DelegateDisposable(Action cleanup)
     {
-        _cleanup = cleanup;
+        this.cleanup = cleanup;
     }
 
     public void Dispose()
     {
-        _cleanup?.Invoke();
+        cleanup?.Invoke();
     }
 }

--- a/src/Fallout.Utilities/EnvironmentInfo.Variables.cs
+++ b/src/Fallout.Utilities/EnvironmentInfo.Variables.cs
@@ -23,11 +23,11 @@ public static partial class EnvironmentInfo
     /// Returns all paths from the <em>PATH</em> environment variable.
     /// </summary>
     public static IReadOnlyCollection<string> Paths
-        => GetVariable<string[]>(s_pathVariableName, s_pathVariableSeparator).NotNull()
+        => GetVariable<string[]>(pathVariableName, pathVariableSeparator).NotNull()
             .Select(ExpandVariables).ToList();
 
-    private static readonly string s_pathVariableName = Variables.Single(x => x.Key.EqualsOrdinalIgnoreCase("PATH")).Key;
-    private static readonly char s_pathVariableSeparator = IsWin ? ';' : ':';
+    private static readonly string pathVariableName = Variables.Single(x => x.Key.EqualsOrdinalIgnoreCase("PATH")).Key;
+    private static readonly char pathVariableSeparator = IsWin ? ';' : ':';
 
     /// <summary>
     /// Indicates whether the environment variable exists.

--- a/src/Fallout.Utilities/IO/AbsolutePath.cs
+++ b/src/Fallout.Utilities/IO/AbsolutePath.cs
@@ -15,7 +15,7 @@ namespace Fallout.Common.IO;
 /// </summary>
 [Serializable]
 [TypeConverter(typeof(TypeConverter))]
-[DebuggerDisplay("{" + nameof(_path) + "}")]
+[DebuggerDisplay("{" + nameof(path) + "}")]
 public class AbsolutePath : IAbsolutePathHolder, IFormattable
 {
     public const string DoubleQuote = "d";
@@ -52,11 +52,11 @@ public class AbsolutePath : IAbsolutePathHolder, IFormattable
         return new AbsolutePath(path);
     }
 
-    private readonly string _path;
+    private readonly string path;
 
     private AbsolutePath(string path)
     {
-        _path = NormalizePath(path);
+        this.path = NormalizePath(path);
     }
 
     AbsolutePath IAbsolutePathHolder.Path => this;
@@ -78,23 +78,23 @@ public class AbsolutePath : IAbsolutePathHolder, IFormattable
     /// <summary>
     /// Returns the name of the file or directory.
     /// </summary>
-    public string Name => Path.GetFileName(_path);
+    public string Name => Path.GetFileName(path);
 
     /// <summary>
     /// Returns the name of the file without extension.
     /// </summary>
-    public string NameWithoutExtension => Path.GetFileNameWithoutExtension(_path);
+    public string NameWithoutExtension => Path.GetFileNameWithoutExtension(path);
 
     /// <summary>
     /// Returns the extension of the file with dot.
     /// </summary>
-    public string Extension => Path.GetExtension(_path);
+    public string Extension => Path.GetExtension(path);
 
     /// <summary>
     /// Returns the parent path (directory).
     /// </summary>
     public AbsolutePath Parent =>
-        !IsWinRoot(_path.TrimEnd(WinSeparator)) && !IsUncRoot(_path) && !IsUnixRoot(_path)
+        !IsWinRoot(path.TrimEnd(WinSeparator)) && !IsUncRoot(path) && !IsUnixRoot(path)
             ? this / ".."
             : null;
 
@@ -130,8 +130,8 @@ public class AbsolutePath : IAbsolutePathHolder, IFormattable
 
     protected bool Equals(AbsolutePath other)
     {
-        var stringComparison = HasWinRoot(_path) ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-        return string.Equals(_path, other._path, stringComparison);
+        var stringComparison = HasWinRoot(path) ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        return string.Equals(path, other.path, stringComparison);
     }
 
     public override bool Equals(object obj)
@@ -147,7 +147,7 @@ public class AbsolutePath : IAbsolutePathHolder, IFormattable
 
     public override int GetHashCode()
     {
-        return _path?.GetHashCode() ?? 0;
+        return path?.GetHashCode() ?? 0;
     }
 
     public override string ToString()
@@ -179,11 +179,11 @@ public class AbsolutePath : IAbsolutePathHolder, IFormattable
     {
         return format switch
         {
-            DoubleQuote => _path.DoubleQuote(),
-            DoubleQuoteIfNeeded => _path.DoubleQuoteIfNeeded(),
-            SingleQuote => _path.SingleQuote(),
-            SingleQuoteIfNeeded => _path.SingleQuoteIfNeeded(),
-            null or NoQuotes => _path,
+            DoubleQuote => path.DoubleQuote(),
+            DoubleQuoteIfNeeded => path.DoubleQuoteIfNeeded(),
+            SingleQuote => path.SingleQuote(),
+            SingleQuoteIfNeeded => path.SingleQuoteIfNeeded(),
+            null or NoQuotes => path,
             _ => throw new ArgumentException($"Format '{format}' is not recognized")
         };
     }

--- a/src/Fallout.Utilities/IO/RelativePath.cs
+++ b/src/Fallout.Utilities/IO/RelativePath.cs
@@ -9,16 +9,16 @@ namespace Fallout.Common.IO;
 /// Represents a relative path with the separator of the current operating system.
 /// </summary>
 [Serializable]
-[DebuggerDisplay("{" + nameof(_path) + "}")]
+[DebuggerDisplay("{" + nameof(path) + "}")]
 public class RelativePath
 {
-    private readonly string _path;
-    private readonly char? _separator;
+    private readonly string path;
+    private readonly char? separator;
 
     protected RelativePath(string path, char? separator = null)
     {
-        _path = path;
-        _separator = separator;
+        this.path = path;
+        this.separator = separator;
     }
 
     public static explicit operator RelativePath(string path)
@@ -31,7 +31,7 @@ public class RelativePath
 
     public static implicit operator string(RelativePath path)
     {
-        return path?._path;
+        return path?.path;
     }
 
 #if NET6_0_OR_GREATER
@@ -46,7 +46,7 @@ public class RelativePath
 
     public static RelativePath operator /(RelativePath left, string right)
     {
-        var separator = left.NotNull()._separator;
+        var separator = left.NotNull().separator;
         return new RelativePath(NormalizePath(Combine(left, (RelativePath) right, separator), separator), separator);
     }
 
@@ -57,6 +57,6 @@ public class RelativePath
 
     public override string ToString()
     {
-        return _path;
+        return path;
     }
 }

--- a/src/Fallout.Utilities/Security/EncryptionUtility.cs
+++ b/src/Fallout.Utilities/Security/EncryptionUtility.cs
@@ -44,7 +44,7 @@ internal static class EncryptionUtility
     private const int V1KeyLength = 32;
     private const int V1IvLength = 16;
     private const int V1Iterations = 10_000;
-    private static readonly byte[] s_v1StaticSalt = { 0x49, 0x76, 0x61, 0x6e, 0x20, 0x4d, 0x65, 0x64, 0x76, 0x65, 0x64, 0x65, 0x76 };
+    private static readonly byte[] v1StaticSalt = { 0x49, 0x76, 0x61, 0x6e, 0x20, 0x4d, 0x65, 0x64, 0x76, 0x65, 0x64, 0x65, 0x76 };
 
     public static string Decrypt(string cipherText, string password, string name)
     {
@@ -127,7 +127,7 @@ internal static class EncryptionUtility
         var ciphertext = Convert.FromBase64String(base64Ciphertext);
         var passwordBytes = Encoding.UTF8.GetBytes(password);
 
-        var keyAndIv = Rfc2898DeriveBytes.Pbkdf2(passwordBytes, s_v1StaticSalt, V1Iterations, HashAlgorithmName.SHA256, V1KeyLength + V1IvLength);
+        var keyAndIv = Rfc2898DeriveBytes.Pbkdf2(passwordBytes, v1StaticSalt, V1Iterations, HashAlgorithmName.SHA256, V1KeyLength + V1IvLength);
         var key = new byte[V1KeyLength];
         var iv = new byte[V1IvLength];
         Buffer.BlockCopy(keyAndIv, 0, key, 0, V1KeyLength);
@@ -153,7 +153,7 @@ internal static class EncryptionUtility
         var plaintext = Encoding.UTF8.GetBytes(clearText);
         var passwordBytes = Encoding.UTF8.GetBytes(password);
 
-        var keyAndIv = Rfc2898DeriveBytes.Pbkdf2(passwordBytes, s_v1StaticSalt, V1Iterations, HashAlgorithmName.SHA256, V1KeyLength + V1IvLength);
+        var keyAndIv = Rfc2898DeriveBytes.Pbkdf2(passwordBytes, v1StaticSalt, V1Iterations, HashAlgorithmName.SHA256, V1KeyLength + V1IvLength);
         var key = new byte[V1KeyLength];
         var iv = new byte[V1IvLength];
         Buffer.BlockCopy(keyAndIv, 0, key, 0, V1KeyLength);

--- a/src/Fallout.Utilities/Text/String.Replace.cs
+++ b/src/Fallout.Utilities/Text/String.Replace.cs
@@ -19,11 +19,11 @@ public static partial class StringExtensions
         return Regex.Replace(str, pattern, matchEvaluator, options);
     }
 
-    private static readonly Regex s_unicodeRegex = new(@"\\u(?<Value>[a-zA-Z0-9]{4})", RegexOptions.Compiled);
+    private static readonly Regex unicodeRegex = new(@"\\u(?<Value>[a-zA-Z0-9]{4})", RegexOptions.Compiled);
 
     public static string ReplaceUnicode(this string str)
     {
-        return s_unicodeRegex.Replace(str, m => ((char) int.Parse(m.Groups["Value"].Value, NumberStyles.HexNumber)).ToString());
+        return unicodeRegex.Replace(str, m => ((char) int.Parse(m.Groups["Value"].Value, NumberStyles.HexNumber)).ToString());
     }
 
     public static string ReplaceKnownWords(this string str)


### PR DESCRIPTION
Resolves #481

**Description:**
This PR completes the one-time migration sweep to enforce `camelCase` naming for private fields across the codebase.

**Changes:**
- Renamed all `_`, `s_`, `m_`, and `g_` prefixed private fields to `camelCase` exclusively within the `src/**/*.cs` directory.
- Excluded auto-generated code and the `tests/` directory to strictly maintain the requested scope.
- Bumped `dotnet_naming_rule.private_fields_should_be_camel_case.severity` from `suggestion` to `warning` in `.editorconfig`.
- Verified a clean build with zero new naming warnings.