### PR TITLE
Emit per-target status in build-graph.json and re-emit on transitions

### DIFF
--- a/src/Fallout.Build/Execution/Extensions/BuildGraphUtility.cs
+++ b/src/Fallout.Build/Execution/Extensions/BuildGraphUtility.cs
@@ -74,7 +74,23 @@ internal static class BuildGraphUtility
             SortedNames(target.ExecutionDependencies),
             SortedNames(target.OrderDependencies),
             SortedNames(target.TriggerDependencies),
-            SortedNames(target.Triggers));
+            SortedNames(target.Triggers),
+            ToStatus(target.Status));
+
+    // Projects the internal execution status onto the small vocabulary the graph control
+    // renders. Neutral states (not scheduled, not run, collective grouping) emit null, so a
+    // structural/plan snapshot stays unstyled and only a real run paints the nodes. Additive:
+    // a consumer that predates the field simply ignores it, so this is not a schema break.
+    private static string ToStatus(ExecutionStatus status)
+        => status switch
+        {
+            ExecutionStatus.Scheduled => "queued",
+            ExecutionStatus.Running => "running",
+            ExecutionStatus.Succeeded => "succeeded",
+            ExecutionStatus.Failed or ExecutionStatus.Aborted => "failed",
+            ExecutionStatus.Skipped => "skipped",
+            _ => null,
+        };
 
     // Sorted for deterministic output — the graph carries no execution order, so the display
     // order is irrelevant to consumers and a stable ordering avoids spurious file churn.
@@ -95,5 +111,6 @@ internal static class BuildGraphUtility
         IReadOnlyList<string> DependsOn,
         IReadOnlyList<string> After,
         IReadOnlyList<string> TriggeredBy,
-        IReadOnlyList<string> Triggers);
+        IReadOnlyList<string> Triggers,
+        string Status);
 }

--- a/src/Fallout.Build/Execution/Extensions/SerializeBuildGraphAttribute.cs
+++ b/src/Fallout.Build/Execution/Extensions/SerializeBuildGraphAttribute.cs
@@ -7,15 +7,22 @@ using Fallout.Common.IO;
 namespace Fallout.Build.Execution.Extensions;
 
 /// <summary>
-/// Emits <c>build-graph.json</c> into the temporary directory on every build initialization,
-/// giving editor tooling (the VS Code extension) a machine-readable projection of the target
-/// graph. The projection itself lives in <see cref="BuildGraphUtility"/>; this attribute only owns
-/// the build-lifecycle hook and the file write. Best-effort — a serialization failure never fails
-/// the build.
+/// Emits <c>build-graph.json</c> into the temporary directory at build initialization, then re-emits
+/// it on every target state transition so editor tooling (the VS Code extension) can watch the file
+/// and animate the run live — queued → running → succeeded/failed. The projection itself lives in
+/// <see cref="BuildGraphUtility"/>; this attribute only owns the build-lifecycle hooks and the file
+/// write. Best-effort — a serialization failure never fails the build.
 /// </summary>
-internal class SerializeBuildGraphAttribute : BuildExtensionAttributeBase, IOnBuildInitialized
+internal class SerializeBuildGraphAttribute : BuildExtensionAttributeBase,
+    IOnBuildInitialized, IOnTargetRunning, IOnTargetSucceeded, IOnTargetFailed, IOnTargetSkipped
 {
     private const string GraphFileName = "build-graph.json";
+
+    // Guards the file write only; the executor updates target.Status in place, so each transition
+    // re-serializes the same captured collection with its now-current statuses.
+    private readonly object writeLock = new();
+    private IReadOnlyCollection<ExecutableTarget> targets;
+    private string falloutVersion;
 
     private AbsolutePath GraphFile => Build.TemporaryDirectory / GraphFileName;
 
@@ -23,10 +30,35 @@ internal class SerializeBuildGraphAttribute : BuildExtensionAttributeBase, IOnBu
         IReadOnlyCollection<ExecutableTarget> executableTargets,
         IReadOnlyCollection<ExecutableTarget> executionPlan)
     {
+        targets = executableTargets;
+        falloutVersion = FindFalloutVersion();
+        WriteGraph();
+    }
+
+    // Each transition re-emits the whole graph with current statuses. The executor sets
+    // target.Status before invoking these, so the write reflects the transition that just happened.
+    public void OnTargetRunning(ExecutableTarget target) => WriteGraph();
+
+    public void OnTargetSucceeded(ExecutableTarget target) => WriteGraph();
+
+    public void OnTargetFailed(ExecutableTarget target) => WriteGraph();
+
+    public void OnTargetSkipped(ExecutableTarget target) => WriteGraph();
+
+    private void WriteGraph()
+    {
+        if (targets == null)
+        {
+            return;
+        }
+
         try
         {
-            var json = BuildGraphUtility.GetJsonString(executableTargets, FindFalloutVersion());
-            GraphFile.WriteAllText(json);
+            var json = BuildGraphUtility.GetJsonString(targets, falloutVersion);
+            lock (writeLock)
+            {
+                GraphFile.WriteAllText(json);
+            }
         }
         catch (Exception exception)
         {

--- a/tests/Fallout.Build.Specs/BuildGraphUtilitySpecs.Sample_graph_matches_the_contract_snapshot.verified.json
+++ b/tests/Fallout.Build.Specs/BuildGraphUtilitySpecs.Sample_graph_matches_the_contract_snapshot.verified.json
@@ -15,7 +15,8 @@
       "triggeredBy": [],
       "triggers": [
         "Publish"
-      ]
+      ],
+      "status": null
     },
     {
       "name": "Publish",
@@ -28,7 +29,8 @@
       "triggeredBy": [
         "Test"
       ],
-      "triggers": []
+      "triggers": [],
+      "status": null
     },
     {
       "name": "Restore",
@@ -39,7 +41,8 @@
       "dependsOn": [],
       "after": [],
       "triggeredBy": [],
-      "triggers": []
+      "triggers": [],
+      "status": null
     },
     {
       "name": "Test",
@@ -54,7 +57,8 @@
         "Restore"
       ],
       "triggeredBy": [],
-      "triggers": []
+      "triggers": [],
+      "status": null
     }
   ]
 }

--- a/tests/Fallout.Build.Specs/BuildGraphUtilitySpecs.cs
+++ b/tests/Fallout.Build.Specs/BuildGraphUtilitySpecs.cs
@@ -143,7 +143,34 @@ public class BuildGraphUtilitySpecs
         firstTarget.EnumerateObject().Select(x => x.Name)
             .Should().Equal(
                 "name", "description", "declaredIn", "default", "listed",
-                "dependsOn", "after", "triggeredBy", "triggers");
+                "dependsOn", "after", "triggeredBy", "triggers", "status");
+    }
+
+    [Theory]
+    [InlineData(ExecutionStatus.Scheduled, "queued")]
+    [InlineData(ExecutionStatus.Running, "running")]
+    [InlineData(ExecutionStatus.Succeeded, "succeeded")]
+    [InlineData(ExecutionStatus.Failed, "failed")]
+    [InlineData(ExecutionStatus.Aborted, "failed")]
+    [InlineData(ExecutionStatus.Skipped, "skipped")]
+    // Neutral states emit null so a structural/plan snapshot stays unstyled; only a real run paints.
+    [InlineData(ExecutionStatus.None, null)]
+    [InlineData(ExecutionStatus.NotRun, null)]
+    [InlineData(ExecutionStatus.Collective, null)]
+    public void Execution_status_projects_to_the_control_vocabulary(ExecutionStatus status, string expected)
+    {
+        var target = new ExecutableTarget { Name = "Compile", Status = status };
+
+        BuildGraphUtility.GetModel(new[] { target }, SampleVersion).Targets.Single().Status
+            .Should().Be(expected);
+    }
+
+    [Fact]
+    public void Status_is_added_without_bumping_the_schema_version()
+    {
+        // The status field is additive — a consumer that predates it ignores the extra key — so it
+        // rides schema v1. This guard pairs with Schema_version_is_1 to make that intent explicit.
+        BuildGraphUtility.SchemaVersion.Should().Be(1);
     }
 
     [Theory]


### PR DESCRIPTION
The producer half of the live run graph: `build-graph.json` now carries per-target `status` and is re-written on every target transition, so editor tooling (the VS Code extension) can watch the file and animate a run live — queued → running → succeeded/failed.

- `BuildGraphUtility` projects `ExecutionStatus` onto the control's vocabulary (`scheduled→queued`, `running`, `succeeded`, `failed`/`aborted→failed`, `skipped`). Neutral states (`none`/`notrun`/`collective`) emit `null`, so a structural or `--plan` snapshot stays unstyled — only a real run paints the nodes.
- `SerializeBuildGraphAttribute` captures the targets at init and now also implements `IOnTargetRunning`/`Succeeded`/`Failed`/`Skipped`, re-emitting on each (the executor updates `target.Status` in place before firing the hook). Best-effort, locked write — never fails the build.

**Additive / non-breaking:** a consumer predating the field ignores the extra key, so it stays **schema v1** (guarded by a test).

**Verified:** unit tests cover the status projection (`scheduled→queued`, neutral→`null`, etc.); dogfooding `./build.ps1 Clean` emits `build-graph.json` with `Clean=succeeded` and everything else `null`.

Independent of the graph-control PRs — it just widens the JSON contract. The consumer side (the control's `mountLive` + the extension's file-watcher) animates this automatically.
