### PR TITLE
Add the Information verbosity rung and map levels explicitly

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -52,7 +52,8 @@
         "Verbose",
         "Normal",
         "Minimal",
-        "Quiet"
+        "Quiet",
+        "Information"
       ]
     },
     "FalloutBuild": {

--- a/src/Fallout.Build/Attributes/VerbosityMappingAttribute.cs
+++ b/src/Fallout.Build/Attributes/VerbosityMappingAttribute.cs
@@ -17,6 +17,7 @@ public class VerbosityMappingAttribute : BuildExtensionAttributeBase, IOnBuildIn
 
     public string Quiet { get; set; }
     public string Minimal { get; set; }
+    public string Information { get; set; }
     public string Normal { get; set; }
     public string Verbose { get; set; }
 
@@ -34,6 +35,8 @@ public class VerbosityMappingAttribute : BuildExtensionAttributeBase, IOnBuildIn
             VerbosityMapping.Mappings.Add(targetType, (Verbosity.Quiet, GetMappedValue(Quiet)));
         if (Minimal != null)
             VerbosityMapping.Mappings.Add(targetType, (Verbosity.Minimal, GetMappedValue(Minimal)));
+        if (Information != null)
+            VerbosityMapping.Mappings.Add(targetType, (Verbosity.Information, GetMappedValue(Information)));
         if (Normal != null)
             VerbosityMapping.Mappings.Add(targetType, (Verbosity.Normal, GetMappedValue(Normal)));
         if (Verbose != null)

--- a/src/Fallout.Build/FalloutBuild.Statics.cs
+++ b/src/Fallout.Build/FalloutBuild.Statics.cs
@@ -66,8 +66,8 @@ public abstract partial class FalloutBuild
     [Parameter("Logging verbosity during build execution. Default is 'Normal'.")]
     public static Verbosity Verbosity
     {
-        get => (Verbosity) Logging.Level;
-        set => Logging.Level = (LogLevel) value;
+        get => Logging.Level.ToVerbosity();
+        set => Logging.Level = value.ToLogLevel();
     }
 
     /// <summary>

--- a/src/Fallout.Build/LevelMapping.cs
+++ b/src/Fallout.Build/LevelMapping.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using Serilog.Events;
+
+namespace Fallout.Common;
+
+/// <summary>
+/// Explicit conversions between <see cref="Verbosity"/>, <see cref="LogLevel"/> and Serilog's
+/// <see cref="LogEventLevel"/>.
+/// </summary>
+/// <remarks>
+/// These used to be ordinal casts, which coupled three independently-owned enums by declaration
+/// order: adding a member to any of them silently re-mapped the others. Keep the conversions
+/// exhaustive and explicit. See #556.
+/// </remarks>
+internal static class LevelMapping
+{
+    public static LogLevel ToLogLevel(this Verbosity verbosity)
+        => verbosity switch
+        {
+            Verbosity.Verbose => LogLevel.Trace,
+            Verbosity.Normal => LogLevel.Normal,
+            Verbosity.Information => LogLevel.Information,
+            Verbosity.Minimal => LogLevel.Warning,
+            Verbosity.Quiet => LogLevel.Error,
+            _ => throw new ArgumentOutOfRangeException(nameof(verbosity), verbosity, message: null)
+        };
+
+    public static Verbosity ToVerbosity(this LogLevel level)
+        => level switch
+        {
+            LogLevel.Trace => Verbosity.Verbose,
+            LogLevel.Normal => Verbosity.Normal,
+            LogLevel.Information => Verbosity.Information,
+            LogLevel.Warning => Verbosity.Minimal,
+            LogLevel.Error => Verbosity.Quiet,
+            // Verbosity has no Critical rung, and adding one would give users a setting that hides
+            // ordinary errors. Quiet is the closest thing a user can ask for.
+            LogLevel.Critical => Verbosity.Quiet,
+            _ => throw new ArgumentOutOfRangeException(nameof(level), level, message: null)
+        };
+
+    public static LogEventLevel ToLogEventLevel(this LogLevel level)
+        => level switch
+        {
+            LogLevel.Trace => LogEventLevel.Verbose,
+            LogLevel.Normal => LogEventLevel.Debug,
+            LogLevel.Information => LogEventLevel.Information,
+            LogLevel.Warning => LogEventLevel.Warning,
+            LogLevel.Error => LogEventLevel.Error,
+            LogLevel.Critical => LogEventLevel.Fatal,
+            _ => throw new ArgumentOutOfRangeException(nameof(level), level, message: null)
+        };
+
+    public static LogLevel ToLogLevel(this LogEventLevel level)
+        => level switch
+        {
+            LogEventLevel.Verbose => LogLevel.Trace,
+            LogEventLevel.Debug => LogLevel.Normal,
+            LogEventLevel.Information => LogLevel.Information,
+            LogEventLevel.Warning => LogLevel.Warning,
+            LogEventLevel.Error => LogLevel.Error,
+            LogEventLevel.Fatal => LogLevel.Critical,
+            _ => throw new ArgumentOutOfRangeException(nameof(level), level, message: null)
+        };
+}

--- a/src/Fallout.Build/LogLevel.cs
+++ b/src/Fallout.Build/LogLevel.cs
@@ -1,12 +1,36 @@
-﻿using System;
+using System;
 using System.Linq;
 
 namespace Fallout.Common;
 
+/// <summary>
+/// Minimum severity that reaches the log, in the framework's own vocabulary.
+/// </summary>
+/// <remarks>
+/// Covers the same set of severities as <c>ILogger</c> and Serilog. <see cref="Normal"/> is the
+/// historical name for the debug severity. Members are appended rather than ordered by severity,
+/// because consumers compile the numeric values in. Ordered least to most severe, the ladder is
+/// <see cref="Trace"/>, <see cref="Normal"/>, <see cref="Information"/>, <see cref="Warning"/>,
+/// <see cref="Error"/>, <see cref="Critical"/>. Do not renumber — convert explicitly instead.
+/// See #556.
+/// </remarks>
 public enum LogLevel
 {
+    /// <summary>Trace-level detail.</summary>
     Trace,
+
+    /// <summary>Debug severity, including the output of external tools.</summary>
     Normal,
+
+    /// <summary>Warnings.</summary>
     Warning,
-    Error
+
+    /// <summary>Errors.</summary>
+    Error,
+
+    /// <summary>Informational messages: build steps and tool invocations.</summary>
+    Information,
+
+    /// <summary>Unrecoverable failures. Maps to Serilog's fatal severity.</summary>
+    Critical
 }

--- a/src/Fallout.Build/Logging.cs
+++ b/src/Fallout.Build/Logging.cs
@@ -32,22 +32,8 @@ public static class Logging
 
     public static LogLevel Level
     {
-        get => LevelSwitch.MinimumLevel switch
-        {
-            LogEventLevel.Verbose => LogLevel.Trace,
-            LogEventLevel.Debug => LogLevel.Normal,
-            LogEventLevel.Warning => LogLevel.Warning,
-            LogEventLevel.Error => LogLevel.Error,
-            _ => throw new ArgumentOutOfRangeException(nameof(LevelSwitch), LevelSwitch.MinimumLevel, message: null)
-        };
-        set => LevelSwitch.MinimumLevel = value switch
-        {
-            LogLevel.Trace => LogEventLevel.Verbose,
-            LogLevel.Normal => LogEventLevel.Debug,
-            LogLevel.Warning => LogEventLevel.Warning,
-            LogLevel.Error => LogEventLevel.Error,
-            _ => throw new ArgumentOutOfRangeException(nameof(value), value, message: null)
-        };
+        get => LevelSwitch.MinimumLevel.ToLogLevel();
+        set => LevelSwitch.MinimumLevel = value.ToLogEventLevel();
     }
 
     public static void Configure(IFalloutBuild build = null)

--- a/src/Fallout.Build/Utilities/SchemaUtility.cs
+++ b/src/Fallout.Build/Utilities/SchemaUtility.cs
@@ -59,11 +59,13 @@ public static class SchemaUtility
             ? new JsonObject { ["type"] = "string" }
             : StringEnumSchema(targetNames);
 
+        // Reflected, not hardcoded: the list used to be spelled out here and drifted from the enum
+        // whenever a rung was added. See #556.
         ctx.Definitions["Verbosity"] = new JsonObject
         {
             ["type"] = "string",
             ["description"] = string.Empty,
-            ["enum"] = new JsonArray("Verbose", "Normal", "Minimal", "Quiet")
+            ["enum"] = new JsonArray(Enum.GetNames<Verbosity>().Select(x => (JsonNode)x).ToArray())
         };
 
         // Build the FalloutBuild base schema (all framework-level parameters) and the user extension

--- a/src/Fallout.Build/Verbosity.cs
+++ b/src/Fallout.Build/Verbosity.cs
@@ -1,12 +1,34 @@
-﻿using System;
+using System;
 using System.Linq;
 
 namespace Fallout.Common;
 
+/// <summary>
+/// Logging verbosity of a build run, selected with <c>--verbosity</c>.
+/// </summary>
+/// <remarks>
+/// Members are appended rather than ordered by how much they show, because consumers compile the
+/// numeric values in. Ordered quietest to loudest, the ladder is <see cref="Quiet"/>,
+/// <see cref="Minimal"/>, <see cref="Information"/>, <see cref="Normal"/>, <see cref="Verbose"/>.
+/// Do not renumber — convert explicitly instead. See #556.
+/// </remarks>
 public enum Verbosity
 {
+    /// <summary>Everything, including trace-level detail.</summary>
     Verbose,
+
+    /// <summary>Build steps, plus the output of every external tool that runs.</summary>
     Normal,
+
+    /// <summary>Warnings and errors only.</summary>
     Minimal,
-    Quiet
+
+    /// <summary>Errors only.</summary>
+    Quiet,
+
+    /// <summary>
+    /// Build steps and tool invocations, without the tools' own output. Sits between
+    /// <see cref="Minimal"/> and <see cref="Normal"/>.
+    /// </summary>
+    Information
 }

--- a/tests/Fallout.Build.Specs/CompletionUtilitySpecs.TestGetCompletionItemsParameterBuild.verified.txt
+++ b/tests/Fallout.Build.Specs/CompletionUtilitySpecs.TestGetCompletionItemsParameterBuild.verified.txt
@@ -34,6 +34,7 @@
     Verbose,
     Normal,
     Minimal,
-    Quiet
+    Quiet,
+    Information
   ]
 }

--- a/tests/Fallout.Build.Specs/CompletionUtilitySpecs.TestGetCompletionItemsTargetBuild.verified.txt
+++ b/tests/Fallout.Build.Specs/CompletionUtilitySpecs.TestGetCompletionItemsTargetBuild.verified.txt
@@ -31,6 +31,7 @@
     Verbose,
     Normal,
     Minimal,
-    Quiet
+    Quiet,
+    Information
   ]
 }

--- a/tests/Fallout.Build.Specs/ParameterServiceSpecs.cs
+++ b/tests/Fallout.Build.Specs/ParameterServiceSpecs.cs
@@ -105,6 +105,7 @@ public class ParameterServiceSpecs
         var build = new TestBuild();
         var verbosities = new[]
         {
+            (nameof(Verbosity.Information), Verbosity.Information),
             (nameof(Verbosity.Minimal), Verbosity.Minimal),
             (nameof(Verbosity.Normal), Verbosity.Normal),
             (nameof(Verbosity.Quiet), Verbosity.Quiet),

--- a/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestCustomParameterAttribute.verified.json
+++ b/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestCustomParameterAttribute.verified.json
@@ -20,7 +20,8 @@
         "Verbose",
         "Normal",
         "Minimal",
-        "Quiet"
+        "Quiet",
+        "Information"
       ]
     },
     "FalloutBuild": {

--- a/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestEmptyBuild.verified.json
+++ b/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestEmptyBuild.verified.json
@@ -20,7 +20,8 @@
         "Verbose",
         "Normal",
         "Minimal",
-        "Quiet"
+        "Quiet",
+        "Information"
       ]
     },
     "FalloutBuild": {

--- a/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestParameterBuild.verified.json
+++ b/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestParameterBuild.verified.json
@@ -65,7 +65,8 @@
         "Verbose",
         "Normal",
         "Minimal",
-        "Quiet"
+        "Quiet",
+        "Information"
       ]
     },
     "FalloutBuild": {

--- a/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestTargetBuild.verified.json
+++ b/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestTargetBuild.verified.json
@@ -26,7 +26,8 @@
         "Verbose",
         "Normal",
         "Minimal",
-        "Quiet"
+        "Quiet",
+        "Information"
       ]
     },
     "FalloutBuild": {

--- a/tests/Fallout.Build.Specs/VerbosityLevelMappingSpecs.cs
+++ b/tests/Fallout.Build.Specs/VerbosityLevelMappingSpecs.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Fallout.Common.Execution;
+using FluentAssertions;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Xunit;
+
+namespace Fallout.Common.Specs;
+
+/// <summary>
+/// Covers the verbosity ladder and the conversions between <see cref="Verbosity" />,
+/// <see cref="LogLevel" /> and Serilog's <see cref="LogEventLevel" />. See #556.
+///
+/// Before this, there was no setting that showed information and above: Normal mapped to Serilog
+/// Debug (every line of external tool output) and Minimal jumped straight to Warning. The two enums
+/// were also converted by raw ordinal cast, and the <see cref="Logging.Level" /> getter threw for the
+/// Information and Fatal minimums.
+/// </summary>
+[Collection(ProcessGlobalStateCollection.Name)]
+public class VerbosityLevelMappingSpecs
+{
+    [Theory]
+    [InlineData(Verbosity.Verbose, LogEventLevel.Verbose)]
+    [InlineData(Verbosity.Normal, LogEventLevel.Debug)]
+    [InlineData(Verbosity.Information, LogEventLevel.Information)]
+    [InlineData(Verbosity.Minimal, LogEventLevel.Warning)]
+    [InlineData(Verbosity.Quiet, LogEventLevel.Error)]
+    public void Each_verbosity_selects_its_serilog_minimum(Verbosity verbosity, LogEventLevel expected)
+    {
+        WithVerbosity(verbosity, () => Logging.LevelSwitch.MinimumLevel.Should().Be(expected));
+    }
+
+    [Fact]
+    public void The_information_rung_shows_information_and_hides_debug()
+    {
+        WithVerbosity(Verbosity.Information, () =>
+        {
+            var written = Capture();
+
+            written.Should().NotContain(LogEventLevel.Debug);
+            written.Should().Contain(LogEventLevel.Information);
+            written.Should().Contain(LogEventLevel.Warning);
+            written.Should().Contain(LogEventLevel.Error);
+        });
+    }
+
+    [Fact]
+    public void The_normal_rung_still_shows_debug()
+    {
+        WithVerbosity(Verbosity.Normal, () => Capture().Should().Contain(LogEventLevel.Debug));
+    }
+
+    [Theory]
+    [InlineData(Verbosity.Verbose)]
+    [InlineData(Verbosity.Normal)]
+    [InlineData(Verbosity.Information)]
+    [InlineData(Verbosity.Minimal)]
+    [InlineData(Verbosity.Quiet)]
+    public void Verbosity_round_trips_through_the_log_level(Verbosity verbosity)
+    {
+        WithVerbosity(verbosity, () => FalloutBuild.Verbosity.Should().Be(verbosity));
+    }
+
+    [Theory]
+    [MemberData(nameof(AllLogEventLevels))]
+    public void Every_serilog_level_maps_to_a_defined_log_level(LogEventLevel level)
+    {
+        var originalVerbosity = FalloutBuild.Verbosity;
+        try
+        {
+            Logging.LevelSwitch.MinimumLevel = level;
+
+            // The getter used to throw for Information and Fatal.
+            var mapped = Logging.Level;
+
+            Enum.IsDefined(mapped).Should().BeTrue();
+        }
+        finally
+        {
+            FalloutBuild.Verbosity = originalVerbosity;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(AllLogEventLevels))]
+    public void Every_serilog_level_round_trips_through_the_log_level(LogEventLevel level)
+    {
+        var originalVerbosity = FalloutBuild.Verbosity;
+        try
+        {
+            Logging.LevelSwitch.MinimumLevel = level;
+            var mapped = Logging.Level;
+
+            Logging.Level = mapped;
+
+            Logging.LevelSwitch.MinimumLevel.Should().Be(level);
+        }
+        finally
+        {
+            FalloutBuild.Verbosity = originalVerbosity;
+        }
+    }
+
+    [Fact]
+    public void The_conversion_is_not_an_ordinal_cast()
+    {
+        // LogLevel carries a Critical rung that Verbosity has no member for. An ordinal cast would
+        // produce an undefined Verbosity value; the explicit mapping picks the closest rung.
+        var originalVerbosity = FalloutBuild.Verbosity;
+        try
+        {
+            Logging.Level = LogLevel.Critical;
+
+            var verbosity = FalloutBuild.Verbosity;
+
+            Enum.IsDefined(verbosity).Should().BeTrue("an ordinal cast would yield (Verbosity)5");
+            verbosity.Should().Be(Verbosity.Quiet);
+        }
+        finally
+        {
+            FalloutBuild.Verbosity = originalVerbosity;
+        }
+    }
+
+    [Fact]
+    public void Existing_verbosity_members_keep_their_numeric_values()
+    {
+        // Consumers compile these constants in, so adding a rung must not renumber the others.
+        ((int)Verbosity.Verbose).Should().Be(0);
+        ((int)Verbosity.Normal).Should().Be(1);
+        ((int)Verbosity.Minimal).Should().Be(2);
+        ((int)Verbosity.Quiet).Should().Be(3);
+    }
+
+    [Fact]
+    public void Existing_log_level_members_keep_their_numeric_values()
+    {
+        ((int)LogLevel.Trace).Should().Be(0);
+        ((int)LogLevel.Normal).Should().Be(1);
+        ((int)LogLevel.Warning).Should().Be(2);
+        ((int)LogLevel.Error).Should().Be(3);
+    }
+
+    public static TheoryData<LogEventLevel> AllLogEventLevels
+    {
+        get
+        {
+            var data = new TheoryData<LogEventLevel>();
+            foreach (var level in Enum.GetValues<LogEventLevel>())
+                data.Add(level);
+            return data;
+        }
+    }
+
+    /// <summary>Runs <paramref name="assert" /> at a given verbosity, then restores the previous one.</summary>
+    private static void WithVerbosity(Verbosity verbosity, Action assert)
+    {
+        var original = FalloutBuild.Verbosity;
+        try
+        {
+            FalloutBuild.Verbosity = verbosity;
+            assert.Invoke();
+        }
+        finally
+        {
+            FalloutBuild.Verbosity = original;
+        }
+    }
+
+    /// <summary>
+    /// Logs one event per level through a logger gated by the shared level switch, and returns the
+    /// levels that survived the gate.
+    /// </summary>
+    private static LogEventLevel[] Capture()
+    {
+        var sink = new CollectingSink();
+        var logger = new LoggerConfiguration()
+            .MinimumLevel.ControlledBy(Logging.LevelSwitch)
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        foreach (var level in Enum.GetValues<LogEventLevel>())
+            logger.Write(level, "a {Level} line", level);
+
+        return sink.Levels.ToArray();
+    }
+
+    private class CollectingSink : ILogEventSink
+    {
+        public List<LogEventLevel> Levels { get; } = new();
+
+        public void Emit(LogEvent logEvent) => Levels.Add(logEvent.Level);
+    }
+}

--- a/tests/Fallout.Common.Specs/CI/ConfigurationGenerationSpecs.Test_testName=null_attribute=TeamCityAttribute.verified.txt
+++ b/tests/Fallout.Common.Specs/CI/ConfigurationGenerationSpecs.Test_testName=null_attribute=TeamCityAttribute.verified.txt
@@ -82,7 +82,7 @@ project {
             label = "Verbosity",
             description = "Logging verbosity during build execution. Default is 'Normal'.",
             value = "Normal",
-            options = listOf("Minimal" to "Minimal", "Normal" to "Normal", "Quiet" to "Quiet", "Verbose" to "Verbose"),
+            options = listOf("Information" to "Information", "Minimal" to "Minimal", "Normal" to "Normal", "Quiet" to "Quiet", "Verbose" to "Verbose"),
             display = ParameterDisplay.NORMAL)
         password (
             "env.GitHubToken",


### PR DESCRIPTION
Adds the missing rung between `Minimal` and `Normal`. There was no verbosity setting that showed information and above.

### What changed
- Append `Verbosity.Information`, `LogLevel.Information` and `LogLevel.Critical`, so both enums cover the same severities as `ILogger` and Serilog. Members are appended, not renumbered, so existing numeric values are unchanged.
- New `LevelMapping` holds exhaustive conversions between `Verbosity`, `LogLevel` and Serilog `LogEventLevel`. This replaces the ordinal casts in `FalloutBuild.Verbosity` and the partial switch statements in `Logging.Level`.
- `Logging.Level` returns a value for every `LogEventLevel`. It used to throw for the Information and Fatal minimums, and `LoggingLevelSwitch` defaults to Information.
- `VerbosityMappingAttribute` takes an `Information` value, so tool wrappers can map the new rung.
- `SchemaUtility` reflects the `Verbosity` members instead of listing them inline.

### Why
External tool output defaults to the Serilog Debug level, and `Verbosity.Normal` selects Debug as its minimum. The default therefore streams every line of `dotnet`, `git` and `npm` output as `[DBG]`. The only quieter setting was `Minimal`, which also hides `[INF]` and so hides which commands ran.

Measured on a build that shells out to `git` and `dotnet`:

| `--verbosity` | `[DBG]` | `[INF]` | `[WRN]` | `[ERR]` |
|---|---|---|---|---|
| `Normal` | 47 | 3 | 2 | 2 |
| `Information` | 0 | 3 | 2 | 2 |
| `Minimal` | 0 | 0 | 2 | 2 |

At `Information` the tool invocation lines survive, so you still see `> /usr/bin/git --version` without the tool output.

Two things a reviewer should weigh:

- **The default is unchanged.** `Normal` still selects Debug. Moving the default off the firehose is a separate decision, and it belongs with #104.
- **`LogLevel.Critical` maps to `Verbosity.Quiet`.** `Verbosity` has no Critical rung, and adding one would give users a setting that hides ordinary errors. This is the one lossy direction, and a spec pins it.

`Verbosity` members are appended rather than ordered by how much they show. That reads oddly in the source, but renumbering a public enum is a breaking change for consumers that compile the constants in. The mapping is explicit precisely so declaration order stops mattering. Specs pin the existing numeric values.

### What the snapshot churn is
The added enum member flows into generated output: four `SchemaUtilitySpecs` schemas, both `CompletionUtilitySpecs` item lists, the TeamCity generated configuration, and the hardcoded value set in `ParameterServiceSpecs`. All updated.

### Verification
`dotnet test` on `Fallout.Build.Specs`, `Fallout.Common.Specs`, `Fallout.Cli.Specs` and `Fallout.Tooling.Specs`. 27 new specs pass, 8 of which failed before the mapping commit. Behaviour confirmed end to end against a build that shells out to real tools, per the table above.

Closes #556