### PR TITLE
Recognize release/vMAJOR.MINOR branches in the release pipeline

### DIFF
--- a/.github/workflows/publish-packages-release.yml
+++ b/.github/workflows/publish-packages-release.yml
@@ -78,9 +78,10 @@ jobs:
         run: |
           set -euo pipefail
           TAG_SHA="${{ github.sha }}"
-          # Match CalVer production lines (release/2026, …) and gitflow support lines
+          # Match CalVer production lines (release/2026, …), legacy-style minor
+          # release lines (release/v10.4, …), and gitflow support lines
           # (support/v10 legacy semver, support/2026 retired years, …).
-          REACHABLE=$(git branch -r --contains "$TAG_SHA" | grep -E 'origin/(release/[0-9]{4}|support/(v[0-9]+|[0-9]{4}))' || true)
+          REACHABLE=$(git branch -r --contains "$TAG_SHA" | grep -E 'origin/(release/(v[0-9]+\.[0-9]+|[0-9]{4})|support/(v[0-9]+|[0-9]{4}))' || true)
           if [ -z "$REACHABLE" ]; then
             echo "::error::Tag ${GITHUB_REF_NAME} at $TAG_SHA is not reachable from any production branch."
             echo "Tag-triggered releases only fire from release/YYYY (production) or support/* (legacy/retired) branches."

--- a/version.json
+++ b/version.json
@@ -3,6 +3,7 @@
   "version": "10.0.0-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/release/\\d{4}$",
+    "^refs/heads/release/v\\d+\\.\\d+$",
     "^refs/heads/support/\\d{4}$",
     "^refs/heads/support/v\\d+$"
   ],


### PR DESCRIPTION
Cutting a legacy-style minor release line (`release/v10.4`) from `main` currently can't publish — the pipeline only knows CalVer `release/YYYY` and `support/*`. Two gates reject it:

- **`validate-ref`** (`publish-packages-release.yml`) matched only `release/[0-9]{4}` / `support/*`, so a `v*` tag on `release/v10.4` fails the reachability check and every downstream publish job is skipped.
- **`publicReleaseRefSpec`** (`version.json`) didn't match `release/vN.N`, so NB.GV treated the branch as non-public and git-sha-suffixed the version instead of a clean `-rc.N`.

This teaches both the `release/v\d+\.\d+` shape. `release/v11` (no minor) stays excluded — retired lines don't publish.

## Context
Surfaced while cutting `v10.4.0-rc.1` (`release/v10.4`). rc.1 was published via `workflow_dispatch` (which skips `validate-ref`); this makes normal tag-pushes (rc.2, GA) on the line self-sufficient.

## Note
The branching docs (`docs/branching-and-release.md`, `docs/agents/release-and-versioning.md`) describe a **CalVer-only** production model. A `release/v10.x` line is a deliberate divergence — a docs/ADR reconciliation is a worthwhile follow-up, out of scope here.