### PR TITLE
Add a cleanup step for bootstrapper files to remove stale `NUKE_ENTERPRISE_TOKEN` handling

### DIFF
--- a/docs/migration/from-nuke.md
+++ b/docs/migration/from-nuke.md
@@ -66,8 +66,9 @@ If your build had previously worked against NUKE, it should now work against Fal
 | Fully-qualified type refs | `Nuke.Common.AbsolutePath` | `Fallout.Common.AbsolutePath` |
 | Base class name | `: NukeBuild` | `: FalloutBuild` |
 | Base interface name | `: INukeBuild` | `: IFalloutBuild` |
-| MSBuild properties in `_build.csproj` | `<NukeRootDirectory>` | `<FalloutRootDirectory>` |
-| Bootstrap scripts | `dotnet nuke`, `.nuke/temp` | `dotnet fallout`, `.fallout/temp` |
+| MSBuild properties in `_build.csproj` | `<NukeRootDirectory>`, `<NukeTelemetryVersion>` | `<FalloutRootDirectory>`, `<FalloutTelemetryVersion>` |
+| Bootstrap scripts | `dotnet nuke`, `NUKE_TELEMETRY_OPTOUT`, `.nuke/temp` | `dotnet fallout`, `FALLOUT_TELEMETRY_OPTOUT`, `.fallout/temp` |
+| Removes stale Nuke Enterprise NuGet source | The whole env var check for `NUKE_ENTERPRISE_TOKEN` and its handling | The bootstrapper files (`build.sh` and `build.ps1`) without these `if`'s |
 | Telemetry knobs (removed) | `<NukeTelemetryVersion>`, `NUKE_TELEMETRY_OPTOUT` | *dropped* — Fallout has no telemetry ([ADR-0010](../adr/0010-no-telemetry-collection.md)); `fallout migrate` strips them |
 | Config directory | `.nuke/` | `.fallout/` (contents preserved) |
 

--- a/src/Fallout.Migrate/Migration.cs
+++ b/src/Fallout.Migrate/Migration.cs
@@ -30,6 +30,7 @@ internal sealed class Migration(AbsolutePath rootDirectory, bool dryRun, TextWri
         new BumpDotNetVersionStep(),
         new RewriteCsFilesStep(),
         new RewriteBootstrapScriptsStep(),
+        new CleanupBootstrapScriptsStep(),
         new RenameNukeDirectoryStep()
     ];
 

--- a/src/Fallout.Migrate/Steps/CleanupBootstrapScriptsStep.cs
+++ b/src/Fallout.Migrate/Steps/CleanupBootstrapScriptsStep.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Fallout.Common.IO;
+using Fallout.Migrate.Common;
+
+namespace Fallout.Migrate.Steps;
+
+/// <summary>
+/// This migration step cleans up bootstrap scripts by removing unnecessary code.
+/// The unnecessary code includes checks for a specific environment variable and related logic.
+/// </summary>
+internal partial class CleanupBootstrapScriptsStep : IMigrationStep
+{
+    public Task ExecuteAsync(MigrationContext context, Summary summary)
+    {
+        foreach (var file in new[]
+                 {
+                     "build.sh",
+                     "build.ps1"
+                 })
+        {
+            var path = context.RootDirectory / file;
+            if (path.FileExists())
+            {
+                MigrationFileOperations.ApplyRewrite(context, path, Cleanup, summary);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static RewriteResult Cleanup(string content)
+    {
+        var envVarToCheck = "NUKE_ENTERPRISE_TOKEN";
+        if (!content.Contains(envVarToCheck))
+        {
+            return new(content, 0);
+        }
+
+        // This is just to preserve the current line ending the user has for this files
+        string newline =
+            GetLineFeedRegex().Match(content).Value is { Length: > 0 } value
+                ? value
+                : Environment.NewLine;
+
+        var lines = GetLineFeedRegex().Split(content).ToList();
+
+        // here, we get the index of the line that contains the environment variable check
+        var indexOfEnterpriseEnvVarCheck = lines.FindIndex(line => line.Contains(envVarToCheck));
+        
+        // here, we get the index of the line that ends the if block
+        // which is fi on bash and a simple "}" in powershell
+        var endOfIfBlock = lines.FindIndex(indexOfEnterpriseEnvVarCheck,
+            line => line.Trim() == "}" || line.Trim() == "fi");
+
+        // this is "just" to remove the empty line after the if block
+        if (lines.Count > endOfIfBlock + 1 && lines[endOfIfBlock + 1].Trim() == "")
+        {
+            endOfIfBlock++;
+        }
+
+        lines.RemoveRange(indexOfEnterpriseEnvVarCheck, endOfIfBlock - indexOfEnterpriseEnvVarCheck + 1);
+
+        return new(string.Join(newline, lines), 1);
+    }
+
+    [GeneratedRegex(@"\r\n|\n|\r")]
+    private static partial Regex GetLineFeedRegex();
+}

--- a/tests/Fallout.Migrate.Specs/MigrationIntegrationSpecs.cs
+++ b/tests/Fallout.Migrate.Specs/MigrationIntegrationSpecs.cs
@@ -88,6 +88,7 @@ public class MigrationIntegrationSpecs : IDisposable
         buildSh.Should().Contain("dotnet fallout");
         buildSh.Should().NotContain("TELEMETRY_OPTOUT"); // telemetry removed — opt-out stripped, not renamed (ADR-0010)
         buildSh.Should().Contain(".fallout/temp");
+        buildSh.Should().NotContain("if [[ ! -z ${NUKE_ENTERPRISE_TOKEN+x} && \"$NUKE_ENTERPRISE_TOKEN\" != \"\" ]]; then");
 
         // .nuke/ moved to .fallout/.
         (tempDirectory / ".nuke").DirectoryExists().Should().BeFalse();

--- a/tests/Fallout.Migrate.Specs/ScriptRewriterSpecs.cs
+++ b/tests/Fallout.Migrate.Specs/ScriptRewriterSpecs.cs
@@ -1,3 +1,7 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Fallout.Migrate.Common;
 using FluentAssertions;
 using Xunit;
 using Fallout.Migrate.Steps;
@@ -65,4 +69,123 @@ public class ScriptRewriterSpecs
         var result = ScriptRewriter.Rewrite(input);
         result.EditCount.Should().Be(0);
     }
+
+    [Fact]
+    public async Task Removes_Nuke_enterprise_unix_bootstrapper_leftovers()
+    {
+        var filename = "build.sh";
+        var dir = CreateBootstrapScript(filename, """
+                                                  echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+                                                  if [[ ! -z ${NUKE_ENTERPRISE_TOKEN+x} && "$NUKE_ENTERPRISE_TOKEN" != "" ]]; then
+                                                      "$DOTNET_EXE" nuget remove source "nuke-enterprise" &>/dev/null || true
+                                                      "$DOTNET_EXE" nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password "$NUKE_ENTERPRISE_TOKEN" --store-password-in-clear-text &>/dev/null || true
+                                                  fi
+
+                                                  "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+                                                  "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"
+                                                  """);
+
+        Summary summary = await ExecuteMigrationStep(dir);
+
+        var buildSh = await File.ReadAllTextAsync(Path.Combine(dir, filename));
+        summary.EditCount.Should().Be(1);
+        buildSh.Should().Be(
+            """
+            echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+            "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+            "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"
+            """);
+    }
+
+    [Fact]
+    public async Task Does_not_throw_when_Nuke_enterprise_check_is_last_in_file()
+    {
+        var filename = "build.sh";
+        var dir = CreateBootstrapScript(filename,"""
+                                                 if [[ ! -z ${NUKE_ENTERPRISE_TOKEN+x} && "$NUKE_ENTERPRISE_TOKEN" != "" ]]; then
+                                                     "$DOTNET_EXE" nuget remove source "nuke-enterprise" &>/dev/null || true
+                                                     "$DOTNET_EXE" nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password "$NUKE_ENTERPRISE_TOKEN" --store-password-in-clear-text &>/dev/null || true
+                                                 fi
+                                                 """);
+
+        Summary summary = await ExecuteMigrationStep(dir);
+
+        var buildSh = await File.ReadAllTextAsync(Path.Combine(dir, filename));
+        summary.EditCount.Should().Be(1);
+        buildSh.Should().Be("");
+    }
+
+    [Fact]
+    public async Task Removes_Nuke_enterprise_windows_bootstrapper_leftovers()
+    {
+        var filename = "build.ps1";
+        var dir = CreateBootstrapScript(filename,"""
+                                                 Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
+
+                                                 if (Test-Path env:NUKE_ENTERPRISE_TOKEN) {
+                                                     & $env:DOTNET_EXE nuget remove source "nuke-enterprise" > $null
+                                                     & $env:DOTNET_EXE nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password $env:NUKE_ENTERPRISE_TOKEN > $null
+                                                 }
+
+                                                 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
+                                                 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }
+                                                 """);
+
+        Summary summary = await ExecuteMigrationStep(dir);
+
+        var buildPs1 = await File.ReadAllTextAsync(Path.Combine(dir, filename));
+        summary.EditCount.Should().Be(1);
+        buildPs1.Should().Be(
+            """
+            Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
+
+            ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
+            ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }
+            """);
+    }
+
+    [Fact]
+    public async Task Leaves_bootstrapper_scripts_without_leftovers_alone()
+    {
+        var filename = "build.sh";
+        var dir = CreateBootstrapScript(filename,"""
+                                                 echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+                                                 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+                                                 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"
+                                                 """);
+
+        Summary summary = await ExecuteMigrationStep(dir);
+
+        var buildSh = await File.ReadAllTextAsync(Path.Combine(dir, filename));
+        summary.EditCount.Should().Be(0);
+        buildSh.Should().Be(
+            """
+            echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+            "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+            "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"
+            """);
+    }
+
+    private string CreateBootstrapScript(string bootstrapFile, string bootstrapFileConent)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "fallout-migrate-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+
+        File.WriteAllText(Path.Combine(dir, bootstrapFile), bootstrapFileConent);
+
+        return dir;
+    }
+
+    private static async Task<Summary> ExecuteMigrationStep(string dir)
+    {
+        var step = new CleanupBootstrapScriptsStep();
+        var summary = new Summary();
+        await step.ExecuteAsync(new MigrationContext(dir, false, TextWriter.Null), summary);
+        return summary;
+    }
+
 }


### PR DESCRIPTION
Closes: #518 

Add a small cleanup step, which removes stale env var check for the `NUKE_ENTERPRISE_TOKEN` variable, which in return adds a special nuget source (which at best is stale and at worst non-existent).

- Added direct cleanup tests
- Additional MigrationsIntegrationTests
<!-- Keep it terse: one-line summary, then short "what changed" bullets. -->
<!-- Link the issue and summarize it — don't recite it. See docs/agents/issue-and-pr-style.md. -->
<!-- Or let Copilot draft one, then trim it. -->

<!-- This repo merges via rebase only (linear history). Curate your commits into a -->
<!-- clean sequence before final approval — see CONTRIBUTING.md → Merging. -->
