### PR TITLE
Emit real blank lines instead of a zero-width space

### DIFF
--- a/src/Fallout.Build/Host.cs
+++ b/src/Fallout.Build/Host.cs
@@ -52,7 +52,7 @@ public partial class Host
             string.Empty,
             $"                       {LogoDimmed}.NET build system{LogoReset}",
             $"                     {LogoYellow}☢{LogoReset} {LogoDimmed}survived the NUKE{LogoReset}"
-        }.ForEach(x => Debug(x.Replace(" ", " ")));
+        }.ForEach(Debug);
 
         Debug();
     }

--- a/src/Fallout.Build/Theming/AnsiConsoleHostTheme.cs
+++ b/src/Fallout.Build/Theming/AnsiConsoleHostTheme.cs
@@ -110,10 +110,9 @@ public class AnsiConsoleHostTheme : AnsiConsoleTheme, IHostTheme
 
     private string Format(string text, string code)
     {
-        // TODO: replace multi-spaces
         // TODO: settings for bold/non-bold ?
         return !text.IsNullOrWhiteSpace()
             ? $"{code}{text}{AnsiStyleReset}"
-            : "​";
+            : string.Empty;
     }
 }

--- a/src/Fallout.Build/Theming/IHostTheme.cs
+++ b/src/Fallout.Build/Theming/IHostTheme.cs
@@ -12,6 +12,9 @@ public interface IHostTheme
     void WriteWarning(string text = null);
     void WriteError(string text = null);
 
+    // The Format* methods return an empty string for text that is null, empty, or whitespace only.
+    // Implementations must not substitute a filler character for a blank line — see #551, where a
+    // zero-width space was used and leaked into every blank line of build output.
     internal string FormatSuccess(string text);
     internal string FormatVerbose(string text);
     internal string FormatDebug(string text);

--- a/src/Fallout.Build/Theming/SystemConsoleHostTheme.cs
+++ b/src/Fallout.Build/Theming/SystemConsoleHostTheme.cs
@@ -74,32 +74,32 @@ public class SystemConsoleHostTheme : SystemConsoleTheme, IHostTheme
 
     string IHostTheme.FormatSuccess(string text)
     {
-        return text;
+        return Format(text);
     }
 
     string IHostTheme.FormatVerbose(string text)
     {
-        return text;
+        return Format(text);
     }
 
     string IHostTheme.FormatDebug(string text)
     {
-        return text;
+        return Format(text);
     }
 
     string IHostTheme.FormatInformation(string text)
     {
-        return text;
+        return Format(text);
     }
 
     string IHostTheme.FormatWarning(string text)
     {
-        return text;
+        return Format(text);
     }
 
     string IHostTheme.FormatError(string text)
     {
-        return text;
+        return Format(text);
     }
 
     private void Write(string text, SystemConsoleThemeStyle style)
@@ -107,7 +107,15 @@ public class SystemConsoleHostTheme : SystemConsoleTheme, IHostTheme
         using (DelegateDisposable.SetAndRestore(() => Console.ForegroundColor, style.Foreground ?? Console.ForegroundColor))
         using (DelegateDisposable.SetAndRestore(() => Console.BackgroundColor, style.Background ?? Console.BackgroundColor))
         {
-            Console.WriteLine(!text.IsNullOrWhiteSpace() ? text : "​");
+            Console.WriteLine(Format(text));
         }
+    }
+
+    private string Format(string text)
+    {
+        // This theme carries colour through the console's own foreground/background, so formatting
+        // is identity for real text. Blank text still normalises to an empty string, matching
+        // AnsiConsoleHostTheme.
+        return !text.IsNullOrWhiteSpace() ? text : string.Empty;
     }
 }

--- a/tests/Fallout.Build.Specs/ConsoleOutputCharacterSpecs.cs
+++ b/tests/Fallout.Build.Specs/ConsoleOutputCharacterSpecs.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Linq;
+using Fallout.Common.Execution.Theming;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.Common.Specs;
+
+/// <summary>
+/// Guards normal console output against non-printing characters. See #551. Two hacks put them
+/// there: the ANSI theme returned a zero-width space instead of an empty string for blank text, and
+/// <see cref="Host.WriteLogo"/> rewrote every space in the logo as a non-breaking space.
+/// </summary>
+[Collection(ProcessGlobalStateCollection.Name)]
+public class ConsoleOutputCharacterSpecs
+{
+    private const string ZeroWidthSpace = "​";
+    private const string NonBreakingSpace = " ";
+
+    /// <summary>Leading spaces on the logo's tagline lines.</summary>
+    private const int TaglineIndent = 21;
+
+    public static TheoryData<string> BlankTexts => new() { null, string.Empty, " ", "   " };
+
+    [Theory]
+    [MemberData(nameof(BlankTexts))]
+    public void The_ansi_theme_renders_blank_text_as_an_empty_string(string text)
+    {
+        var theme = (IHostTheme)AnsiConsoleHostTheme.Default256AnsiColorTheme;
+
+        theme.FormatInformation(text).Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(BlankTexts))]
+    public void The_system_theme_renders_blank_text_as_an_empty_string(string text)
+    {
+        var theme = (IHostTheme)SystemConsoleHostTheme.DefaultSystemColorTheme;
+
+        theme.FormatInformation(text).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void The_two_themes_agree_on_blank_text()
+    {
+        var ansi = (IHostTheme)AnsiConsoleHostTheme.Default256AnsiColorTheme;
+        var system = (IHostTheme)SystemConsoleHostTheme.DefaultSystemColorTheme;
+
+        ansi.FormatInformation(text: null).Should().Be(system.FormatInformation(text: null));
+    }
+
+    [Fact]
+    public void Blank_themed_output_carries_no_zero_width_space()
+    {
+        var theme = (IHostTheme)AnsiConsoleHostTheme.Default256AnsiColorTheme;
+
+        theme.FormatInformation(text: null).Should().NotContain(ZeroWidthSpace);
+    }
+
+    [Fact]
+    public void The_logo_uses_ordinary_spaces()
+    {
+        CaptureLogo().Should().NotContain(NonBreakingSpace);
+    }
+
+    [Fact]
+    public void The_logo_carries_no_zero_width_space()
+    {
+        CaptureLogo().Should().NotContain(ZeroWidthSpace);
+    }
+
+    [Fact]
+    public void The_logo_still_indents_its_tagline()
+    {
+        var tagline = CaptureLogo().Split('\n').Single(x => x.Contains("survived the NUKE"));
+
+        // Asserted as a run of ordinary spaces rather than a prefix, because the themed line starts
+        // with a colour escape. Non-breaking spaces would not match this.
+        tagline.Should().Contain(new string(' ', TaglineIndent));
+    }
+
+    private static string CaptureLogo()
+    {
+        var original = Console.Out;
+        using var writer = new StringWriter();
+        try
+        {
+            Console.SetOut(writer);
+            // Render through the host the spec's module initializer already installed. Constructing
+            // one here would reassign the process-wide Host.Instance that WriteLogo resolves its
+            // theme from, and leak that host into the rest of the collection.
+            FalloutBuild.Host.WriteLogo();
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        return writer.ToString();
+    }
+}


### PR DESCRIPTION
Removes the non-printing characters from normal build output.

### What changed
- Both host themes return an empty string for null, empty, or whitespace-only text. They previously returned `U+200B` (zero-width space), so every blank line of build output carried an invisible character.
- `SystemConsoleHostTheme.Format*` routes through the same normalisation. It used to return the input unchanged, so `null` in gave `null` out, and the two themes disagreed.
- `Host.WriteLogo` no longer rewrites every space as `U+00A0` (non-breaking space).
- The blank-text contract is now written on `IHostTheme`.

### Why
`grep "^$"` did not match blank lines in build logs. Copied output carried invisible characters into issues and chat.

The issue named one zero-width-space site. There were two: `SystemConsoleHostTheme.Write` had the same substitution.

Whitespace-only text now renders as an empty line in the system theme, where it previously kept its spaces. That matches what the ANSI theme already did, so the two themes agree.

One risk worth a reviewer eye: the non-breaking spaces may have been intended to stop an HTML-rendering CI log viewer from collapsing the logo indentation. Modern viewers render pre-formatted text, so ordinary spaces should be fine. A spec pins the tagline indentation so a regression here is caught.

### Verification
`dotnet test tests/Fallout.Build.Specs` and `tests/Fallout.Common.Specs`. 13 new specs pass, 12 of which failed before the fix.

Closes #551