### PR TITLE
Draw the target block banner as a box

### DIFF
--- a/src/Fallout.Build/Host.cs
+++ b/src/Fallout.Build/Host.cs
@@ -61,17 +61,20 @@ public partial class Host
     {
         return DelegateDisposable.CreateBracket(() =>
         {
-            var formattedBlockText = text
+            var blockTextLines = text
                 .Split(new[]
                 {
                     EnvironmentInfo.NewLine
-                }, StringSplitOptions.None)
-                .Select(Theme.FormatInformation);
+                }, StringSplitOptions.None);
+
+            // The rule spans the widest content line plus the "║ " prefix. Measure the raw lines,
+            // not the themed ones — theming adds escape sequences that occupy no console cells.
+            var rule = "╬" + '═'.Repeat(blockTextLines.Max(x => x.Length) + 1);
 
             Debug();
-            Debug("╬" + '═'.Repeat(text.Length + 5));
-            formattedBlockText.ForEach(x => Debug($"║ {x}"));
-            Debug("╬" + '═'.Repeat(Math.Max(text.Length - 4, 2)));
+            Debug(rule);
+            blockTextLines.Select(Theme.FormatInformation).ForEach(x => Debug($"║ {x}"));
+            Debug(rule);
             Debug();
         });
     }

--- a/tests/Fallout.Build.Specs/BlockBannerGeometrySpecs.cs
+++ b/tests/Fallout.Build.Specs/BlockBannerGeometrySpecs.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Fallout.Common.Execution.Theming;
+using Fallout.Common.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.Common.Specs;
+
+/// <summary>
+/// Covers the geometry of the target block banner drawn by <see cref="Host.WriteBlock"/>. See #552.
+/// The two rules were sized by unrelated expressions (<c>text.Length + 5</c> and
+/// <c>max(text.Length - 4, 2)</c>), and multi-line text was measured including its newline
+/// characters rather than by its widest line.
+/// </summary>
+[Collection(ProcessGlobalStateCollection.Name)]
+public class BlockBannerGeometrySpecs
+{
+    [Theory]
+    [InlineData("Levels")]
+    [InlineData("A")]
+    [InlineData("Compile")]
+    [InlineData("A considerably longer target name")]
+    public void Both_rules_span_the_same_width(string text)
+    {
+        var (top, _, bottom) = RenderBanner(text);
+
+        top.Length.Should().Be(bottom.Length);
+    }
+
+    [Theory]
+    [InlineData("Levels")]
+    [InlineData("A")]
+    [InlineData("A considerably longer target name")]
+    public void The_rules_span_the_content_line(string text)
+    {
+        var (top, content, bottom) = RenderBanner(text);
+
+        top.Should().HaveLength(content.Single().Length);
+        bottom.Should().HaveLength(content.Single().Length);
+    }
+
+    [Fact]
+    public void A_rule_is_a_junction_followed_by_horizontal_bars()
+    {
+        var (top, _, bottom) = RenderBanner("Compile");
+
+        top.Should().StartWith("╬").And.MatchRegex("^╬═+$");
+        bottom.Should().StartWith("╬").And.MatchRegex("^╬═+$");
+    }
+
+    [Fact]
+    public void Multi_line_text_is_measured_by_its_widest_line()
+    {
+        var text = string.Join(EnvironmentInfo.NewLine, "short", "the widest line here", "mid");
+
+        var (top, content, bottom) = RenderBanner(text);
+
+        content.Should().HaveCount(3);
+        var widest = content.Max(x => x.Length);
+        top.Should().HaveLength(widest);
+        bottom.Should().HaveLength(widest);
+    }
+
+    [Fact]
+    public void Multi_line_text_is_not_measured_by_its_raw_length()
+    {
+        var text = string.Join(EnvironmentInfo.NewLine, "a", "b", "c");
+
+        var (top, _, _) = RenderBanner(text);
+
+        // Raw length is 3 lines plus separators. The widest line is a single character, so a rule
+        // sized off the raw string would be visibly wider than the content.
+        top.Should().HaveLength("║ a".Length);
+    }
+
+    /// <summary>Renders a banner and returns its top rule, content lines, and bottom rule.</summary>
+    private static (string Top, string[] Content, string Bottom) RenderBanner(string text)
+    {
+        var lines = StripAnsi(Capture(() => new BannerHost().WriteBlock(text).Dispose()))
+            .Split('\n')
+            .Select(x => x.TrimEnd('\r'))
+            .Where(x => x.Length > 0)
+            .ToArray();
+
+        var top = lines.First();
+        var bottom = lines.Last();
+        var content = lines.Skip(count: 1).Take(lines.Length - 2).ToArray();
+        return (top, content, bottom);
+    }
+
+    private static string Capture(Action action)
+    {
+        var original = Console.Out;
+        // WriteBlock writes through the static Host.Debug, which resolves the theme from
+        // Host.Instance — and constructing any Host reassigns it. Restore it so this spec doesn't
+        // leak a live console-writing host into the rest of the collection.
+        var instanceProperty = typeof(Host).GetProperty("Instance", ReflectionUtility.Static)
+            .NotNull("typeof(Host).GetProperty(\"Instance\") != null");
+        var originalInstance = instanceProperty.GetValue(obj: null);
+
+        using var writer = new StringWriter();
+        try
+        {
+            Console.SetOut(writer);
+            action.Invoke();
+        }
+        finally
+        {
+            Console.SetOut(original);
+            instanceProperty.SetValue(obj: null, originalInstance);
+        }
+
+        return writer.ToString();
+    }
+
+    /// <summary>
+    /// Drops ANSI escape sequences, and the zero-width space the themes emit for a blank line
+    /// (#551), so the spec sees only the printable banner and is unaffected by that separate fix.
+    /// </summary>
+    private static string StripAnsi(string text) =>
+        Regex.Replace(text, @"\x1b\[[0-9;]*m", string.Empty).Replace("​", string.Empty);
+
+    /// <summary>Concrete <see cref="Host" /> that keeps the base banner rendering.</summary>
+    private class BannerHost : Host
+    {
+        internal override IHostTheme Theme => AnsiConsoleHostTheme.Default256AnsiColorTheme;
+    }
+}


### PR DESCRIPTION
Makes the target block banner symmetric. Before, the two rules had unrelated widths.

### What changed
- Size both rules from the widest content line plus the width of the `║ ` prefix.
- Measure the raw text lines, not the themed ones. Theming adds escape sequences that occupy no console cells.
- Add `BlockBannerGeometrySpecs` over single-line and multi-line block text.

### Why
The top rule was `text.Length + 5` and the bottom was `max(text.Length - 4, 2)`. Multi-line text was measured by the raw string length, which includes the newline characters, so a tall banner got a rule far wider than its widest line.

Before and after, for a target named `Levels`:

```
╬═══════════        ╬═══════
║ Levels            ║ Levels
╬══                 ╬═══════
```

### Verification
`dotnet test tests/Fallout.Build.Specs` — 10 new specs pass, 9 of which failed before the fix. Also confirmed against a real build run.

Closes #552