### PR TITLE
List each CLI parameter once in the help text

### DIFF
--- a/src/Fallout.Build/Execution/ValueInjectionUtility.cs
+++ b/src/Fallout.Build/Execution/ValueInjectionUtility.cs
@@ -86,11 +86,31 @@ internal static class ValueInjectionUtility
 
     public static IReadOnlyCollection<MemberInfo> GetParameterMembers(Type type, bool includeUnlisted)
     {
-        // TODO: check duplicated names
         return GetInjectionMembers(type)
             .Where(x => x.Attribute is ParameterAttribute attribute && (includeUnlisted || attribute.List))
             .Select(x => x.Member)
+            // A build class implementing a component interface can re-declare one of the interface's
+            // parameters. Both members then describe the same CLI parameter, which used to be listed
+            // twice by --help and to overwrite itself in the generated schema. Group by the name the
+            // user actually types and keep the most specific declaration.
+            .GroupBy(ParameterService.GetParameterDashedName, StringComparer.OrdinalIgnoreCase)
+            .Select(x => x
+                .OrderBy(GetDeclarationSpecificity)
+                .ThenBy(y => y.DeclaringType.NotNull().FullName, StringComparer.Ordinal)
+                .Last())
             .OrderBy(ParameterService.GetParameterMemberName).ToList();
+    }
+
+    /// <summary>
+    /// Ranks competing declarations of one parameter. Interface declarations rank below any class
+    /// declaration; among classes, the deeper the inheritance chain, the more specific.
+    /// </summary>
+    private static int GetDeclarationSpecificity(MemberInfo member)
+    {
+        var declaringType = member.DeclaringType.NotNull();
+        return declaringType.IsInterface
+            ? 0
+            : declaringType.Descendants(x => x.BaseType).Count();
     }
 
     public static IReadOnlyCollection<(MemberInfo Member, ValueInjectionAttributeBase Attribute)> GetInjectionMembers(Type type)

--- a/tests/Fallout.Build.Specs/DuplicateParameterSpecs.cs
+++ b/tests/Fallout.Build.Specs/DuplicateParameterSpecs.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Fallout.Common.Execution;
+using Fallout.Common.ValueInjection;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.Common.Specs;
+
+/// <summary>
+/// Covers duplicate CLI parameters in <see cref="ValueInjectionUtility.GetParameterMembers"/>. See
+/// #554. A build class that implements a component interface and re-declares one of the interface's
+/// parameters produced two members for one CLI parameter, so <c>--help</c> listed it twice and the
+/// generated schema silently overwrote one declaration with the other.
+/// </summary>
+public class DuplicateParameterSpecs
+{
+    [Fact]
+    public void A_parameter_re_declared_from_an_interface_is_listed_once()
+    {
+        GetDashedNames<BuildShadowingAnInterfaceParameter>()
+            .Should().ContainSingle(x => x == "api-key");
+    }
+
+    [Fact]
+    public void The_build_class_declaration_wins_over_the_interface()
+    {
+        var member = GetParameters<BuildShadowingAnInterfaceParameter>()
+            .Single(x => ParameterService.GetParameterDashedName(x) == "api-key");
+
+        member.DeclaringType.Should().Be(typeof(BuildShadowingAnInterfaceParameter));
+        // GetParameterDescription trims the trailing period.
+        ParameterService.GetParameterDescription(member).Should().Be("Declared on the build class");
+    }
+
+    [Fact]
+    public void Parameters_that_do_not_collide_are_all_kept()
+    {
+        GetDashedNames<BuildShadowingAnInterfaceParameter>()
+            .Should().Contain(new[] { "api-key", "only-on-the-interface", "only-on-the-build" });
+    }
+
+    [Fact]
+    public void An_uncontested_interface_parameter_is_still_listed()
+    {
+        GetDashedNames<BuildUsingInterfaceParametersOnly>()
+            .Should().Contain("api-key");
+    }
+
+    [Fact]
+    public void Every_listed_parameter_has_a_distinct_dashed_name()
+    {
+        var names = GetDashedNames<BuildShadowingAnInterfaceParameter>();
+
+        names.Should().OnlyHaveUniqueItems();
+    }
+
+    private static MemberInfo[] GetParameters<T>() =>
+        ValueInjectionUtility.GetParameterMembers(typeof(T), includeUnlisted: true).ToArray();
+
+    private static string[] GetDashedNames<T>() =>
+        GetParameters<T>().Select(ParameterService.GetParameterDashedName).ToArray();
+
+    private interface IHaveAnApiKey
+    {
+        [Parameter("Declared on the interface.")]
+        string ApiKey => null;
+
+        [Parameter("Only on the interface.")]
+        string OnlyOnTheInterface => null;
+    }
+
+    // The fields are private on purpose. That is the idiomatic build-class parameter declaration,
+    // and it is what triggers the duplicate: GetAllMembers only drops the interface member when the
+    // class declares a *public* member of the same name.
+    private class BuildShadowingAnInterfaceParameter : FalloutBuild, IHaveAnApiKey
+    {
+        [Parameter("Declared on the build class.")]
+        private readonly string ApiKey;
+
+        [Parameter("Only on the build.")]
+        private readonly string OnlyOnTheBuild;
+    }
+
+    private class BuildUsingInterfaceParametersOnly : FalloutBuild, IHaveAnApiKey
+    {
+    }
+}


### PR DESCRIPTION
Collapses duplicate declarations of one CLI parameter. On this repo, `./build.sh --help` printed `--nuget-api-key` twice.

### What changed
- `ValueInjectionUtility.GetParameterMembers` groups members by the dashed name the user types, and keeps the most specific declaration.
- Precedence is explicit: an interface declaration ranks below any class declaration, and among classes a deeper inheritance chain wins. Ties break on declaring-type name, so the result is deterministic.
- Add `DuplicateParameterSpecs`.

### Why
A build class can implement a component interface and re-declare one of its parameters. `build/Build.cs` does this with `NuGetApiKey`, which `IPublish` also declares. Both members reached the help renderer.

Two notes for review:

- The duplicate only appears when the class declaration is **private**. `GetAllMembers` drops the interface member when the class declares a *public* member of the same name, and the idiomatic build-class parameter is a private readonly field. The specs declare their fields private for this reason.
- The generated schema was also affected. It wrote both members under one JSON key, so the surviving description and type were incidental. Regenerating the schema after this change produces no diff, so the winner happens to match what the overwrite produced.

This resolves the standing `// TODO: check duplicated names` on `GetParameterMembers`.

### Verification
`dotnet test tests/Fallout.Build.Specs` — 5 new specs pass, 3 of which failed before the fix. `./build.sh --help` now lists `--nuget-api-key` once.

Closes #554