### PR TITLE
Fallout-branded build-graph control PoC (elkjs + React Flow)

### DIFF
--- a/poc/graph-control/.gitignore
+++ b/poc/graph-control/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.playwright-mcp/
+*.local

--- a/poc/graph-control/.gitignore
+++ b/poc/graph-control/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
+dist-lib/
 .playwright-mcp/
 *.local

--- a/poc/graph-control/README.md
+++ b/poc/graph-control/README.md
@@ -17,7 +17,20 @@ npm install
 npm run dev        # dev server, hot reload — opens the demo fixture
 npm run build      # → dist/index.html, a single self-contained file you can double-click
 npm run build:lib  # → dist-lib/fallout-graph-control.js, an IIFE for host embedding
+npm run report     # → dist-lib/report.html, a self-contained static build-graph report
 ```
+
+## Static HTML report
+
+`npm run report [build-graph.json] [out.html]` emits one self-contained HTML file
+(the control's IIFE and the graph JSON inlined) — double-clickable, offline, no
+server. This is the shape the `fallout` `--plan` HTML report will take. With no
+graph path a small sample is used.
+
+**Dark by default** (`data-theme="dark"` is pinned), with a toggle that remembers
+the viewer's choice in `localStorage` — a shared report stays dark regardless of
+the viewer's OS, but can be flipped to light. In the VS Code webview the control
+instead follows the editor theme (no pin), and no toggle is shown.
 
 ## Embedding in a host (webview / HTML report)
 

--- a/poc/graph-control/README.md
+++ b/poc/graph-control/README.md
@@ -1,0 +1,36 @@
+# @fallout/graph-control (PoC)
+
+Fallout-branded build/run graph control. Not a GitHub clone — its own dark,
+radioactive-amber identity, built to become the run-graph control for the VS
+Code extension, the `--plan` HTML report, and eventually the Fallout CI platform.
+
+**Stack:** [elkjs](https://github.com/kieler/elkjs) (layered layout) +
+[React Flow](https://reactflow.dev) (`@xyflow/react`, interaction/pan/zoom).
+Layout and render are deliberately separate layers — the layout is
+surface-independent, the renderer is swappable.
+
+## Run it
+
+```bash
+cd poc/graph-control
+npm install
+npm run dev        # dev server, hot reload — opens the demo fixture
+npm run build      # → dist/index.html, a single self-contained file you can double-click
+```
+
+## How it maps to Fallout
+
+- Data model mirrors `build-graph.json` (see `src/model.ts` ↔
+  `poc/vscode-fallout/src/model.ts` and `SerializeBuildGraphAttribute.cs`).
+- Edge semantics match the Mermaid/`--plan` output: solid = `dependsOn`,
+  dashed = `after`, thick = `triggers`.
+- A host injects a real graph via `window.__FALLOUT_GRAPH__`; otherwise the
+  bundled demo fixture renders.
+- `status` on a target (`queued`/`running`/`succeeded`/`failed`/`skipped`) is
+  **reserved for the live/CI phase** and absent from schema v1.
+
+## Phases
+
+1. **This PoC** — layout + brand look, static, standalone HTML. ✅
+2. Wire into the VS Code extension (replace Mermaid) + emit the static HTML report.
+3. Live: `BuildManager` streams per-target status → the control animates the run.

--- a/poc/graph-control/README.md
+++ b/poc/graph-control/README.md
@@ -16,7 +16,23 @@ cd poc/graph-control
 npm install
 npm run dev        # dev server, hot reload — opens the demo fixture
 npm run build      # → dist/index.html, a single self-contained file you can double-click
+npm run build:lib  # → dist-lib/fallout-graph-control.js, an IIFE for host embedding
 ```
+
+## Embedding in a host (webview / HTML report)
+
+`build:lib` emits one self-contained IIFE (React + React Flow + elkjs bundled,
+CSS injected at runtime) exposing a global. Load it as a single `<script>` and:
+
+```js
+FalloutGraph.mount(document.getElementById('graph'), buildGraph, {
+    onRunTarget: (name) => { /* host decides what "run" means */ },
+});
+```
+
+Re-calling `mount` on the same element reconciles in place — that's how the VS
+Code extension does its live refresh. The runtime `<style>` injection needs
+`style-src 'unsafe-inline'` in the host's CSP.
 
 ## How it maps to Fallout
 

--- a/poc/graph-control/index.html
+++ b/poc/graph-control/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Fallout — Build Graph</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
+</html>

--- a/poc/graph-control/package-lock.json
+++ b/poc/graph-control/package-lock.json
@@ -1,0 +1,2195 @@
+{
+    "name": "@fallout/graph-control",
+    "version": "0.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@fallout/graph-control",
+            "version": "0.0.0",
+            "dependencies": {
+                "@xyflow/react": "^12.3.5",
+                "elkjs": "^0.9.3",
+                "react": "^18.3.1",
+                "react-dom": "^18.3.1"
+            },
+            "devDependencies": {
+                "@types/react": "^18.3.12",
+                "@types/react-dom": "^18.3.1",
+                "@vitejs/plugin-react": "^4.3.4",
+                "typescript": "^5.9.3",
+                "vite": "^6.0.7",
+                "vite-plugin-singlefile": "^2.1.0"
+            }
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/compat-data": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/remapping": "^2.3.5",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/generator": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+            "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/gen-mapping": "^0.3.12",
+                "@jridgewell/trace-mapping": "^0.3.28",
+                "jsesc": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "browserslist": "^4.24.0",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-globals": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-transforms": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-plugin-utils": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+            "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-string-parser": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-option": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/parser": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.29.7"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-react-jsx-self": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+            "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-react-jsx-source": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+            "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/template": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/traverse": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+            "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "debug": "^4.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/types": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-beta.27",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+            "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+            "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+            "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+            "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+            "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+            "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+            "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+            "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+            "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+            "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+            "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+            "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+            "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+            "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+            "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+            "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+            "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+            "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+            "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+            "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+            "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+            "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+            "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+            "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+            "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+            "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@types/babel__core": {
+            "version": "7.20.5",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.20.7",
+                "@babel/types": "^7.20.7",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
+            }
+        },
+        "node_modules/@types/babel__generator": {
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+            "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__template": {
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "node_modules/@types/babel__traverse": {
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+            "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.28.2"
+            }
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-drag": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+            "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-selection": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+            "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-transition": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+            "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/d3-zoom": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+            "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-interpolate": "*",
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.15",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+            "devOptional": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/react": {
+            "version": "18.3.31",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+            "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "csstype": "^3.2.2"
+            }
+        },
+        "node_modules/@types/react-dom": {
+            "version": "18.3.7",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+            "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+            "devOptional": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^18.0.0"
+            }
+        },
+        "node_modules/@vitejs/plugin-react": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+            "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.28.0",
+                "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+                "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+                "@rolldown/pluginutils": "1.0.0-beta.27",
+                "@types/babel__core": "^7.20.5",
+                "react-refresh": "^0.17.0"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+            }
+        },
+        "node_modules/@xyflow/react": {
+            "version": "12.11.2",
+            "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
+            "integrity": "sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==",
+            "license": "MIT",
+            "dependencies": {
+                "@xyflow/system": "0.0.79",
+                "classcat": "^5.0.3",
+                "zustand": "^4.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": ">=17",
+                "@types/react-dom": ">=17",
+                "react": ">=17",
+                "react-dom": ">=17"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@xyflow/system": {
+            "version": "0.0.79",
+            "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.79.tgz",
+            "integrity": "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-drag": "^3.0.7",
+                "@types/d3-interpolate": "^3.0.4",
+                "@types/d3-selection": "^3.0.10",
+                "@types/d3-transition": "^3.0.8",
+                "@types/d3-zoom": "^3.0.8",
+                "d3-drag": "^3.0.0",
+                "d3-interpolate": "^3.0.1",
+                "d3-selection": "^3.0.0",
+                "d3-zoom": "^3.0.0"
+            }
+        },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.10.44",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.44.tgz",
+            "integrity": "sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/browserslist": {
+            "version": "4.28.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+            "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "baseline-browser-mapping": "^2.10.42",
+                "caniuse-lite": "^1.0.30001803",
+                "electron-to-chromium": "^1.5.389",
+                "node-releases": "^2.0.51",
+                "update-browserslist-db": "^1.2.3"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
+        "node_modules/caniuse-lite": {
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "CC-BY-4.0"
+        },
+        "node_modules/classcat": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+            "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+            "license": "MIT"
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "devOptional": true,
+            "license": "MIT"
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-dispatch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-drag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-selection": "3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-selection": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-transition": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3",
+                "d3-dispatch": "1 - 3",
+                "d3-ease": "1 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-timer": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "d3-selection": "2 - 3"
+            }
+        },
+        "node_modules/d3-zoom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "2 - 3",
+                "d3-transition": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/electron-to-chromium": {
+            "version": "1.5.393",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+            "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/elkjs": {
+            "version": "0.9.3",
+            "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
+            "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+            "license": "EPL-2.0"
+        },
+        "node_modules/esbuild": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.25.12",
+                "@esbuild/android-arm": "0.25.12",
+                "@esbuild/android-arm64": "0.25.12",
+                "@esbuild/android-x64": "0.25.12",
+                "@esbuild/darwin-arm64": "0.25.12",
+                "@esbuild/darwin-x64": "0.25.12",
+                "@esbuild/freebsd-arm64": "0.25.12",
+                "@esbuild/freebsd-x64": "0.25.12",
+                "@esbuild/linux-arm": "0.25.12",
+                "@esbuild/linux-arm64": "0.25.12",
+                "@esbuild/linux-ia32": "0.25.12",
+                "@esbuild/linux-loong64": "0.25.12",
+                "@esbuild/linux-mips64el": "0.25.12",
+                "@esbuild/linux-ppc64": "0.25.12",
+                "@esbuild/linux-riscv64": "0.25.12",
+                "@esbuild/linux-s390x": "0.25.12",
+                "@esbuild/linux-x64": "0.25.12",
+                "@esbuild/netbsd-arm64": "0.25.12",
+                "@esbuild/netbsd-x64": "0.25.12",
+                "@esbuild/openbsd-arm64": "0.25.12",
+                "@esbuild/openbsd-x64": "0.25.12",
+                "@esbuild/openharmony-arm64": "0.25.12",
+                "@esbuild/sunos-x64": "0.25.12",
+                "@esbuild/win32-arm64": "0.25.12",
+                "@esbuild/win32-ia32": "0.25.12",
+                "@esbuild/win32-x64": "0.25.12"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "license": "MIT"
+        },
+        "node_modules/jsesc": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
+        },
+        "node_modules/micromatch/node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/node-releases": {
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.20",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+            "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.16",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/react": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "scheduler": "^0.23.2"
+            },
+            "peerDependencies": {
+                "react": "^18.3.1"
+            }
+        },
+        "node_modules/react-refresh": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+            "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "4.62.2",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+            "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.9"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.62.2",
+                "@rollup/rollup-android-arm64": "4.62.2",
+                "@rollup/rollup-darwin-arm64": "4.62.2",
+                "@rollup/rollup-darwin-x64": "4.62.2",
+                "@rollup/rollup-freebsd-arm64": "4.62.2",
+                "@rollup/rollup-freebsd-x64": "4.62.2",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+                "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+                "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+                "@rollup/rollup-linux-arm64-musl": "4.62.2",
+                "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+                "@rollup/rollup-linux-loong64-musl": "4.62.2",
+                "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+                "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+                "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+                "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+                "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+                "@rollup/rollup-linux-x64-gnu": "4.62.2",
+                "@rollup/rollup-linux-x64-musl": "4.62.2",
+                "@rollup/rollup-openbsd-x64": "4.62.2",
+                "@rollup/rollup-openharmony-arm64": "4.62.2",
+                "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+                "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+                "@rollup/rollup-win32-x64-gnu": "4.62.2",
+                "@rollup/rollup-win32-x64-msvc": "4.62.2",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/scheduler": {
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            }
+        },
+        "node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/update-browserslist-db": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/vite": {
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.25.0",
+                "fdir": "^6.4.4",
+                "picomatch": "^4.0.2",
+                "postcss": "^8.5.3",
+                "rollup": "^4.34.9",
+                "tinyglobby": "^0.2.13"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "jiti": ">=1.21.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-plugin-singlefile": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.3.3.tgz",
+            "integrity": "sha512-XVnGH0QzbOa8fxRSsHdCarVN1BSBXNi7uLMQYlrGRN5apdHkk62XQWRJhVever0lnfuyBkwn+kvVChdm/OoOUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "micromatch": "^4.0.8"
+            },
+            "engines": {
+                "node": ">18.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^4.59.0",
+                "vite": "^5.4.21 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/zustand": {
+            "version": "4.5.7",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+            "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+            "license": "MIT",
+            "dependencies": {
+                "use-sync-external-store": "^1.2.2"
+            },
+            "engines": {
+                "node": ">=12.7.0"
+            },
+            "peerDependencies": {
+                "@types/react": ">=16.8",
+                "immer": ">=9.0.6",
+                "react": ">=16.8"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "immer": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                }
+            }
+        }
+    }
+}

--- a/poc/graph-control/package-lock.json
+++ b/poc/graph-control/package-lock.json
@@ -19,6 +19,7 @@
                 "@vitejs/plugin-react": "^4.3.4",
                 "typescript": "^5.9.3",
                 "vite": "^6.0.7",
+                "vite-plugin-css-injected-by-js": "^3.5.2",
                 "vite-plugin-singlefile": "^2.1.0"
             }
         },
@@ -2132,6 +2133,16 @@
                 "yaml": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vite-plugin-css-injected-by-js": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-3.5.2.tgz",
+            "integrity": "sha512-2MpU/Y+SCZyWUB6ua3HbJCrgnF0KACAsmzOQt1UvRVJCGF6S8xdA3ZUhWcWdM9ivG4I5az8PnQmwwrkC2CAQrQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "vite": ">2.0.0-0"
             }
         },
         "node_modules/vite-plugin-singlefile": {

--- a/poc/graph-control/package.json
+++ b/poc/graph-control/package.json
@@ -8,6 +8,7 @@
         "dev": "vite",
         "build": "vite build",
         "build:lib": "vite build --config vite.lib.config.ts",
+        "report": "node scripts/report.mjs",
         "preview": "vite preview"
     },
     "dependencies": {

--- a/poc/graph-control/package.json
+++ b/poc/graph-control/package.json
@@ -7,6 +7,7 @@
     "scripts": {
         "dev": "vite",
         "build": "vite build",
+        "build:lib": "vite build --config vite.lib.config.ts",
         "preview": "vite preview"
     },
     "dependencies": {
@@ -21,6 +22,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "typescript": "^5.9.3",
         "vite": "^6.0.7",
+        "vite-plugin-css-injected-by-js": "^3.5.2",
         "vite-plugin-singlefile": "^2.1.0"
     }
 }

--- a/poc/graph-control/package.json
+++ b/poc/graph-control/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@fallout/graph-control",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "description": "Fallout-branded build/run graph control (elkjs layout + React Flow). PoC for the VS Code extension, the --plan HTML report, and the future Fallout CI run graph.",
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "preview": "vite preview"
+    },
+    "dependencies": {
+        "@xyflow/react": "^12.3.5",
+        "elkjs": "^0.9.3",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+    },
+    "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^5.9.3",
+        "vite": "^6.0.7",
+        "vite-plugin-singlefile": "^2.1.0"
+    }
+}

--- a/poc/graph-control/scripts/report.mjs
+++ b/poc/graph-control/scripts/report.mjs
@@ -1,0 +1,98 @@
+// Emits a self-contained static HTML build-graph report: the control's IIFE and
+// the graph JSON are inlined into one file — double-clickable, offline, no server.
+// This is the shape the `fallout` --plan HTML report will take.
+//
+//   node scripts/report.mjs [build-graph.json] [out.html]
+//
+// With no graph path a small sample is used, so `npm run report` works out of the
+// box. Dark by default (data-theme="dark"), with a toggle that remembers the
+// viewer's choice — a shared report stays dark regardless of the viewer's OS.
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+const bundle = join(root, 'dist-lib', 'fallout-graph-control.js');
+
+const graphArg = process.argv[2];
+const outArg = process.argv[3] ?? join(root, 'dist-lib', 'report.html');
+
+// Ensure the library bundle exists (build it once if missing).
+if (!existsSync(bundle)) {
+    console.log('[report] building library bundle…');
+    execSync('npm run build:lib', { cwd: root, stdio: 'inherit' });
+}
+
+const sample = {
+    version: 1,
+    falloutVersion: '2026.1.0-preview.412.g8f3a1c',
+    targets: [
+        { name: 'Restore', description: 'dotnet restore', default: false, listed: true, dependsOn: [], after: ['Clean'], triggeredBy: [], triggers: [] },
+        { name: 'Clean', description: 'Wipe artifacts', default: false, listed: false, dependsOn: [], after: [], triggeredBy: [], triggers: [] },
+        { name: 'Compile', description: 'Build all projects', default: false, listed: true, dependsOn: ['Restore'], after: [], triggeredBy: [], triggers: [] },
+        { name: 'Test', description: 'xUnit suite', default: false, listed: true, dependsOn: ['Compile'], after: [], triggeredBy: [], triggers: [] },
+        { name: 'Pack', description: 'NuGet pack (default)', default: true, listed: true, dependsOn: ['Compile'], after: [], triggeredBy: [], triggers: ['Canary'] },
+        { name: 'Canary', description: 'Smoke-test the package', default: false, listed: true, dependsOn: [], after: [], triggeredBy: ['Pack'], triggers: [] },
+    ],
+};
+
+const graph = graphArg ? JSON.parse(readFileSync(resolve(graphArg), 'utf8')) : sample;
+const bundleJs = readFileSync(bundle, 'utf8');
+
+// JSON is embedded as a JS value; escape </script> so a target name can't break out.
+const graphLiteral = JSON.stringify(graph).replace(/<\/script>/gi, '<\\/script>');
+
+const html = `<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Fallout — Build Graph Report</title>
+<style>
+    html, body { height: 100%; margin: 0; padding: 0; }
+    #graph { height: 100vh; }
+    /* keep the header's target count clear of the fixed toggle button.
+       Higher specificity than the control's own .graph-header rule, which is
+       injected at runtime (after this <style>) and would otherwise win. */
+    .fallout-graph .graph-header { padding-right: 56px; }
+    #theme-toggle {
+        position: fixed; top: 12px; right: 14px; z-index: 10;
+        width: 30px; height: 30px; border-radius: 8px; cursor: pointer;
+        display: grid; place-items: center; font-size: 15px; line-height: 1;
+        background: var(--surface-raised); color: var(--text);
+        border: 1px solid var(--border);
+    }
+    #theme-toggle:hover { border-color: var(--fallout-yellow-line); }
+</style>
+</head>
+<body>
+<div id="graph"></div>
+<button id="theme-toggle" title="Toggle light / dark" aria-label="Toggle light / dark"></button>
+<script>window.__FALLOUT_GRAPH__ = ${graphLiteral};</script>
+<script>${bundleJs}</script>
+<script>
+    FalloutGraph.mount(document.getElementById('graph'), window.__FALLOUT_GRAPH__, {});
+    (function () {
+        var root = document.documentElement, btn = document.getElementById('theme-toggle');
+        function apply(t) {
+            root.dataset.theme = t;
+            btn.textContent = t === 'dark' ? '☀' : '☾';
+            try { localStorage.setItem('fallout-report-theme', t); } catch (e) {}
+        }
+        var saved;
+        try { saved = localStorage.getItem('fallout-report-theme'); } catch (e) {}
+        apply(saved || 'dark');
+        btn.addEventListener('click', function () {
+            apply(root.dataset.theme === 'dark' ? 'light' : 'dark');
+        });
+    })();
+</script>
+</body>
+</html>
+`;
+
+writeFileSync(resolve(outArg), html);
+const kb = Math.round(Buffer.byteLength(html) / 1024);
+console.log(`[report] wrote ${resolve(outArg)} (${kb} KB, self-contained, ${graph.targets.length} targets)`);

--- a/poc/graph-control/src/GraphControl.tsx
+++ b/poc/graph-control/src/GraphControl.tsx
@@ -87,7 +87,7 @@ export function GraphControl({ graph, onRunTarget }: GraphControlProps) {
                 <span><i className="k-depends" /> depends on</span>
                 <span><i className="k-after" /> runs after</span>
                 <span><i className="k-trigger" /> triggers</span>
-                <span className="legend-hint">click a target to run it</span>
+                {onRunTarget && <span className="legend-hint">click a target to run it</span>}
             </div>
         </div>
     );

--- a/poc/graph-control/src/GraphControl.tsx
+++ b/poc/graph-control/src/GraphControl.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+    ReactFlow,
+    Background,
+    BackgroundVariant,
+    Controls,
+    type Edge,
+    type Node,
+    type NodeMouseHandler,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import './control.css';
+import { TargetNode } from './TargetNode';
+import { layoutGraph, type TargetNodeData } from './layout';
+import type { BuildGraph } from './model';
+
+const nodeTypes = { target: TargetNode };
+
+export interface GraphControlProps {
+    graph: BuildGraph;
+    /** Fired when a target card is clicked — the host decides what "run" means. */
+    onRunTarget?: (target: string) => void;
+}
+
+/**
+ * The reusable Fallout graph control. Same component drives the VS Code webview,
+ * the static --plan HTML report, and (later) the live CI run graph — only the
+ * data source and the onRunTarget handler change.
+ */
+export function GraphControl({ graph, onRunTarget }: GraphControlProps) {
+    const [nodes, setNodes] = useState<Node<TargetNodeData>[]>([]);
+    const [edges, setEdges] = useState<Edge[]>([]);
+    const [ready, setReady] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+        setReady(false);
+        void layoutGraph(graph).then((laid) => {
+            if (cancelled) return;
+            setNodes(laid.nodes);
+            setEdges(laid.edges);
+            setReady(true);
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [graph]);
+
+    const onNodeClick = useMemo<NodeMouseHandler>(
+        () => (_event, node) => onRunTarget?.(node.id),
+        [onRunTarget],
+    );
+
+    return (
+        <div className="fallout-graph">
+            <div className="graph-header">
+                <span className="mark" aria-hidden="true">
+                    ☢
+                </span>
+                <span className="graph-title">Build graph</span>
+                {graph.falloutVersion && <span className="graph-version">Fallout {graph.falloutVersion}</span>}
+                <span className="graph-count">{graph.targets.length} targets</span>
+            </div>
+            <div className="graph-canvas">
+                {ready && (
+                    <ReactFlow
+                        nodes={nodes}
+                        edges={edges}
+                        nodeTypes={nodeTypes}
+                        onNodeClick={onNodeClick}
+                        fitView
+                        fitViewOptions={{ padding: 0.2 }}
+                        minZoom={0.2}
+                        maxZoom={2}
+                        proOptions={{ hideAttribution: true }}
+                        nodesDraggable={false}
+                        nodesConnectable={false}
+                        elementsSelectable
+                    >
+                        <Background variant={BackgroundVariant.Dots} gap={22} size={1} className="graph-bg" />
+                        <Controls showInteractive={false} />
+                    </ReactFlow>
+                )}
+            </div>
+            <div className="graph-legend">
+                <span><i className="k-depends" /> depends on</span>
+                <span><i className="k-after" /> runs after</span>
+                <span><i className="k-trigger" /> triggers</span>
+                <span className="legend-hint">click a target to run it</span>
+            </div>
+        </div>
+    );
+}

--- a/poc/graph-control/src/GraphControl.tsx
+++ b/poc/graph-control/src/GraphControl.tsx
@@ -9,6 +9,7 @@ import {
     type NodeMouseHandler,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
+import './theme.css';
 import './control.css';
 import { TargetNode } from './TargetNode';
 import { layoutGraph, type TargetNodeData } from './layout';

--- a/poc/graph-control/src/TargetNode.tsx
+++ b/poc/graph-control/src/TargetNode.tsx
@@ -1,0 +1,48 @@
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
+import type { TargetNodeData } from './layout';
+
+const STATUS_LABEL: Record<string, string> = {
+    queued: 'Queued',
+    running: 'Running',
+    succeeded: 'Succeeded',
+    failed: 'Failed',
+    skipped: 'Skipped',
+};
+
+/**
+ * One build target, rendered as a Fallout-branded card. Not a GitHub clone:
+ * dark radioactive-amber surface, a status rail on the left, connection dots on
+ * the accent border. The default target gets a yellow ring; unlisted targets dim.
+ */
+export function TargetNode({ data }: NodeProps<Node<TargetNodeData>>) {
+    const status = data.status;
+    const classes = [
+        'target-node',
+        data.isDefault ? 'is-default' : '',
+        data.listed ? '' : 'is-unlisted',
+        status ? `status-${status}` : 'status-none',
+    ]
+        .filter(Boolean)
+        .join(' ');
+
+    const subtitle = data.description ?? data.declaredIn;
+
+    return (
+        <div className={classes} title={data.declaredIn ? `${data.label} — ${data.declaredIn}` : data.label}>
+            <Handle type="target" position={Position.Left} className="target-handle" />
+            <span className="status-rail" aria-hidden="true" />
+            <span className={`status-dot ${status ? '' : 'idle'}`} aria-hidden="true">
+                {status === 'running' && <span className="spinner" />}
+            </span>
+            <div className="target-body">
+                <div className="target-name">
+                    {data.label}
+                    {data.isDefault && <span className="default-tag">default</span>}
+                </div>
+                {subtitle && <div className="target-sub">{subtitle}</div>}
+            </div>
+            {status && <span className="status-label">{STATUS_LABEL[status] ?? status}</span>}
+            <Handle type="source" position={Position.Right} className="source-handle" />
+        </div>
+    );
+}

--- a/poc/graph-control/src/control.css
+++ b/poc/graph-control/src/control.css
@@ -1,0 +1,261 @@
+/* Layout chrome + node/edge styling for the Fallout graph control.
+   Brand tokens come from theme.css; this file only shapes the control. */
+
+.fallout-graph {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+}
+
+/* ---- header ---- */
+.graph-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--border);
+}
+.graph-header .mark {
+    color: var(--fallout-yellow);
+    font-size: 18px;
+    line-height: 1;
+    filter: drop-shadow(0 0 6px var(--fallout-yellow-dim));
+}
+.graph-title {
+    font-weight: 600;
+    letter-spacing: 0.01em;
+}
+.graph-version {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-faint);
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+}
+.graph-count {
+    margin-left: auto;
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+/* ---- canvas ---- */
+.graph-canvas {
+    position: relative;
+    flex: 1;
+    min-height: 0;
+}
+.react-flow {
+    background: transparent;
+}
+.graph-bg {
+    color: var(--border);
+}
+
+/* ---- node ---- */
+.target-node {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 248px;
+    padding: 10px 14px 10px 16px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    overflow: hidden;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.1s ease;
+}
+.target-node:hover {
+    border-color: var(--fallout-yellow-line);
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.45);
+    cursor: pointer;
+}
+.target-node.is-default {
+    border-color: var(--fallout-yellow-line);
+    box-shadow: 0 0 0 1px var(--fallout-yellow-dim), 0 0 22px var(--fallout-yellow-dim);
+}
+.target-node.is-unlisted {
+    border-style: dashed;
+    opacity: 0.55;
+}
+
+/* status rail on the left edge */
+.status-rail {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    background: var(--status-queued);
+}
+.status-none .status-rail {
+    background: var(--border);
+}
+.status-running .status-rail {
+    background: var(--status-running);
+}
+.status-succeeded .status-rail {
+    background: var(--status-succeeded);
+}
+.status-failed .status-rail {
+    background: var(--status-failed);
+}
+.status-skipped .status-rail {
+    background: var(--status-skipped);
+}
+.status-queued .status-rail {
+    background: var(--status-queued);
+}
+
+/* status dot / spinner */
+.status-dot {
+    position: relative;
+    flex: 0 0 auto;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 2px solid var(--status-queued);
+}
+.status-dot.idle {
+    border-color: var(--text-faint);
+}
+.status-succeeded .status-dot {
+    border-color: var(--status-succeeded);
+    background: var(--status-succeeded);
+}
+.status-failed .status-dot {
+    border-color: var(--status-failed);
+    background: var(--status-failed);
+}
+.status-running .status-dot {
+    border-color: var(--fallout-yellow-line);
+}
+.status-running .spinner {
+    position: absolute;
+    inset: -2px;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    border-top-color: var(--fallout-yellow);
+    animation: spin 0.8s linear infinite;
+}
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.target-body {
+    min-width: 0;
+    flex: 1;
+}
+.target-name {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.default-tag {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fallout-yellow);
+    background: var(--fallout-yellow-dim);
+    padding: 1px 6px;
+    border-radius: 999px;
+}
+.target-sub {
+    margin-top: 2px;
+    font-size: 11px;
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.status-label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
+/* connection dots — echo the GitHub handle look but on the Fallout accent */
+.react-flow__handle.target-handle,
+.react-flow__handle.source-handle {
+    width: 7px;
+    height: 7px;
+    background: var(--bg-bottom);
+    border: 2px solid var(--fallout-yellow-line);
+}
+
+/* ---- edges ---- */
+.react-flow__edge.edge-dependsOn .react-flow__edge-path {
+    stroke: var(--edge);
+    stroke-width: 1.5;
+}
+.react-flow__edge.edge-after .react-flow__edge-path {
+    stroke: var(--edge);
+    stroke-width: 1.5;
+    stroke-dasharray: 5 4;
+}
+.react-flow__edge.edge-triggers .react-flow__edge-path {
+    stroke: var(--edge-trigger);
+    stroke-width: 2.5;
+}
+
+/* ---- legend ---- */
+.graph-legend {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    padding: 10px 18px;
+    border-top: 1px solid var(--border);
+    font-size: 12px;
+    color: var(--text-muted);
+}
+.graph-legend i {
+    display: inline-block;
+    width: 22px;
+    height: 0;
+    margin-right: 7px;
+    vertical-align: middle;
+}
+.graph-legend .k-depends {
+    border-top: 1.5px solid var(--edge);
+}
+.graph-legend .k-after {
+    border-top: 1.5px dashed var(--edge);
+}
+.graph-legend .k-trigger {
+    border-top: 2.5px solid var(--edge-trigger);
+}
+.legend-hint {
+    margin-left: auto;
+    color: var(--text-faint);
+    font-style: italic;
+}
+
+/* React Flow controls, restyled to the dark brand */
+.react-flow__controls {
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.5);
+    border-radius: 8px;
+    overflow: hidden;
+}
+.react-flow__controls-button {
+    background: var(--surface-raised);
+    border-bottom: 1px solid var(--border);
+    color: var(--text);
+}
+.react-flow__controls-button:hover {
+    background: var(--fallout-yellow-dim);
+}
+.react-flow__controls-button svg {
+    fill: var(--text-muted);
+}

--- a/poc/graph-control/src/fixture.ts
+++ b/poc/graph-control/src/fixture.ts
@@ -1,0 +1,24 @@
+import type { BuildGraph } from './model';
+
+// A representative Fallout build+publish graph. Statuses are included to show
+// the live/CI look — a real static build-graph.json (schema v1) omits them.
+// Structure mirrors the actual pipeline: Restore → Compile → Test/Pack →
+// publish fan-out, plus an `after` order-edge and a `triggers` edge to exercise
+// all three edge styles.
+export const demoGraph: BuildGraph = {
+    version: 1,
+    falloutVersion: '2026.1.0-preview.412.g8f3a1c',
+    targets: [
+        { name: 'Clean', description: 'Wipe artifacts + bin/obj', default: false, listed: true, declaredIn: 'Build.Common', dependsOn: [], after: [], triggeredBy: [], triggers: [], status: 'succeeded' },
+        { name: 'Restore', description: 'dotnet restore fallout.slnx', default: false, listed: true, declaredIn: 'Build.Common', dependsOn: [], after: ['Clean'], triggeredBy: [], triggers: [], status: 'succeeded' },
+        { name: 'Compile', description: 'Build all projects', default: false, listed: true, declaredIn: 'Build.Common', dependsOn: ['Restore'], after: [], triggeredBy: [], triggers: [], status: 'succeeded' },
+        { name: 'GenerateTools', description: 'Regenerate tool wrappers', default: false, listed: false, declaredIn: 'Build.CodeGen', dependsOn: ['Restore'], after: [], triggeredBy: [], triggers: [], status: 'skipped' },
+        { name: 'Test', description: 'xUnit across the suite', default: false, listed: true, declaredIn: 'Build.Common', dependsOn: ['Compile'], after: [], triggeredBy: [], triggers: [], status: 'running' },
+        { name: 'Pack', description: 'NuGet pack (default target)', default: true, listed: true, declaredIn: 'Build.Pack', dependsOn: ['Compile'], after: [], triggeredBy: [], triggers: [], status: 'running' },
+        { name: 'ValidateRef', description: 'Assert release/vX.Y ref', default: false, listed: true, declaredIn: 'Build.Publish', dependsOn: [], after: [], triggeredBy: [], triggers: [], status: 'succeeded' },
+        { name: 'PublishGitHubPackages', description: 'Push preview to GH Packages', default: false, listed: true, declaredIn: 'Build.Publish', dependsOn: ['Test', 'Pack'], after: ['ValidateRef'], triggeredBy: [], triggers: ['Canary'], status: 'queued' },
+        { name: 'PublishGitHubReleases', description: 'Create GitHub Release', default: false, listed: true, declaredIn: 'Build.Publish', dependsOn: ['Pack'], after: [], triggeredBy: [], triggers: [], status: 'queued' },
+        { name: 'PublishNuGet', description: 'Push GA to nuget.org', default: false, listed: true, declaredIn: 'Build.Publish', dependsOn: ['Test', 'Pack'], after: ['ValidateRef'], triggeredBy: [], triggers: [], status: 'queued' },
+        { name: 'Canary', description: 'Smoke-test published package', default: false, listed: true, declaredIn: 'Build.Publish', dependsOn: [], after: [], triggeredBy: ['PublishGitHubPackages'], triggers: [], status: 'queued' },
+    ],
+};

--- a/poc/graph-control/src/layout.ts
+++ b/poc/graph-control/src/layout.ts
@@ -1,0 +1,100 @@
+import ELK from 'elkjs/lib/elk.bundled.js';
+import type { Edge, Node } from '@xyflow/react';
+import type { BuildGraph, Relation } from './model';
+
+// elk.bundled.js runs the layout inline (no web worker / no external asset),
+// which keeps the single-file HTML build self-contained.
+const elk = new ELK();
+
+export const NODE_WIDTH = 248;
+export const NODE_HEIGHT = 60;
+
+/** Data carried on every React Flow node — consumed by TargetNode. */
+export interface TargetNodeData extends Record<string, unknown> {
+    label: string;
+    description?: string;
+    declaredIn?: string;
+    isDefault: boolean;
+    listed: boolean;
+    status?: string;
+}
+
+/** A directed edge plus the relation that produced it (drives styling). */
+interface RelationEdge {
+    source: string;
+    target: string;
+    relation: Relation;
+}
+
+/**
+ * Flattens the four relation arrays into directed edges pointing in
+ * execution-flow direction (prerequisite → dependent) — same semantics as the
+ * Mermaid/--plan output. `triggeredBy` is the mirror of `triggers`, so we emit
+ * `triggers` alone to avoid duplicate edges.
+ */
+function collectEdges(graph: BuildGraph): RelationEdge[] {
+    const edges: RelationEdge[] = [];
+    for (const t of graph.targets) {
+        for (const d of t.dependsOn) edges.push({ source: d, target: t.name, relation: 'dependsOn' });
+        for (const d of t.after) edges.push({ source: d, target: t.name, relation: 'after' });
+        for (const d of t.triggers) edges.push({ source: t.name, target: d, relation: 'triggers' });
+    }
+    return edges;
+}
+
+/**
+ * Runs elkjs `layered` layout left-to-right and returns React Flow nodes/edges
+ * with absolute positions. Async because elk.layout is promise-based.
+ */
+export async function layoutGraph(graph: BuildGraph): Promise<{ nodes: Node<TargetNodeData>[]; edges: Edge[] }> {
+    const relationEdges = collectEdges(graph);
+    const known = new Set(graph.targets.map((t) => t.name));
+
+    const elkGraph = {
+        id: 'root',
+        layoutOptions: {
+            'elk.algorithm': 'layered',
+            'elk.direction': 'RIGHT',
+            'elk.layered.spacing.nodeNodeBetweenLayers': '96',
+            'elk.spacing.nodeNode': '28',
+            'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
+            'elk.edgeRouting': 'ORTHOGONAL',
+        },
+        children: graph.targets.map((t) => ({ id: t.name, width: NODE_WIDTH, height: NODE_HEIGHT })),
+        // Drop edges that reference an unknown target — a defensive guard so a
+        // malformed graph lays out instead of throwing.
+        edges: relationEdges
+            .filter((e) => known.has(e.source) && known.has(e.target))
+            .map((e, i) => ({ id: `e${i}`, sources: [e.source], targets: [e.target] })),
+    };
+
+    const laid = await elk.layout(elkGraph);
+    const positions = new Map((laid.children ?? []).map((c) => [c.id, { x: c.x ?? 0, y: c.y ?? 0 }]));
+
+    const nodes: Node<TargetNodeData>[] = graph.targets.map((t) => ({
+        id: t.name,
+        type: 'target',
+        position: positions.get(t.name) ?? { x: 0, y: 0 },
+        data: {
+            label: t.name,
+            description: t.description,
+            declaredIn: t.declaredIn,
+            isDefault: t.default,
+            listed: t.listed,
+            status: t.status,
+        },
+    }));
+
+    const edges: Edge[] = relationEdges
+        .filter((e) => known.has(e.source) && known.has(e.target))
+        .map((e, i) => ({
+            id: `e${i}`,
+            source: e.source,
+            target: e.target,
+            type: 'smoothstep',
+            data: { relation: e.relation },
+            className: `edge-${e.relation}`,
+        }));
+
+    return { nodes, edges };
+}

--- a/poc/graph-control/src/main.tsx
+++ b/poc/graph-control/src/main.tsx
@@ -1,0 +1,23 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { GraphControl } from './GraphControl';
+import { demoGraph } from './fixture';
+import type { BuildGraph } from './model';
+import './theme.css';
+
+// The host can inject a real build-graph.json as window.__FALLOUT_GRAPH__
+// (this is exactly how the static --plan HTML report will embed it). Falls back
+// to the bundled demo graph when nothing is injected.
+declare global {
+    interface Window {
+        __FALLOUT_GRAPH__?: BuildGraph;
+    }
+}
+
+const graph = window.__FALLOUT_GRAPH__ ?? demoGraph;
+
+createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+        <GraphControl graph={graph} onRunTarget={(t) => console.log('run target:', t)} />
+    </StrictMode>,
+);

--- a/poc/graph-control/src/main.tsx
+++ b/poc/graph-control/src/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from 'react-dom/client';
 import { GraphControl } from './GraphControl';
 import { demoGraph } from './fixture';
 import type { BuildGraph } from './model';
-import './theme.css';
 
 // The host can inject a real build-graph.json as window.__FALLOUT_GRAPH__
 // (this is exactly how the static --plan HTML report will embed it). Falls back

--- a/poc/graph-control/src/model.ts
+++ b/poc/graph-control/src/model.ts
@@ -1,0 +1,33 @@
+// Mirrors the build-graph.json schema the Fallout framework emits
+// (see poc/vscode-fallout/src/model.ts and SerializeBuildGraphAttribute.cs).
+// The only addition is `status`, which is absent in schema v1 and reserved for
+// the live/CI phase — treat it as optional everywhere.
+
+/** How one target relates to another in the build graph. */
+export type Relation = 'dependsOn' | 'after' | 'triggeredBy' | 'triggers';
+
+/** Live execution state of a target. Absent in build-graph.json v1 (static). */
+export type Status = 'queued' | 'running' | 'succeeded' | 'failed' | 'skipped';
+
+/** A single build target, as emitted into build-graph.json. */
+export interface Target {
+    name: string;
+    description?: string;
+    default: boolean;
+    listed: boolean;
+    /** Declaring C# type (class or interface) — disambiguates go-to-definition. */
+    declaredIn?: string;
+    dependsOn: string[];
+    after: string[];
+    triggeredBy: string[];
+    triggers: string[];
+    /** Live-only; unset for a static graph. */
+    status?: Status;
+}
+
+/** Parsed contents of build-graph.json. */
+export interface BuildGraph {
+    version: number;
+    falloutVersion?: string;
+    targets: Target[];
+}

--- a/poc/graph-control/src/mount.tsx
+++ b/poc/graph-control/src/mount.tsx
@@ -1,0 +1,28 @@
+import { createRoot, type Root } from 'react-dom/client';
+import { GraphControl } from './GraphControl';
+import type { BuildGraph } from './model';
+
+// Library entry for host embedding (VS Code webview, static HTML report).
+// The IIFE build exposes these as `window.FalloutGraph`.
+
+export interface MountOptions {
+    onRunTarget?: (target: string) => void;
+}
+
+// One React root per container, reused across graph updates so re-rendering with
+// a fresh graph reconciles in place (drives the extension's live refresh).
+const roots = new WeakMap<HTMLElement, Root>();
+
+export function mount(el: HTMLElement, graph: BuildGraph, options: MountOptions = {}): void {
+    let root = roots.get(el);
+    if (!root) {
+        root = createRoot(el);
+        roots.set(el, root);
+    }
+    root.render(<GraphControl graph={graph} onRunTarget={options.onRunTarget} />);
+}
+
+export function unmount(el: HTMLElement): void {
+    roots.get(el)?.unmount();
+    roots.delete(el);
+}

--- a/poc/graph-control/src/theme.css
+++ b/poc/graph-control/src/theme.css
@@ -37,8 +37,26 @@
     --font-mono: ui-monospace, 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
 }
 
+/* Light palette. Dark is the default (the :root block above). Light applies when
+   the viewer explicitly toggles it (data-theme="light"), or when the host OS
+   prefers light and no explicit theme is pinned. An explicit data-theme wins over
+   the OS preference in both directions — the static report pins data-theme="dark"
+   so it stays dark regardless of the viewer's OS. */
+:root[data-theme='light'] {
+    --bg-top: #f4f4f2;
+    --bg-bottom: #e9e9e6;
+    --glow: #f8efc8;
+    --surface: #ffffff;
+    --surface-raised: #ffffff;
+    --border: #d8d8d2;
+    --text: #1a1a1a;
+    --text-muted: #666;
+    --text-faint: #999;
+    --edge: #c4c4bc;
+}
+
 @media (prefers-color-scheme: light) {
-    :root:not([data-theme='dark']) {
+    :root:not([data-theme='dark']):not([data-theme='light']) {
         --bg-top: #f4f4f2;
         --bg-bottom: #e9e9e6;
         --glow: #f8efc8;

--- a/poc/graph-control/src/theme.css
+++ b/poc/graph-control/src/theme.css
@@ -1,0 +1,73 @@
+/*
+ * Fallout brand tokens — extracted from .assets/fallout-logo.svg and
+ * fallout-social-preview.svg. This is the single source of truth for the
+ * control's look; swap these values, not the component code, to reskin.
+ *
+ * Dark-first: the Fallout brand is fundamentally a dark, radioactive-amber
+ * surface. A light fallback is provided but the identity lives in the dark.
+ */
+:root {
+    --fallout-yellow: #f5c800; /* radioactive trefoil — primary accent */
+    --fallout-yellow-dim: rgba(245, 200, 0, 0.14);
+    --fallout-yellow-line: rgba(245, 200, 0, 0.28);
+
+    --bg-top: #111113;
+    --bg-bottom: #0a0a0b;
+    --glow: #2a2205;
+
+    --surface: #17171a;
+    --surface-raised: #1e1e22;
+    --border: #2a2a30;
+
+    --text: #eaeaea;
+    --text-muted: #8a8a90;
+    --text-faint: #66666c;
+
+    /* status palette — our own, tuned for the dark surface (not GitHub's) */
+    --status-queued: #6b6b73;
+    --status-running: var(--fallout-yellow);
+    --status-succeeded: #4ac26b;
+    --status-failed: #ff5c57;
+    --status-skipped: #55555c;
+
+    --edge: #3d3d44;
+    --edge-trigger: var(--fallout-yellow-line);
+
+    --font-sans: 'Anthropic Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --font-mono: ui-monospace, 'SF Mono', 'Cascadia Code', 'Consolas', monospace;
+}
+
+@media (prefers-color-scheme: light) {
+    :root:not([data-theme='dark']) {
+        --bg-top: #f4f4f2;
+        --bg-bottom: #e9e9e6;
+        --glow: #f8efc8;
+        --surface: #ffffff;
+        --surface-raised: #ffffff;
+        --border: #d8d8d2;
+        --text: #1a1a1a;
+        --text-muted: #666;
+        --text-faint: #999;
+        --edge: #c4c4bc;
+    }
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+    height: 100%;
+    margin: 0;
+}
+
+body {
+    font-family: var(--font-sans);
+    color: var(--text);
+    background:
+        radial-gradient(55% 60% at 22% 45%, var(--glow) 0%, transparent 70%),
+        linear-gradient(135deg, var(--bg-top) 0%, var(--bg-bottom) 100%);
+    background-attachment: fixed;
+}

--- a/poc/graph-control/tsconfig.json
+++ b/poc/graph-control/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "useDefineForClassFields": true,
+        "lib": ["ES2022", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "skipLibCheck": true,
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "moduleDetection": "force",
+        "noEmit": true,
+        "jsx": "react-jsx",
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "include": ["src"]
+}

--- a/poc/graph-control/vite.config.ts
+++ b/poc/graph-control/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { viteSingleFile } from 'vite-plugin-singlefile';
+
+// `viteSingleFile` inlines JS/CSS into one index.html so the built artifact is a
+// double-clickable, offline, self-contained file — the same shape the eventual
+// `fallout` --plan HTML report will take. `npm run dev` keeps a normal dev server.
+export default defineConfig({
+    plugins: [react(), viteSingleFile()],
+    build: {
+        target: 'es2022',
+        assetsInlineLimit: 100_000_000,
+        cssCodeSplit: false,
+    },
+});

--- a/poc/graph-control/vite.lib.config.ts
+++ b/poc/graph-control/vite.lib.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import cssInjectedByJs from 'vite-plugin-css-injected-by-js';
+
+// Library build: one self-contained IIFE (React + React Flow + elkjs bundled,
+// CSS injected at runtime) exposing `window.FalloutGraph.mount(...)`. Hosts load
+// it as a single <script> — the same way the extension used to load mermaid.
+// The runtime <style> injection needs `style-src 'unsafe-inline'` in the host CSP.
+export default defineConfig({
+    plugins: [react(), cssInjectedByJs()],
+    build: {
+        target: 'es2022',
+        outDir: 'dist-lib',
+        emptyOutDir: true,
+        lib: {
+            entry: 'src/mount.tsx',
+            name: 'FalloutGraph',
+            formats: ['iife'],
+            fileName: () => 'fallout-graph-control.js',
+        },
+    },
+});

--- a/poc/graph-control/vite.lib.config.ts
+++ b/poc/graph-control/vite.lib.config.ts
@@ -8,6 +8,12 @@ import cssInjectedByJs from 'vite-plugin-css-injected-by-js';
 // The runtime <style> injection needs `style-src 'unsafe-inline'` in the host CSP.
 export default defineConfig({
     plugins: [react(), cssInjectedByJs()],
+    // Vite library mode (unlike app mode) does not substitute process.env.NODE_ENV,
+    // so React's reference would throw `process is not defined` in a plain browser
+    // <script> host. Bake it in — the bundle ships React's production build.
+    define: {
+        'process.env.NODE_ENV': JSON.stringify('production'),
+    },
     build: {
         target: 'es2022',
         outDir: 'dist-lib',


### PR DESCRIPTION
Phase 1 PoC of a Fallout-branded, GitHub-Actions-style build/run graph control — the intended replacement for the VS Code extension's Mermaid graph, and the basis for the `--plan` HTML report and (eventually) the Fallout CI run graph.

Not a GitHub clone: its own dark radioactive-amber identity, tokens lifted from the logo assets.

**Stack** — layout and render kept as separate layers:
- **elkjs** (`layered`, left-to-right) computes node positions — surface-independent.
- **React Flow** (`@xyflow/react`) renders + handles pan/zoom/click.

**How it fits Fallout**
- Consumes the existing `build-graph.json` schema. Edge semantics match Mermaid/`--plan`: solid = `dependsOn`, dashed = `after`, thick = `triggers`.
- Host injects a real graph via `window.__FALLOUT_GRAPH__`; otherwise a demo fixture renders.
- Optional per-target `status` is wired through the node now but reserved for the live phase — schema v1 omits it.
- Vite + singlefile emits one self-contained `dist/index.html` — the same shape the static HTML report will take.

**Scope** — exploratory, lives under `poc/`; nothing shipped/wired yet (hence `skip-changelog`).

**Try it**
```
cd poc/graph-control && npm install && npm run dev
```

**Next**
- Phase 2: wire into the extension (replace Mermaid in `graphPanel.ts`) + emit the static HTML report.
- Phase 3: `BuildManager` streams per-target status → the control animates the run.
