### PR TITLE
Make the workflow_dispatch publish path actually publish

### DIFF
--- a/.github/workflows/publish-packages-release.yml
+++ b/.github/workflows/publish-packages-release.yml
@@ -142,11 +142,27 @@ jobs:
   # (see header comment). When a release/YYYY production line is ready for the
   # broad audience — or for cutting a support/v10 maintenance patch — invoke
   # workflow_dispatch with the flag set.
+  #
+  # The condition below accepts the string 'true' as well as the boolean. A
+  # `type: boolean` input only arrives as a real boolean when the run is started
+  # from the Actions UI; the REST API — and therefore `gh workflow run`, which
+  # rejects a JSON boolean outright — can only send strings. Comparing a string
+  # to a boolean casts both to numbers ('true' → NaN, true → 1), so a bare
+  # `== true` silently skipped every CLI-triggered publish while the run still
+  # reported success. See the runbook's `gh workflow run` invocation.
   publish-nuget-org:
     name: publish → nuget.org
     runs-on: ubuntu-latest
     needs: [test-and-pack]
-    if: github.event_name == 'workflow_dispatch' && inputs.publish-to-nugetorg == true
+    # `always() && needs...result == 'success'` rather than a bare dependency:
+    # validate-ref is skipped by design on workflow_dispatch, and a skipped job
+    # propagates through the graph — test-and-pack's own always() rescues only
+    # itself, not its dependents. Without this the whole dispatch path silently
+    # published nothing while the run still reported success.
+    if: >-
+      always() && needs.test-and-pack.result == 'success'
+      && github.event_name == 'workflow_dispatch'
+      && (inputs.publish-to-nugetorg == true || inputs.publish-to-nugetorg == 'true')
     environment:
       name: nuget-org
       url: https://www.nuget.org/profiles/Fallout
@@ -186,6 +202,10 @@ jobs:
     name: publish → GitHub Packages
     runs-on: ubuntu-latest
     needs: [test-and-pack]
+    # See publish-nuget-org: survives validate-ref's by-design skip on
+    # workflow_dispatch, which is what makes a re-run after a partial publish
+    # actually re-publish.
+    if: always() && needs.test-and-pack.result == 'success'
     permissions:
       packages: write
     environment:
@@ -225,6 +245,8 @@ jobs:
     name: publish → GitHub Releases
     runs-on: ubuntu-latest
     needs: [test-and-pack]
+    # See publish-nuget-org.
+    if: always() && needs.test-and-pack.result == 'success'
     permissions:
       contents: write
     environment:


### PR DESCRIPTION
The `workflow_dispatch` path on `publish-packages-release.yml` could never publish anything. It is the documented way to publish to nuget.org and the documented way to retry a partial publish — both silently did nothing while the run reported **success**.

Found while publishing `v10.4.0-rc.4`: run [30202826208](https://github.com/Fallout-build/Fallout/actions/runs/30202826208) shows `test + pack: success` with all three publish jobs `skipped`, and a green overall conclusion.

### Two independent causes

**1. Skip propagation.** `validate-ref` is skipped by design on `workflow_dispatch` (`if: github.event_name == 'push'`), and a skipped job propagates through the dependency graph. `test-and-pack` survives with `always()` — but that rescues only itself; its dependents still saw a skipped ancestor. This is why `publish-github-packages` and `publish-github-releases` skipped **despite carrying no condition at all**, which is the part that makes the failure so quiet.

**2. The boolean compare.** The opt-in was `inputs.publish-to-nugetorg == true`. A `type: boolean` input is only a real boolean when the run starts from the Actions UI; the REST API can only send strings, and `gh workflow run` rejects a JSON boolean outright (`cannot unmarshal bool into Go value of type string`). Comparing a string to a boolean casts both to numbers — `'true'` → NaN, `true` → 1 — so the opt-in never matched from the CLI, including the exact invocation in [docs/branching-and-release.md](https://github.com/Fallout-build/Fallout/blob/release/v10.4/docs/branching-and-release.md).

### Fix

All three publish jobs gate on `always() && needs.test-and-pack.result == 'success'`, and the opt-in accepts the string as well as the boolean.

Tag-push behaviour is unchanged: `validate-ref` still gates it, and nuget.org still requires both the flag and the `nuget-org` environment approval. This also makes the runbook's "re-running a publish job is idempotent" claim true for the first time.

### Verification

Merging this and re-dispatching for `v10.4.0-rc.4` is the test — `publish → nuget.org` should reach the approval gate instead of skipping. No code change, so `Test`/`Pack` are unaffected.
