### PR TITLE
Bump System.Security.Cryptography.Xml to the advisory-patched versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="System.Text.Json" Version="10.0.8" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
@@ -81,13 +81,13 @@
     <PackageVersion Update="Microsoft.Build.Framework" Version="17.14.28" />
     <PackageVersion Update="Microsoft.Build.Tasks.Core" Version="17.14.28" />
     <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="17.14.28" />
-    <PackageVersion Update="System.Security.Cryptography.Xml" Version="9.0.15" />
+    <PackageVersion Update="System.Security.Cryptography.Xml" Version="9.0.18" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Update="Microsoft.Build" Version="17.11.48" />
     <PackageVersion Update="Microsoft.Build.Framework" Version="17.11.48" />
     <PackageVersion Update="Microsoft.Build.Tasks.Core" Version="17.11.48" />
     <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="17.11.48" />
-    <PackageVersion Update="System.Security.Cryptography.Xml" Version="8.0.3" />
+    <PackageVersion Update="System.Security.Cryptography.Xml" Version="8.0.4" />
   </ItemGroup>
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -54,7 +54,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <!-- Nerdbank.GitVersioning lets us read ThisAssembly.AssemblyInformationalVersion in
          Build.cs as the canonical version source. Replaces GitVersion.Tool (#81). Direct
          dependency because _build.csproj turns off central package management. -->


### PR DESCRIPTION
`System.Security.Cryptography.Xml` is pinned at versions inside the affected range of five high-severity advisories — uncontrolled resource consumption during XML decryption (CVSS 7.5):

- [GHSA-23rf-6693-g89p](https://github.com/advisories/GHSA-23rf-6693-g89p)
- [GHSA-8q5v-6pqq-x66h](https://github.com/advisories/GHSA-8q5v-6pqq-x66h)
- [GHSA-cvvh-rhrc-wg4q](https://github.com/advisories/GHSA-cvvh-rhrc-wg4q)
- [GHSA-g8r8-53c2-pm3f](https://github.com/advisories/GHSA-g8r8-53c2-pm3f)
- [GHSA-mmjf-rqrv-855v](https://github.com/advisories/GHSA-mmjf-rqrv-855v)

Each line moves to its first patched release:

| TFM | Before | After |
|---|---|---|
| net10.0 | 10.0.6 | 10.0.10 |
| net9.0 | 9.0.15 | 9.0.18 |
| net8.0 | 8.0.3 | 8.0.4 |

`Fallout.Common` declares the package as a direct dependency, so consumers inherit the vulnerable version transitively and `NuGetAudit` fires on their build project — the only fix on their side is a local pin. Migrating Quartz.NET off NUKE surfaced this; it currently has to carry:

```xml
<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
```

Both the central version list and `build/_build.csproj` are bumped — the build project turns off central package management, so its inline pin is separate.

`dotnet restore fallout.slnx` is clean for every `src/` project afterwards. `tests/Consumers/Fallout.Consumer.NuGet` still warns because it resolves the published `Fallout.Common` from nuget.org; that clears once a release ships with this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
