### PR TITLE
Configure Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Monitor GitHub Actions (.github/workflows/*.yml)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Description:

Follow-up to #531.
Adds Dependabot configuration for the `github-actions` ecosystem.
Cross-references #535, which introduces configurable action references for generated GitHub Actions workflows.