### PR TITLE
Add AbsolutePath.Temp

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -176,3 +176,6 @@ dotnet_style_require_accessibility_modifiers = omit_if_default:silent
 
 [tests/**/*.cs]
 dotnet_naming_rule.private_fields_should_be_camel_case.severity = suggestion
+
+# In tests, using async isn't adding a lot of value other than noise
+resharper_method_has_async_overload_highlighting = none

--- a/src/Fallout.Utilities/IO/AbsolutePath.cs
+++ b/src/Fallout.Utilities/IO/AbsolutePath.cs
@@ -52,6 +52,17 @@ public class AbsolutePath : IAbsolutePathHolder, IFormattable
         return new AbsolutePath(path);
     }
 
+    /// <summary>
+    /// Returns a unique path within the OS temp directory, optionally prefixed with <paramref name="prefix"/>.
+    /// Does not create the file or directory.
+    /// </summary>
+    public static AbsolutePath Temp(string prefix = null)
+    {
+        var suffix = Guid.NewGuid().ToString("N").Substring(0, 8);
+        var name = string.IsNullOrEmpty(prefix) ? suffix : $"{prefix}-{suffix}";
+        return Create(Path.GetTempPath()) / name;
+    }
+
     private readonly string path;
 
     private AbsolutePath(string path)

--- a/tests/Fallout.Migrate.Specs/MigrationIntegrationSpecs.cs
+++ b/tests/Fallout.Migrate.Specs/MigrationIntegrationSpecs.cs
@@ -1,192 +1,174 @@
 using System;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
+using Fallout.Common.IO;
 using FluentAssertions;
 using Xunit;
 
 namespace Fallout.Migrate.Specs;
 
-public class MigrationIntegrationSpecs
+public class MigrationIntegrationSpecs : IDisposable
 {
-    [Fact]
-    public async Task MigratesVanillaConsumerRepo()
+    private readonly AbsolutePath tempDirectory;
+
+    public MigrationIntegrationSpecs()
     {
-        var temp = CreateVanillaFixture();
+        // Arrange
+        tempDirectory = AbsolutePath.Temp("fallout-migrate-test");
+        (tempDirectory / "build").CreateDirectory();
+        (tempDirectory / ".nuke").CreateDirectory();
 
-        try
-        {
-            var migration = new Migration(temp, dryRun: false, TextWriter.Null);
-            var summary = await migration.RunAsync();
+        (tempDirectory / "build" / "_build.csproj").WriteAllText(
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <OutputType>Exe</OutputType>
+                <TargetFramework>net10.0</TargetFramework>
+                <NukeRootDirectory>.\..</NukeRootDirectory>
+                <NukeTelemetryVersion>1</NukeTelemetryVersion>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Nuke.Common" Version="9.0.0" />
+              </ItemGroup>
+            </Project>
+            """);
 
-            // Build file rewritten end to end.
-            var buildCsproj = File.ReadAllText(Path.Combine(temp, "build", "_build.csproj"));
-            buildCsproj.Should().Contain(@"Include=""Fallout.Common""");
-            buildCsproj.Should().Contain("<FalloutRootDirectory>");
-            buildCsproj.Should().NotContain("Nuke.Common");
-            buildCsproj.Should().NotContain("<NukeRootDirectory>");
+        (tempDirectory / "build" / "Build.cs").WriteAllText(
+            """
+            using Nuke.Common;
+            using Nuke.Common.Tools.DotNet;
 
-            var buildCs = File.ReadAllText(Path.Combine(temp, "build", "Build.cs"));
-            buildCs.Should().Contain("using Fallout.Common");
-            buildCs.Should().Contain(": FalloutBuild");
-            buildCs.Should().NotContain("using Nuke.");
-            buildCs.Should().NotContain("NukeBuild");
+            class Build : NukeBuild
+            {
+                public static int Main () => Execute<Build>(x => x.Compile);
 
-            var buildSh = File.ReadAllText(Path.Combine(temp, "build.sh"));
-            buildSh.Should().Contain("dotnet fallout");
-            buildSh.Should().NotContain("TELEMETRY_OPTOUT"); // telemetry removed — opt-out stripped, not renamed (ADR-0010)
-            buildSh.Should().Contain(".fallout/temp");
+                Target Compile => _ => _.Executes(() => { });
+            }
+            """);
 
-            // .nuke/ moved to .fallout/.
-            Directory.Exists(Path.Combine(temp, ".nuke")).Should().BeFalse();
-            Directory.Exists(Path.Combine(temp, ".fallout")).Should().BeTrue();
-            File.Exists(Path.Combine(temp, ".fallout", "parameters.json")).Should().BeTrue();
+        (tempDirectory / "build.sh").WriteAllText(
+            """
+            #!/usr/bin/env bash
+            export NUKE_TELEMETRY_OPTOUT=1
+            TEMP_DIRECTORY="$SCRIPT_DIR/.nuke/temp"
+            dotnet nuke "$@"
+            """);
 
-            summary.FilesChanged.Should().BeGreaterThan(0);
-            summary.EditCount.Should().BeGreaterThan(0);
-            summary.DirectoriesRenamed.Should().Be(1);
-            summary.Warnings.Should().BeEmpty();
-        }
-        finally
-        {
-            Directory.Delete(temp, recursive: true);
-        }
+        (tempDirectory / ".nuke" / "parameters.json").WriteAllText("{}");
+    }
+
+    public void Dispose()
+    {
+        tempDirectory.DeleteDirectory();
     }
 
     [Fact]
-    public async Task DryRunDoesNotWriteFiles()
+    public async Task A_vanilla_consumer_repo_is_migrated_end_to_end()
     {
-        var temp = CreateVanillaFixture();
+        // Act
+        var migration = new Migration(tempDirectory, dryRun: false, TextWriter.Null);
+        var summary = await migration.RunAsync();
 
-        try
-        {
-            var beforeCsproj = File.ReadAllText(Path.Combine(temp, "build", "_build.csproj"));
-            var beforeNukeDir = Directory.Exists(Path.Combine(temp, ".nuke"));
+        // Assert
 
-            var summary = await new Migration(temp, dryRun: true, TextWriter.Null).RunAsync();
+        // Build file rewritten end to end.
+        var buildCsproj = (tempDirectory / "build" / "_build.csproj").ReadAllText();
+        buildCsproj.Should().Contain(@"Include=""Fallout.Common""");
+        buildCsproj.Should().Contain("<FalloutRootDirectory>");
+        buildCsproj.Should().NotContain("Nuke.Common");
+        buildCsproj.Should().NotContain("<NukeRootDirectory>");
 
-            File.ReadAllText(Path.Combine(temp, "build", "_build.csproj")).Should().Be(beforeCsproj);
-            Directory.Exists(Path.Combine(temp, ".nuke")).Should().Be(beforeNukeDir);
-            summary.FilesChanged.Should().BeGreaterThan(0); // counts intended edits
-        }
-        finally
-        {
-            Directory.Delete(temp, recursive: true);
-        }
+        var buildCs = (tempDirectory / "build" / "Build.cs").ReadAllText();
+        buildCs.Should().Contain("using Fallout.Common");
+        buildCs.Should().Contain(": FalloutBuild");
+        buildCs.Should().NotContain("using Nuke.");
+        buildCs.Should().NotContain("NukeBuild");
+
+        var buildSh = (tempDirectory / "build.sh").ReadAllText();
+        buildSh.Should().Contain("dotnet fallout");
+        buildSh.Should().NotContain("TELEMETRY_OPTOUT"); // telemetry removed — opt-out stripped, not renamed (ADR-0010)
+        buildSh.Should().Contain(".fallout/temp");
+
+        // .nuke/ moved to .fallout/.
+        (tempDirectory / ".nuke").DirectoryExists().Should().BeFalse();
+        (tempDirectory / ".fallout").DirectoryExists().Should().BeTrue();
+        (tempDirectory / ".fallout" / "parameters.json").FileExists().Should().BeTrue();
+
+        summary.FilesChanged.Should().BeGreaterThan(0);
+        summary.EditCount.Should().BeGreaterThan(0);
+        summary.DirectoriesRenamed.Should().Be(1);
+        summary.Warnings.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task WarnsWhenBothNukeAndFalloutDirectoriesExist()
+    public async Task A_dry_run_does_not_write_any_files()
     {
-        var temp = CreateVanillaFixture();
-        Directory.CreateDirectory(Path.Combine(temp, ".fallout"));
+        // Arrange
+        var beforeCsproj = (tempDirectory / "build" / "_build.csproj").ReadAllText();
+        var beforeNukeDir = (tempDirectory / ".nuke").DirectoryExists();
 
-        try
-        {
-            var summary = await new Migration(temp, dryRun: false, TextWriter.Null).RunAsync();
+        // Act
+        var summary = await new Migration(tempDirectory, dryRun: true, TextWriter.Null).RunAsync();
 
-            summary.Warnings.Should().Contain(w => w.Contains(".nuke/") && w.Contains(".fallout/"));
-            summary.DirectoriesRenamed.Should().Be(0);
-            Directory.Exists(Path.Combine(temp, ".nuke")).Should().BeTrue();
-        }
-        finally
-        {
-            Directory.Delete(temp, recursive: true);
-        }
+        // Assert
+        (tempDirectory / "build" / "_build.csproj").ReadAllText().Should().Be(beforeCsproj);
+        (tempDirectory / ".nuke").DirectoryExists().Should().Be(beforeNukeDir);
+        summary.FilesChanged.Should().BeGreaterThan(0); // counts intended edits
     }
 
     [Fact]
-    public async Task WarnsWhenBuildProjectTargetsOlderThanNet10()
+    public async Task Nuke_and_fallout_directories_coexisting_produces_a_warning()
     {
-        var temp = CreateVanillaFixture();
-        var buildCsprojPath = Path.Combine(temp, "build", "_build.csproj");
-        File.WriteAllText(buildCsprojPath, File.ReadAllText(buildCsprojPath).Replace("net10.0", "net8.0"));
+        // Arrange
+        (tempDirectory / ".fallout").CreateDirectory();
 
-        try
-        {
-            var summary = await new Migration(temp, dryRun: false, TextWriter.Null).RunAsync();
+        // Act
+        var summary = await new Migration(tempDirectory, dryRun: false, TextWriter.Null).RunAsync();
 
-            summary.Warnings.Should().Contain(w =>
-                w.Contains("net8.0") && w.Contains(".NET 10") && w.Contains("_build.csproj"));
-        }
-        finally
-        {
-            Directory.Delete(temp, recursive: true);
-        }
+        // Assert
+        summary.Warnings.Should().Contain(w => w.Contains(".nuke/") && w.Contains(".fallout/"));
+        summary.DirectoriesRenamed.Should().Be(0);
+        (tempDirectory / ".nuke").DirectoryExists().Should().BeTrue();
     }
 
     [Fact]
-    public async Task BumpsDotNetVersionAndSdk()
+    public async Task A_build_project_targeting_an_older_tfm_than_net10_produces_a_warning()
     {
-        var temp = CreateVanillaFixture();
-        var buildCsprojPath = Path.Combine(temp, "build", "_build.csproj");
-        File.WriteAllText(buildCsprojPath, File.ReadAllText(buildCsprojPath).Replace("net10.0", "net8.0"));
-        File.WriteAllText(Path.Combine(temp, "global.json"), """
-                                                              {
-                                                                "sdk": {
-                                                                  "version": "8.0.100",
-                                                                  "rollForward": "latestMinor"
-                                                                }
-                                                              }
-                                                              """);
+        // Arrange
+        var buildCsprojPath = tempDirectory / "build" / "_build.csproj";
+        buildCsprojPath.UpdateText(text => text.Replace("net10.0", "net8.0"));
 
-        try
-        {
-            await new Migration(temp, dryRun: false, TextWriter.Null).RunAsync();
+        // Act
+        var summary = await new Migration(tempDirectory, dryRun: false, TextWriter.Null).RunAsync();
 
-            File.ReadAllText(buildCsprojPath).Should().Contain("<TargetFramework>net10.0</TargetFramework>");
-
-            var globalJson = File.ReadAllText(Path.Combine(temp, "global.json"));
-            globalJson.Should().Contain(@"""version"": ""10.0.100""");
-        }
-        finally
-        {
-            Directory.Delete(temp, recursive: true);
-        }
+        // Assert
+        summary.Warnings.Should().Contain(w =>
+            w.Contains("net8.0") && w.Contains(".NET 10") && w.Contains("_build.csproj"));
     }
 
-    private static string CreateVanillaFixture()
+    [Fact]
+    public async Task Migration_bumps_the_target_framework_and_global_json_sdk_version()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "fallout-migrate-test-" + Guid.NewGuid().ToString("N")[..8]);
-        Directory.CreateDirectory(dir);
-        Directory.CreateDirectory(Path.Combine(dir, "build"));
-        Directory.CreateDirectory(Path.Combine(dir, ".nuke"));
+        // Arrange
+        var buildCsprojPath = tempDirectory / "build" / "_build.csproj";
+        buildCsprojPath.UpdateText(text => text.Replace("net10.0", "net8.0"));
+        (tempDirectory / "global.json").WriteAllText(
+            """
+            {
+              "sdk": {
+                "version": "8.0.100",
+                "rollForward": "latestMinor"
+              }
+            }
+            """);
 
-        File.WriteAllText(Path.Combine(dir, "build", "_build.csproj"), """
-                                                                       <Project Sdk="Microsoft.NET.Sdk">
-                                                                         <PropertyGroup>
-                                                                           <OutputType>Exe</OutputType>
-                                                                           <TargetFramework>net10.0</TargetFramework>
-                                                                           <NukeRootDirectory>.\..</NukeRootDirectory>
-                                                                           <NukeTelemetryVersion>1</NukeTelemetryVersion>
-                                                                         </PropertyGroup>
-                                                                         <ItemGroup>
-                                                                           <PackageReference Include="Nuke.Common" Version="9.0.0" />
-                                                                         </ItemGroup>
-                                                                       </Project>
-                                                                       """);
+        // Act
+        await new Migration(tempDirectory, dryRun: false, TextWriter.Null).RunAsync();
 
-        File.WriteAllText(Path.Combine(dir, "build", "Build.cs"), """
-                                                                  using Nuke.Common;
-                                                                  using Nuke.Common.Tools.DotNet;
+        // Assert
+        buildCsprojPath.ReadAllText().Should().Contain("<TargetFramework>net10.0</TargetFramework>");
 
-                                                                  class Build : NukeBuild
-                                                                  {
-                                                                      public static int Main () => Execute<Build>(x => x.Compile);
-
-                                                                      Target Compile => _ => _.Executes(() => { });
-                                                                  }
-                                                                  """);
-
-        File.WriteAllText(Path.Combine(dir, "build.sh"), """
-                                                         #!/usr/bin/env bash
-                                                         export NUKE_TELEMETRY_OPTOUT=1
-                                                         TEMP_DIRECTORY="$SCRIPT_DIR/.nuke/temp"
-                                                         dotnet nuke "$@"
-                                                         """, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
-
-        File.WriteAllText(Path.Combine(dir, ".nuke", "parameters.json"), "{}");
-
-        return dir;
+        var globalJson = (tempDirectory / "global.json").ReadAllText();
+        globalJson.Should().Contain(@"""version"": ""10.0.100""");
     }
 }


### PR DESCRIPTION
## Summary

Adds AbsolutePath.Temp(prefix) — a unique path under the OS temp directory, without creating the file or directory. Uses it to rewrite MigrationIntegrationSpecs's fixture setup/teardown, replacing the hand-rolled `CreateVanillaFixture`/`Directory.Delete` pair with an IDisposable fixture.

## Changes

- AbsolutePath.Temp(string prefix = null) — new static factory.
- MigrationIntegrationSpecs rewritten to build its fixture in the constructor and clean up via Dispose(), using AbsolutePath fluent APIs (/, .ReadAllText(), .WriteAllText(), .DirectoryExists(), etc.) instead of Path.Combine/File.*/Directory.*. Test names renamed to describe behaviour.
- .editorconfig: relax esharper_method_has_async_overload_highlighting to suggestion under 	ests/** — async-suffix convention adds noise, not value, in test code.

## Testing

dotnet test tests/Fallout.Migrate.Specs — 34/34 passing.