### PR TITLE
Render whole ten-minute target durations correctly

### DIFF
--- a/src/Fallout.Build/Host.cs
+++ b/src/Fallout.Build/Host.cs
@@ -114,7 +114,9 @@ public partial class Host
     /// second, otherwise <c>m:ss</c> with minutes accumulating past the hour.
     /// </summary>
     internal static string FormatDuration(TimeSpan duration)
-        => $"{(int)duration.TotalMinutes}:{duration:ss}".Replace("0:00", "< 1sec");
+        => duration < TimeSpan.FromSeconds(1)
+            ? "< 1sec"
+            : $"{(int)duration.TotalMinutes}:{duration.Seconds:00}";
 
     protected internal virtual void WriteTargetOutcome(IFalloutBuild build)
     {

--- a/src/Fallout.Build/Host.cs
+++ b/src/Fallout.Build/Host.cs
@@ -109,6 +109,13 @@ public partial class Host
         }
     }
 
+    /// <summary>
+    /// Renders a target duration for the summary table's duration column: <c>&lt; 1sec</c> below one
+    /// second, otherwise <c>m:ss</c> with minutes accumulating past the hour.
+    /// </summary>
+    internal static string FormatDuration(TimeSpan duration)
+        => $"{(int)duration.TotalMinutes}:{duration:ss}".Replace("0:00", "< 1sec");
+
     protected internal virtual void WriteTargetOutcome(IFalloutBuild build)
     {
         var firstColumn = Math.Max(build.ExecutionPlan.Max(x => x.Name.Length) + 4, val2: 19);
@@ -127,11 +134,8 @@ public partial class Host
             => target.Status == ExecutionStatus.Succeeded ||
                target.Status == ExecutionStatus.Failed ||
                target.Status == ExecutionStatus.Aborted
-                ? GetDuration(target.Duration)
+                ? FormatDuration(target.Duration)
                 : string.Empty;
-
-        static string GetDuration(TimeSpan duration)
-            => $"{(int)duration.TotalMinutes}:{duration:ss}".Replace("0:00", "< 1sec");
 
         static string GetInformation(ExecutableTarget target)
             => target.SummaryInformation.Any()
@@ -174,7 +178,7 @@ public partial class Host
         }
 
         Debug('─'.Repeat(allColumns));
-        Information(CreateLine("Total", string.Empty, GetDuration(totalDuration)));
+        Information(CreateLine("Total", string.Empty, FormatDuration(totalDuration)));
         Debug('═'.Repeat(allColumns));
     }
 

--- a/tests/Fallout.Build.Specs/TargetDurationFormattingSpecs.cs
+++ b/tests/Fallout.Build.Specs/TargetDurationFormattingSpecs.cs
@@ -1,0 +1,54 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.Common.Specs;
+
+/// <summary>
+/// Covers the duration column of the end-of-run summary table (<see cref="Host.FormatDuration"/>).
+/// See #550. The old formatter replaced the substring <c>0:00</c> with the <c>&lt; 1sec</c>
+/// sentinel, so it also matched inside <c>10:00</c> and rendered <c>1&lt; 1sec</c>.
+/// </summary>
+public class TargetDurationFormattingSpecs
+{
+    [Theory]
+    [InlineData(0, "< 1sec")]
+    [InlineData(0.5, "< 1sec")]
+    public void Durations_under_one_second_render_the_sentinel(double seconds, string expected)
+    {
+        Host.FormatDuration(TimeSpan.FromSeconds(seconds)).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1, "0:01")]
+    [InlineData(30, "0:30")]
+    [InlineData(59, "0:59")]
+    [InlineData(60, "1:00")]
+    [InlineData(599, "9:59")]
+    public void Durations_under_ten_minutes_render_minutes_and_seconds(int seconds, string expected)
+    {
+        Host.FormatDuration(TimeSpan.FromSeconds(seconds)).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(10, "10:00")]
+    [InlineData(20, "20:00")]
+    [InlineData(30, "30:00")]
+    [InlineData(90, "90:00")]
+    public void Whole_ten_minute_durations_are_not_mistaken_for_the_sentinel(int minutes, string expected)
+    {
+        Host.FormatDuration(TimeSpan.FromMinutes(minutes)).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Durations_past_an_hour_keep_counting_in_minutes()
+    {
+        Host.FormatDuration(TimeSpan.FromMinutes(125) + TimeSpan.FromSeconds(5)).Should().Be("125:05");
+    }
+
+    [Fact]
+    public void The_sentinel_only_applies_below_one_second()
+    {
+        Host.FormatDuration(TimeSpan.FromSeconds(1)).Should().NotContain("< 1sec");
+    }
+}


### PR DESCRIPTION
Fixes the duration column of the end-of-run summary table. Every whole ten-minute duration rendered as `1< 1sec`.

### What changed
- Extract the duration formatter out of `WriteTargetOutcome` as `Host.FormatDuration`, so it can be covered by specs.
- Replace the `Replace("0:00", "< 1sec")` rewrite with an explicit sub-second check.
- Add `TargetDurationFormattingSpecs` over the sentinel boundary, the sub-ten-minute range, the whole ten-minute multiples, and a duration past an hour.

### Why
The `< 1sec` sentinel was applied with a substring replace. That pattern also matches inside `10:00`, `20:00` and `90:00`, so the minute digits were partly overwritten. The first commit moves the formatter without changing it, so the specs fail on behaviour first. The second commit fixes it.

Rendering is otherwise unchanged: `m:ss`, with minutes accumulating past the hour.

### Verification
`dotnet test tests/Fallout.Build.Specs` — 13 new specs pass.

Closes #550