### PR TITLE
Forward-port the release-pipeline fixes from release/v10.4

### DIFF
--- a/.github/workflows/publish-packages-release.yml
+++ b/.github/workflows/publish-packages-release.yml
@@ -165,7 +165,7 @@ jobs:
       && (inputs.publish-to-nugetorg == true || inputs.publish-to-nugetorg == 'true')
     environment:
       name: nuget-org
-      url: https://www.nuget.org/profiles/Fallout
+      url: https://www.nuget.org/profiles/Fallout.build
     steps:
       - name: 'Setup: .NET SDK'
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/publish-packages-release.yml
+++ b/.github/workflows/publish-packages-release.yml
@@ -142,11 +142,27 @@ jobs:
   # (see header comment). When a release/YYYY production line is ready for the
   # broad audience — or for cutting a support/v10 maintenance patch — invoke
   # workflow_dispatch with the flag set.
+  #
+  # The condition below accepts the string 'true' as well as the boolean. A
+  # `type: boolean` input only arrives as a real boolean when the run is started
+  # from the Actions UI; the REST API — and therefore `gh workflow run`, which
+  # rejects a JSON boolean outright — can only send strings. Comparing a string
+  # to a boolean casts both to numbers ('true' → NaN, true → 1), so a bare
+  # `== true` silently skipped every CLI-triggered publish while the run still
+  # reported success. See the runbook's `gh workflow run` invocation.
   publish-nuget-org:
     name: publish → nuget.org
     runs-on: ubuntu-latest
     needs: [test-and-pack]
-    if: github.event_name == 'workflow_dispatch' && inputs.publish-to-nugetorg == true
+    # `always() && needs...result == 'success'` rather than a bare dependency:
+    # validate-ref is skipped by design on workflow_dispatch, and a skipped job
+    # propagates through the graph — test-and-pack's own always() rescues only
+    # itself, not its dependents. Without this the whole dispatch path silently
+    # published nothing while the run still reported success.
+    if: >-
+      always() && needs.test-and-pack.result == 'success'
+      && github.event_name == 'workflow_dispatch'
+      && (inputs.publish-to-nugetorg == true || inputs.publish-to-nugetorg == 'true')
     environment:
       name: nuget-org
       url: https://www.nuget.org/profiles/Fallout
@@ -186,6 +202,10 @@ jobs:
     name: publish → GitHub Packages
     runs-on: ubuntu-latest
     needs: [test-and-pack]
+    # See publish-nuget-org: survives validate-ref's by-design skip on
+    # workflow_dispatch, which is what makes a re-run after a partial publish
+    # actually re-publish.
+    if: always() && needs.test-and-pack.result == 'success'
     permissions:
       packages: write
     environment:
@@ -225,6 +245,8 @@ jobs:
     name: publish → GitHub Releases
     runs-on: ubuntu-latest
     needs: [test-and-pack]
+    # See publish-nuget-org.
+    if: always() && needs.test-and-pack.result == 'success'
     permissions:
       contents: write
     environment:

--- a/.github/workflows/publish-packages-release.yml
+++ b/.github/workflows/publish-packages-release.yml
@@ -118,6 +118,13 @@ jobs:
         run: dotnet tool restore
       - name: 'Run: Test + Pack'
         run: dotnet fallout Test Pack
+        env:
+          # We check out the tag above, so HEAD is detached and matches none of
+          # version.json's publicReleaseRefSpec entries (they're all branch refs,
+          # and nbgv never matches that spec against refs/tags/*). Without this,
+          # NB.GV treats the build as non-public and stamps a git-height suffix
+          # onto every package — v10.4.0-rc.3 shipped as 10.4.0-rc.3.geabd043cc2.
+          PublicRelease: true
       - name: 'Upload: package artifacts'
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Forward-ports the two release-pipeline fixes made on `release/v10.4` while cutting `v10.4.0-rc.4`. Both were found by shipping that rc; `main` still carries them, and any release branch cut from `main` would reinherit both.

Workflow-only — no product code, no version.json change (the rc pin in [#563](https://github.com/Fallout-build/Fallout/pull/563) is release-branch-only by design and is deliberately **not** ported; `main` keeps `{height}` for per-commit previews).

### 1. Packages were stamped with a git-height suffix

`v10.4.0-rc.3` shipped 22 packages named `10.4.0-rc.3.geabd043cc2`. The pipeline checks out the tag, so HEAD is detached and matches none of `version.json`'s `publicReleaseRefSpec` entries — they're all branch refs, and NB.GV never tests that spec against `refs/tags/*`. `PublicRelease` is now set explicitly on Test + Pack.

Worst at GA: a stable tag would publish with a prerelease-shaped suffix and sort *below* the version it claims to be.

### 2. The whole `workflow_dispatch` publish path was unreachable

Two independent causes, both silent — the run reported **success** while publishing nothing ([evidence](https://github.com/Fallout-build/Fallout/actions/runs/30202826208): `test + pack: success`, all three publish jobs `skipped`, green overall):

- **Skip propagation.** `validate-ref` is skipped by design on `workflow_dispatch`, and a skipped job propagates through the graph. `test-and-pack` survives with `always()`, but that rescues only itself — its dependents still saw a skipped ancestor. This skipped `publish-github-packages` and `publish-github-releases` *despite them carrying no condition at all*.
- **Boolean compare.** `inputs.publish-to-nugetorg == true` only matches when the run starts from the Actions UI. The REST API can only send strings and `gh workflow run` rejects a JSON boolean outright, so string-vs-boolean cast both to numbers (`'true'` → NaN) and the opt-in never matched from the CLI — including the invocation in `docs/branching-and-release.md`.

All three publish jobs now gate on `always() && needs.test-and-pack.result == 'success'`, and the opt-in accepts the string as well as the boolean.

### Verified on `release/v10.4`

`v10.4.0-rc.4` published clean, unsuffixed packages, and the re-dispatch reached the `nuget-org` approval gate instead of skipping. Tag-push behaviour is unchanged — `validate-ref` still gates it, nuget.org still needs both the flag and the environment approval.

Runbook wording is a separate follow-up PR.
