### PR TITLE
Remove unused `buildScript` and `args` parameters from commands

### DIFF
--- a/src/Fallout.Cli/Commands/CakeCleanCommand.cs
+++ b/src/Fallout.Cli/Commands/CakeCleanCommand.cs
@@ -18,9 +18,9 @@ internal sealed class CakeCleanCommand : IFalloutCommand
     public string Name => "cake-clean";
 
     public Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-        => Task.FromResult(Execute(args, rootDirectory, buildScript));
+        => Task.FromResult(Execute());
 
-    private int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private int Execute()
     {
         var cakeFiles = CakeConverter.GetCakeFiles().ToList();
         Host.Information("Found .cake files:");

--- a/src/Fallout.Cli/Commands/CompleteCommand.cs
+++ b/src/Fallout.Cli/Commands/CompleteCommand.cs
@@ -20,9 +20,9 @@ internal sealed class CompleteCommand : IFalloutCommand
     public string Name => "complete";
 
     public Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-        => Task.FromResult(Execute(args, rootDirectory, buildScript));
+        => Task.FromResult(Execute(args, rootDirectory));
 
-    private int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private int Execute(string[] args, AbsolutePath rootDirectory)
     {
         if (rootDirectory == null)
             return 0;

--- a/src/Fallout.Cli/Commands/GetConfigurationCommand.cs
+++ b/src/Fallout.Cli/Commands/GetConfigurationCommand.cs
@@ -19,9 +19,9 @@ internal sealed class GetConfigurationCommand : IFalloutCommand
     public string Name => "get-configuration";
 
     public Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-        => Task.FromResult(Execute(args, rootDirectory, buildScript));
+        => Task.FromResult(Execute(buildScript));
 
-    private int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private int Execute(AbsolutePath buildScript)
     {
         var configuration = _configuration.Read(buildScript.NotNull(), evaluate: false);
 

--- a/src/Fallout.Cli/Commands/Navigation/GetNextDirectoryCommand.cs
+++ b/src/Fallout.Cli/Commands/Navigation/GetNextDirectoryCommand.cs
@@ -12,9 +12,9 @@ internal sealed class GetNextDirectoryCommand : IFalloutCommand
     public string Name => "GetNextDirectory";
 
     public Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-        => Task.FromResult(Execute(args, rootDirectory, buildScript));
+        => Task.FromResult(Execute());
 
-    private int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private int Execute()
     {
         var content = NavigationSession.SessionFile.Existing()?.ReadAllLines();
         if (content == null || string.IsNullOrWhiteSpace(content[0]))

--- a/src/Fallout.Cli/Commands/Navigation/PopDirectoryCommand.cs
+++ b/src/Fallout.Cli/Commands/Navigation/PopDirectoryCommand.cs
@@ -11,9 +11,9 @@ internal sealed class PopDirectoryCommand : IFalloutCommand
     public string Name => "PopDirectory";
 
     public Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-        => Task.FromResult(Execute(args, rootDirectory, buildScript));
+        => Task.FromResult(Execute());
 
-    private int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private int Execute()
     {
         var content = NavigationSession.SessionFile.Existing()?.ReadAllLines().ToList();
         if (content == null || content.Count <= 1)

--- a/src/Fallout.Cli/Commands/Navigation/PushWithChosenRootDirectoryCommand.cs
+++ b/src/Fallout.Cli/Commands/Navigation/PushWithChosenRootDirectoryCommand.cs
@@ -19,9 +19,9 @@ internal sealed class PushWithChosenRootDirectoryCommand : IFalloutCommand
     public string Name => "PushWithChosenRootDirectory";
 
     public Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-        => Task.FromResult(Execute(args, rootDirectory, buildScript));
+        => Task.FromResult(Execute());
 
-    private int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private int Execute()
     {
         return NavigationSession.PushAndSetNext(() =>
         {

--- a/src/Fallout.Cli/Commands/Navigation/PushWithCurrentRootDirectoryCommand.cs
+++ b/src/Fallout.Cli/Commands/Navigation/PushWithCurrentRootDirectoryCommand.cs
@@ -11,9 +11,9 @@ internal sealed class PushWithCurrentRootDirectoryCommand : IFalloutCommand
     public string Name => "PushWithCurrentRootDirectory";
 
     public Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-        => Task.FromResult(Execute(args, rootDirectory, buildScript));
+        => Task.FromResult(Execute(rootDirectory));
 
-    private int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private int Execute(AbsolutePath rootDirectory)
     {
         return NavigationSession.PushAndSetNext(() => rootDirectory.NotNull("No root directory"));
     }

--- a/src/Fallout.Cli/Commands/Navigation/PushWithParentRootDirectoryCommand.cs
+++ b/src/Fallout.Cli/Commands/Navigation/PushWithParentRootDirectoryCommand.cs
@@ -13,11 +13,12 @@ internal sealed class PushWithParentRootDirectoryCommand : IFalloutCommand
     public string Name => "PushWithParentRootDirectory";
 
     public Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-        => Task.FromResult(Execute(args, rootDirectory, buildScript));
+        => Task.FromResult(Execute(rootDirectory));
 
-    private int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private int Execute(AbsolutePath rootDirectory)
     {
-        return NavigationSession.PushAndSetNext(() => TryGetRootDirectoryFrom(Path.GetDirectoryName(rootDirectory.NotNull("No root directory")))
-            .NotNull("No parent root directory"));
+        return NavigationSession.PushAndSetNext(() =>
+            TryGetRootDirectoryFrom(Path.GetDirectoryName(rootDirectory.NotNull("No root directory")))
+                .NotNull("No parent root directory"));
     }
 }

--- a/src/Fallout.Cli/Commands/SecretsCommand.cs
+++ b/src/Fallout.Cli/Commands/SecretsCommand.cs
@@ -34,9 +34,9 @@ internal sealed class SecretsCommand : IFalloutCommand
 
     // ReSharper disable once CognitiveComplexity
     public Task<int> ExecuteAsync(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
-        => Task.FromResult(Execute(args, rootDirectory, buildScript));
+        => Task.FromResult(Execute(args, rootDirectory));
 
-    private int Execute(string[] args, AbsolutePath rootDirectory, AbsolutePath buildScript)
+    private int Execute(string[] args, AbsolutePath rootDirectory)
     {
         var secretParameters = CompletionUtility.GetItemsFromSchema(
                 GetBuildSchemaFile(rootDirectory.NotNull("No root directory")),


### PR DESCRIPTION
Fixing nasty build errors due to the .editorconfig rule `UnusedParameter.Local`'s severity `error`

This only applies to the private `Execute` methods; the `IFalloutCommand` contract is not touched.

When needed, we can re-add them..

<!-- Keep it terse: one-line summary, then short "what changed" bullets. -->
<!-- Link the issue and summarize it — don't recite it. See docs/agents/issue-and-pr-style.md. -->
<!-- Or let Copilot draft one, then trim it. -->

<!-- This repo merges via rebase only (linear history). Curate your commits into a -->
<!-- clean sequence before final approval — see CONTRIBUTING.md → Merging. -->
