### PR TITLE
Make git-repository specs robust to a detached HEAD

### DIFF
--- a/tests/Fallout.Build.Specs/GitRepositoryWorktreeSpecs.cs
+++ b/tests/Fallout.Build.Specs/GitRepositoryWorktreeSpecs.cs
@@ -16,8 +16,7 @@ public class GitRepositoryWorktreeSpecs
     {
         var tempDir = GetTemporaryDirectory();
         const string worktreeName = "test-worktree";
-        var branchName = GitRepository.FromLocalDirectory(Directory.GetCurrentDirectory()).Branch;
-        var worktreePath = CreateWorktree(tempDir, worktreeName, branchName);
+        var worktreePath = CreateWorktree(tempDir, worktreeName);
 
         try
         {
@@ -25,7 +24,7 @@ public class GitRepositoryWorktreeSpecs
             var mainRepository = GitRepository.FromLocalDirectory(Directory.GetCurrentDirectory());
 
             AssertWorktreeRepository(repository, mainRepository, worktreePath);
-            repository.Branch.Should().StartWith($"{branchName}-test-"); // Verify branch name resolution
+            repository.Branch.Should().StartWith(WorktreeBranchPrefix); // Verify branch name resolution
         }
         finally
         {
@@ -39,8 +38,7 @@ public class GitRepositoryWorktreeSpecs
     {
         var tempDir = GetTemporaryDirectory();
         const string worktreeName = "nested-worktree";
-        var branchName = GitRepository.FromLocalDirectory(Directory.GetCurrentDirectory()).Branch;
-        var worktreePath = CreateWorktree(tempDir, worktreeName, branchName);
+        var worktreePath = CreateWorktree(tempDir, worktreeName);
         var nestedPath = worktreePath / "nested" / "deeply" / "nested";
         nestedPath.CreateDirectory();
 
@@ -63,8 +61,7 @@ public class GitRepositoryWorktreeSpecs
     {
         var tempDir = GetTemporaryDirectory();
         const string worktreeName = "detached-head-worktree";
-        var branchName = GitRepository.FromLocalDirectory(Directory.GetCurrentDirectory()).Branch;
-        var worktreePath = CreateWorktree(tempDir, worktreeName, branchName);
+        var worktreePath = CreateWorktree(tempDir, worktreeName);
 
         try
         {
@@ -151,13 +148,18 @@ public class GitRepositoryWorktreeSpecs
         return tempDir;
     }
 
-    private static AbsolutePath CreateWorktree(AbsolutePath tempDir, string worktreeName, string branchName)
+    private const string WorktreeBranchPrefix = "worktree-test-";
+
+    private static AbsolutePath CreateWorktree(AbsolutePath tempDir, string worktreeName)
     {
         var worktreePath = tempDir / worktreeName;
-        var uniqueBranchName = $"{branchName}-test-{Guid.NewGuid().ToString("N")[..8]}";
+        var uniqueBranchName = $"{WorktreeBranchPrefix}{Guid.NewGuid().ToString("N")[..8]}";
 
-        // Create a new branch from the specified branch and checkout in worktree
-        ProcessTasks.StartProcess("git", $"worktree add -b {uniqueBranchName} {worktreePath} {branchName}", workingDirectory: Directory.GetCurrentDirectory())
+        // Base the new branch on HEAD, which resolves whether or not the ambient checkout is
+        // on a named branch. A tag-triggered release build checks out a detached HEAD, where
+        // GitRepository.Branch is null; deriving the base ref from it previously produced an
+        // invalid `git worktree add` invocation and failed the release pack.
+        ProcessTasks.StartProcess("git", $"worktree add -b {uniqueBranchName} {worktreePath} HEAD", workingDirectory: Directory.GetCurrentDirectory())
             .AssertZeroExitCode();
 
         return worktreePath;

--- a/tests/Fallout.Common.Specs/GitHubTasksSpecs.cs
+++ b/tests/Fallout.Common.Specs/GitHubTasksSpecs.cs
@@ -19,6 +19,12 @@ public class GitHubTasksSpecs
         if (!repository.IsGitHubRepository())
             return;
 
+        // The URL helpers below are branch-based (GetGitHubDownloadUrl asserts Branch != null).
+        // A tag-triggered release build checks out a detached HEAD, which has no branch, so
+        // there is nothing meaningful to assert here.
+        if (repository.Branch is null)
+            return;
+
         var rawUrl = $"https://raw.githubusercontent.com/{repository.Identifier}/{repository.Branch}";
         var blobUrl = $"https://github.com/{repository.Identifier}/blob/{repository.Branch}";
         var treeUrl = $"https://github.com/{repository.Identifier}/tree/{repository.Branch}";


### PR DESCRIPTION
The first real tag-triggered release (`v10.4.0-rc.1`) failed the pack step: 4 git specs assume the ambient checkout is on a **named branch**, but a release build checks out a **tag → detached HEAD**, where `GitRepository.Branch` is `null`.

## Root cause
- **`GitRepositoryWorktreeSpecs`** (3 tests) derived the worktree base ref from `.Branch`. Null → `git worktree add -b … <empty>` → `fatal: invalid reference` → `AssertZeroExitCode` throws.
- **`GitHubTasksSpecs.GitHubRepositoryFromLocalDirectorySpec`** builds branch-based URLs; `GetGitHubDownloadUrl` does `branch ??= repository.Branch.NotNull(...)`, which throws on a null branch.

Product code is correct — the detached-HEAD spec itself asserts `Branch` *should* be null. The tests just never accounted for running detached.

## Fix
- Base the worktree on `HEAD` (resolves attached or detached); name the new branch from a fixed prefix.
- Guard the URL spec for a null branch and return early, mirroring its existing non-GitHub early-return.

## Verification
- Both pass on a branch (unchanged): worktree specs 5/5, URL spec 1/1.
- Reproduced the failure and the fix against a detached HEAD in a throwaway repo: old base → `fatal: invalid reference`; `HEAD` base → succeeds.