### PR TITLE
Use `dotnet fallout` instead of ./build.cmd in AppVeyor and Azure Pipelines steps

### DIFF
--- a/src/Fallout.Common/CI/AppVeyor/Configuration/AppVeyorConfiguration.cs
+++ b/src/Fallout.Common/CI/AppVeyor/Configuration/AppVeyorConfiguration.cs
@@ -110,8 +110,13 @@ public class AppVeyorConfiguration : ConfigurationEntity
 
         using (writer.WriteBlock("build_script:"))
         {
-            writer.WriteLine($@"- cmd: .\{BuildCmdPath} {InvokedTargets.JoinSpace()}");
-            writer.WriteLine($@"- sh: ./{BuildCmdPath} {InvokedTargets.JoinSpace()}");
+            // Invoke the `fallout` local tool (cross-platform) rather than the OS-specific build script.
+            // AppVeyor runs `- cmd:` lines only on Windows images and `- sh:` lines only on the rest, so
+            // emit both; the command itself is identical. See GitHub Actions (dotnet fallout) and issue #516.
+            writer.WriteLine("- cmd: dotnet tool restore");
+            writer.WriteLine($"- cmd: dotnet fallout {InvokedTargets.JoinSpace()}");
+            writer.WriteLine("- sh: dotnet tool restore");
+            writer.WriteLine($"- sh: dotnet fallout {InvokedTargets.JoinSpace()}");
         }
 
         if (Cache.Length > 0)

--- a/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesCmdStep.cs
+++ b/src/Fallout.Common/CI/AzurePipelines/Configuration/AzurePipelinesCmdStep.cs
@@ -25,7 +25,10 @@ public class AzurePipelinesCmdStep : AzurePipelinesStep
 
             using (writer.WriteBlock("inputs:"))
             {
-                writer.WriteLine($"script: './{BuildCmdPath} {arguments}'");
+                // Invoke the `fallout` local tool (cross-platform) rather than the OS-specific build script.
+                // CmdLine@2 runs in the agent's default shell (cmd on Windows, bash elsewhere); `&&` works in
+                // both. See GitHub Actions (dotnet fallout) and issue #516.
+                writer.WriteLine($"script: 'dotnet tool restore && dotnet fallout {arguments}'");
             }
 
             if (Imports.Count > 0)

--- a/tests/Fallout.Common.Specs/CI/ConfigurationGenerationSpecs.Test_testName=null_attribute=AppVeyorAttribute.verified.txt
+++ b/tests/Fallout.Common.Specs/CI/ConfigurationGenerationSpecs.Test_testName=null_attribute=AppVeyorAttribute.verified.txt
@@ -31,8 +31,10 @@ install:
   - git submodule update --init --recursive
 
 build_script:
-  - cmd: .\build.cmd Test
-  - sh: ./build.cmd Test
+  - cmd: dotnet tool restore
+  - cmd: dotnet fallout Test
+  - sh: dotnet tool restore
+  - sh: dotnet fallout Test
 
 artifacts:
   - path: 'src/*/obj/**'

--- a/tests/Fallout.Common.Specs/CI/ConfigurationGenerationSpecs.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/tests/Fallout.Common.Specs/CI/ConfigurationGenerationSpecs.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -66,7 +66,7 @@ stages:
           - task: CmdLine@2
             displayName: 'Run: Restore'
             inputs:
-              script: './build.cmd Restore --skip'
+              script: 'dotnet tool restore && dotnet fallout Restore --skip'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -99,7 +99,7 @@ stages:
           - task: CmdLine@2
             displayName: 'Run: Compile'
             inputs:
-              script: './build.cmd Compile --skip'
+              script: 'dotnet tool restore && dotnet fallout Compile --skip'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -134,7 +134,7 @@ stages:
           - task: CmdLine@2
             displayName: 'Run: Test'
             inputs:
-              script: './build.cmd Test --skip --partition $(System.JobPositionInPhase)/2'
+              script: 'dotnet tool restore && dotnet fallout Test --skip --partition $(System.JobPositionInPhase)/2'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -167,7 +167,7 @@ stages:
           - task: CmdLine@2
             displayName: 'Run: Coverage'
             inputs:
-              script: './build.cmd Coverage --skip'
+              script: 'dotnet tool restore && dotnet fallout Coverage --skip'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -206,7 +206,7 @@ stages:
           - task: CmdLine@2
             displayName: 'Run: Restore'
             inputs:
-              script: './build.cmd Restore --skip'
+              script: 'dotnet tool restore && dotnet fallout Restore --skip'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -239,7 +239,7 @@ stages:
           - task: CmdLine@2
             displayName: 'Run: Compile'
             inputs:
-              script: './build.cmd Compile --skip'
+              script: 'dotnet tool restore && dotnet fallout Compile --skip'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -274,7 +274,7 @@ stages:
           - task: CmdLine@2
             displayName: 'Run: Test'
             inputs:
-              script: './build.cmd Test --skip --partition $(System.JobPositionInPhase)/2'
+              script: 'dotnet tool restore && dotnet fallout Test --skip --partition $(System.JobPositionInPhase)/2'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -307,7 +307,7 @@ stages:
           - task: CmdLine@2
             displayName: 'Run: Coverage'
             inputs:
-              script: './build.cmd Coverage --skip'
+              script: 'dotnet tool restore && dotnet fallout Coverage --skip'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)


### PR DESCRIPTION
Fixes #516 for the providers where the bug still lives on `main`.

## Problem
AppVeyor and Azure Pipelines emit a `./build.cmd` invocation that only runs on Windows agents:
- **AppVeyor** emitted `- sh: ./build.cmd …` — a Unix shell running a `.cmd`.
- **Azure** ran `script: './build.cmd …'` in `CmdLine@2` regardless of agent OS.

Both break on Ubuntu/macOS agents. (GitHub Actions — #516's original repro — was already fixed on the 2026 line via `dotnet fallout` in #203/#204, so it needs no change here.)

## Fix
Same shape as the GitHub Actions fix: invoke the cross-platform `fallout` local tool.
- AppVeyor: `dotnet tool restore` + `dotnet fallout <targets>` (emitted under both `- cmd:` and `- sh:` so each image runs the matching pair; command is identical).
- Azure: `script: 'dotnet tool restore && dotnet fallout <targets>'` (`&&` works in cmd and bash; `CmdLine@2` uses the agent's default shell).

No OS branching, no build-script selection.

## Out of scope
- TeamCity and SpaceAutomation already select `.sh` on non-Windows — not broken, left unchanged.
- `BuildCmdPath` stays on the config types (public API) but is no longer consumed by these two writers.

## Verification
Regenerated Verify snapshots; `ConfigurationGenerationSpecs` 18/18 green.