### PR TITLE
Bring the release runbook up to date, protect release branches, and fix main's preview version

### DIFF
--- a/.github/release-branch-ruleset.json
+++ b/.github/release-branch-ruleset.json
@@ -1,0 +1,64 @@
+{
+  "name": "Protect release/** production lines",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/release/**"
+      ]
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": true,
+        "dismissal_restriction": {
+          "enabled": false,
+          "allowed_actors": []
+        },
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": [
+          "merge",
+          "squash",
+          "rebase"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "ubuntu-latest",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/agents/release-and-versioning.md
+++ b/docs/agents/release-and-versioning.md
@@ -8,7 +8,7 @@ The branch/channel/versioning model is defined by [ADR-0004](../adr/0004-calenda
 
 A two-tier maturity ladder (`main` → `release/YYYY`) feeding the production line. GitHub Packages = test/preview; nuget.org = production. Long-lived branches:
 
-- `main` — the **integration trunk *and* the sole prerelease lane.** Default branch. **Both** deliberate improvements + bug fixes **and** faster/AI-assisted work land here. Every push publishes an NB.GV-native prerelease `YYYY.MINOR.PATCH-preview.<height>.g<commit>` (e.g. `2026.1.0-preview.42.gfbb83ef`) to **GitHub Packages only — never nuget.org.** Ordinary review.
+- `main` — the **integration trunk *and* the sole prerelease lane.** Default branch. **Both** deliberate improvements + bug fixes **and** faster/AI-assisted work land here. Every push publishes an NB.GV-native prerelease `YYYY.MINOR.PATCH-preview.<height>.g<commit>` (currently `10.4.0-preview.<height>.g<commit>`, on the 10.x line) to **GitHub Packages only — never nuget.org.** Ordinary review.
 - `release/YYYY` (e.g. `release/2026`) — the **production line** for the calendar year. **Cut from `main` on demand at the first release of the year, not preemptively** ([ADR-0007](../adr/0007-cut-release-branch-on-demand.md)); until then `main` (`-preview`) is the most-stable line. Hardened deliberately (slow crowd's domain, rigorous review), `-rc.N` → GA. After the cut it takes **non-breaking minors + patches only** — never a breaking change. Tag-triggered releases fire from here (the nuget.org tier). Protected per the policy below.
 - `support/v10` (+ `hotfix/v10.1`, `hotfix/v10.2`) — **legacy semver maintenance line**, `10.x`, **security and critical fixes only, no new features** (renamed from `release/v10`). Not renumbered into CalVer. Coexists indefinitely.
 - `support/YYYY` — a **retired** year production line (e.g. `support/2026` once 2027 supersedes it). Security/critical fixes only.
@@ -50,8 +50,8 @@ Tag protection for `v*` tags is a separate ruleset ([17017817](https://github.co
 **Calendar versioning: `YYYY.MINOR.PATCH`** (see [ADR-0004](../adr/0004-calendar-versioning-and-dual-pace-channels.md), as amended by [ADR-0008](../adr/0008-collapse-experimental-into-main.md)). It is mechanically valid SemVer 2.0 — all three components are numeric — so [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning), NuGet, and version ordering all work unchanged. The major *is* the calendar year.
 
 - **`MAJOR` = year**, hand-set in `version.json` at the yearly cut. **`MINOR`** = feature drop within the year. **`PATCH`** = git-height fixes.
-- Per-branch via `version.json`. The preview lane is a **non-public ref** carrying the next planned version with a prerelease tag: `main` → `"2026.1.0-preview.{height}"` (`firstUnstableTag` is `preview`). Each `release/YYYY` carries `"version": "YYYY.x"`; `support/v10` keeps `"version": "10.x"`; `support/YYYY` keeps `"version": "YYYY.x"`. `publicReleaseRefSpec` matches the three production patterns: `^refs/heads/release/\d{4}$`, `^refs/heads/support/\d{4}$`, `^refs/heads/support/v\d+$` (**not** `main`).
-- Preview-lane builds carry the height + commit in the **prerelease segment** (`2026.1.0-preview.<height>.g<commit>`), never the version core — a core like `2026.05.29` would parse as a *stable* release, not a nightly. `main` is a non-public ref, so NB.GV appends the `.g<commit>` suffix. The ladder orders cleanly: `-preview` < `-rc` < GA.
+- Per-branch via `version.json`. The preview lane is a **non-public ref** carrying the next planned version with a prerelease tag: `main` → `"10.4.0-preview.{height}"` (`firstUnstableTag` is `preview`). Each `release/YYYY` carries `"version": "YYYY.x"`; the current `release/v10.4` pins its prerelease literally (`"version": "10.4.0-rc.N"` — a manual counter, see the runbook); `support/v10` keeps `"version": "10.x"`; `support/YYYY` keeps `"version": "YYYY.x"`. `publicReleaseRefSpec` matches the four production patterns: `^refs/heads/release/\d{4}$`, `^refs/heads/release/v\d+\.\d+$`, `^refs/heads/support/\d{4}$`, `^refs/heads/support/v\d+$` (**not** `main`).
+- Preview-lane builds carry the height + commit in the **prerelease segment** (`10.4.0-preview.<height>.g<commit>`), never the version core — a core like `2026.05.29` would parse as a *stable* release, not a nightly. `main` is a non-public ref, so NB.GV appends the `.g<commit>` suffix. The ladder orders cleanly: `-preview` < `-rc` < GA.
 
 GitVersion is still installed as a transitional helper for `MajorMinorPatchVersion` in `Build.cs`; full removal is a follow-up.
 
@@ -97,7 +97,7 @@ If you only discover the breaking nature mid-review, apply all relevant steps be
 
 ## Release pipeline
 
-`.github/workflows/publish-packages-release.yml` is **tag-triggered**: pushing a `v*` tag on a production branch (`release/YYYY` or `support/*`) fires the pipeline. The workflow validates the tag is reachable from such a branch, then fans out a Test+Pack job to three parallel publish jobs:
+`.github/workflows/publish-packages-release.yml` is **tag-triggered**: pushing a `v*` tag on a production branch (`release/YYYY`, `release/vMAJOR.MINOR`, or `support/*`) fires the pipeline. The workflow validates the tag is reachable from such a branch, then fans out a Test+Pack job to three parallel publish jobs:
 
 | Job | Environment | Fires on tag push? | What ships | Gating |
 |---|---|---|---|---|

--- a/docs/agents/release-and-versioning.md
+++ b/docs/agents/release-and-versioning.md
@@ -22,22 +22,28 @@ CI providers in use: **GitHub Actions only** (others were dropped — see [#8](h
 
 ### Branch protection on `release/YYYY` and `support/*`
 
-`main`, every `release/YYYY`, and every `support/*` branch share `main`'s protection profile:
+`main`, every release line, and every `support/*` branch share the same protection profile:
 
 - Required status check: `ubuntu-latest`
 - Linear history required (no merge commits)
-- CODEOWNER review required
-- Dismiss stale approvals when new commits land
+- CODEOWNER review required (0 additional approvals)
 - Direct pushes blocked (PRs only)
 - Force-push and branch deletion blocked
 - Conversation resolution required
 - Admins not enforced (admins can bypass in emergencies)
 
-Apply by mirroring `main`'s protection JSON to the new branch via the GitHub API (or via repo Settings → Branches). Tag protection for `v*` tags (restricting who can fire a release tag) is tracked separately under milestone #13.
+Stale approvals are **not** dismissed when new commits land (`dismiss_stale_reviews: false`).
+
+**How it's applied differs by branch:**
+
+- **Release lines** (`release/v10.4`, a future `release/2027`) — covered by the pattern-based ruleset on `refs/heads/release/**` ([19766406](https://github.com/Fallout-build/Fallout/rules/19766406)), so protection attaches automatically at branch creation. Payload committed at `.github/release-branch-ruleset.json`. **Nothing to apply by hand.**
+- **`main` and `support/*`** — classic per-branch protection, configured individually.
+
+Tag protection for `v*` tags is a separate ruleset ([17017817](https://github.com/Fallout-build/Fallout/rules/17017817)).
 
 **Validation workflows.** `build.yml` runs Test+Pack on Linux on every PR targeting `main`, `release/*`, or `support/*` (with `paths-ignore` for `docs/**`, `.assets/**`, `**/*.md`); its job `ubuntu-latest` is the only required status check. `build-cross-platform.yml` runs Test+Pack on Windows and macOS (one job each) only on PRs targeting `release/*` / `support/*` and on `v*` tag pushes — cross-platform is gated to release intent, not routine `main` work. This is a deliberate cost trade-off. (Both workflows are **generated** from `build/Build.CI.GitHubActions.cs` — change the branch lists in the `MainBranch`/`*BranchPattern` constants there and regenerate, don't hand-edit the `.yml`. The `build-skip.yml` no-op shim reports the `ubuntu-latest` check on docs-only PRs.)
 
-**Merging.** Rebase merge only — squash and plain merge commits are both disabled by repo setting (linear history). Every reviewed commit lands on `main` verbatim, so curate commits into a clean sequence before final approval. See [CONTRIBUTING.md → Merging](https://github.com/Fallout-build/Fallout/blob/main/CONTRIBUTING.md#merging) for the convention.
+**Merging.** Rebase merge only. Plain merge commits are disabled by repo setting; **squash is still enabled at the repo level**, so on release branches the convention — not the setting — is what keeps squashes out. Squashing a promotion would collapse it into one opaque commit, defeating the point of promoting reviewed commits verbatim. Every reviewed commit lands on `main` verbatim, so curate commits into a clean sequence before final approval. See [CONTRIBUTING.md → Merging](https://github.com/Fallout-build/Fallout/blob/main/CONTRIBUTING.md#merging) for the convention.
 
 ## Versioning
 

--- a/docs/branching-and-release.md
+++ b/docs/branching-and-release.md
@@ -40,6 +40,15 @@ Releases fire to multiple channels, each with its own GitHub Environment:
 
 ## Cutting a release
 
+### Prerelease numbers on a release branch are a manual counter
+
+On a release branch, `version.json`'s `version` pins the prerelease number literally — `10.4.0-rc.4`, not `10.4.0-rc.{height}`. **Bump it in a PR before you tag.** Two consequences:
+
+- Every commit on the branch reports the same version until you bump, so the number tracks *release intent* rather than however many commits a promotion happened to carry. (`{height}` sent `rc.3` straight to `rc.23` on the first 19-commit promotion.)
+- Tagging twice without bumping republishes an existing version. `dotnet nuget push --skip-duplicate` swallows that silently, so the packages simply won't update — **check the number first**.
+
+`main` keeps `{height}` (`10.0.0-preview.{height}`): per-commit previews want a value that always moves on its own.
+
 ### Routine stable release (GitHub Packages only)
 
 The default path. Pushing a `v2026.1.X` tag to `release/2026` publishes to GitHub Packages + GitHub Releases. nuget.org is **not** touched. (Git tags keep the `v` prefix — `v2026.1.3` — so the `v*` tag-protection ruleset and `validate-ref` apply; the package version core is `2026.1.3`.)
@@ -53,12 +62,22 @@ git pull --ff-only
 # 2. (Optional) Verify what version NB.GV will compute
 dotnet nbgv get-version   # should report 2026.1.X clean, no -g<sha>
 
-# 3. Create the tag + GitHub Release in one step
+# 3. Create the tag + GitHub Release in one step.
+#    --notes-start-tag is load-bearing: see "Release notes" below.
 gh release create v2026.1.X \
     --target release/2026 \
     --title "v2026.1.X" \
-    --generate-notes
+    --generate-notes \
+    --notes-start-tag <last-GA-tag>     # e.g. 10.3.47, NOT the previous rc
 ```
+
+### Release notes
+
+**Always use `--generate-notes`.** It groups merged PRs by the label taxonomy in [`.github/release.yml`](https://github.com/Fallout-build/Fallout/blob/main/.github/release.yml) and credits every contributor, including a "New Contributors" section. Don't hand-write notes.
+
+**Set `--notes-start-tag` to the last GA tag, not the previous prerelease.** Left to itself, `gh` picks the most recent tag — so an rc diffs against the rc before it and the notes collapse to whatever landed in between. Anchoring on the last GA (`10.3.47` for the 10.4 line) makes every rc's notes show the full set of changes since the last real release, which is what someone evaluating an rc wants to read.
+
+One known gap: work promoted onto a release branch by cherry-pick gets **new commit SHAs**, so GitHub can't map it back to the PRs it came from and it shows up as the single promotion PR instead of the individual ones. The pre-cut history (inherited when the branch was cut) maps fine. If a promotion carried work worth itemising, add a short summary paragraph above the generated section rather than replacing it.
 
 That tag push triggers `.github/workflows/publish-packages-release.yml`:
 

--- a/docs/branching-and-release.md
+++ b/docs/branching-and-release.md
@@ -178,12 +178,10 @@ git pull --ff-only
 git switch -c release/2027 main
 git push -u origin release/2027
 
-# 3. Apply branch protection (mirror main's profile — see
-#    docs/agents/release-and-versioning.md → Branch protection on release/YYYY).
-#    NOTE: scripts/release-branch-protection.json does not exist yet; capture
-#    main's live protection JSON into it (or apply via repo Settings → Branches).
-gh api -X PUT repos/Fallout-build/Fallout/branches/release/2027/protection \
-    --input scripts/release-branch-protection.json
+# 3. Nothing to do — branch protection is already in force. The "Protect
+#    release/** production lines" ruleset targets refs/heads/release/**, so a
+#    new release branch is protected the moment it is pushed. See
+#    "Branch protection" below.
 
 # 4. On release/2027 (the branch itself), set version.json "version": "2027.0".
 #    publicReleaseRefSpec already matches "^refs/heads/release/\\d{4}$" — confirm
@@ -210,6 +208,27 @@ Once a `support/YYYY` or `support/v10` line hits end-of-life:
 4. Optionally apply a more restrictive protection profile (e.g. require admin approval on every merge) to make accidental tags less likely.
 
 Branches are cheap. Deletion is destructive. Default to keeping.
+
+## Branch protection
+
+Production branches are protected by the **"Protect release/\*\* production lines"** ruleset ([ruleset 19766406](https://github.com/Fallout-build/Fallout/rules/19766406)), which targets `refs/heads/release/**`. Because it matches on a pattern, every release line — `release/v10.4` today, a `release/2027` CalVer cut later — is protected the moment the branch exists. There is no per-branch step to remember.
+
+It mirrors `main`'s profile: no deletion, no force-push, linear history required, PRs required with CODEOWNERS review and conversation resolution, and the `ubuntu-latest` status check. Repo admins (`RepositoryRole 5`) bypass, matching the tag ruleset.
+
+The payload lives at [`.github/release-branch-ruleset.json`](https://github.com/Fallout-build/Fallout/blob/main/.github/release-branch-ruleset.json) so the config is reviewable rather than only visible in repo settings. To re-apply after editing it:
+
+```bash
+# Update the existing ruleset in place (preferred — keeps the ID stable)
+gh api -X PUT repos/Fallout-build/Fallout/rulesets/19766406 \
+    --input .github/release-branch-ruleset.json
+
+# Verify which rules actually bind to a branch
+gh api repos/Fallout-build/Fallout/rules/branches/release%2Fv10.4 --jq '[.[].type]'
+```
+
+`support/*` lines are **not** covered by this ruleset — they carry their own classic per-branch protection, applied when the line is created.
+
+> Historical note: `release/v10.4` ran unprotected from its cut until 2026-07-26, because the on-demand cut ([ADR-0007](adr/0007-cut-release-branch-on-demand.md)) had no protection step attached. The pattern-based ruleset exists so that can't recur.
 
 ## Tag protection
 

--- a/docs/branching-and-release.md
+++ b/docs/branching-and-release.md
@@ -103,7 +103,7 @@ One known gap: work promoted onto a release branch by cherry-pick gets **new com
 
 That tag push triggers `.github/workflows/publish-packages-release.yml`:
 
-1. **`validate-ref`** confirms the tag points at a commit reachable from a production branch (`release/YYYY` or `support/*`).
+1. **`validate-ref`** confirms the tag points at a commit reachable from a production branch (`release/YYYY`, `release/vMAJOR.MINOR`, or `support/*`).
 2. **`test-and-pack`** runs `dotnet fallout Test Pack`, uploads `output/packages/*.nupkg` as an artifact.
 3. Three parallel publish jobs consume the artifact:
    - `publish-nuget-org` — **skipped** (not opt-in by default)

--- a/docs/branching-and-release.md
+++ b/docs/branching-and-release.md
@@ -30,7 +30,7 @@ Keep this block current — the examples further down use these values.
 
 | Line | Branch | Ships | Latest |
 |---|---|---|---|
-| Preview | `main` | `10.0.0-preview.<height>.g<sha>` → GitHub Packages, per commit | rolling |
+| Preview | `main` | `10.4.0-preview.<height>.g<sha>` → GitHub Packages, per commit | rolling |
 | Production | `release/v10.4` | `10.4.0-rc.N` → GitHub Packages + GH Release; nuget.org opt-in | `v10.4.0-rc.4` |
 | Legacy | `support/v10` | `10.x` security/critical only | `10.3.47` |
 
@@ -44,7 +44,7 @@ Releases fire to multiple channels, each with its own GitHub Environment:
 
 | Channel | Built from | Cadence | Gating | Version shape |
 |---|---|---|---|---|
-| **preview** → `github-packages` env | `main` | Per-commit | None | `10.0.0-preview.<height>.g<commit>` |
+| **preview** → `github-packages` env | `main` | Per-commit | None | `10.4.0-preview.<height>.g<commit>` |
 | **stable** → `nuget-org` env | `release/*` tags | Slow, deliberate | **Flag opt-in + approval-gated** | `10.4.0-rc.N` today; `YYYY.M.P` after the CalVer cut |
 | **stable/legacy** → `github-packages` env | `release/*`, `support/*` tags | Every tag | None | Same as the tag |
 | **legacy** → `nuget-org` env | `support/v10`, `support/YYYY` tags | Security/critical only | **Flag opt-in + approval-gated** | `10.x` / `YYYY.x` |
@@ -62,7 +62,7 @@ On a release branch, `version.json`'s `version` pins the prerelease number liter
 - Every commit on the branch reports the same version until you bump, so the number tracks *release intent* rather than however many commits a promotion happened to carry. (`{height}` sent `rc.3` straight to `rc.23` on the first 19-commit promotion.)
 - Tagging twice without bumping republishes an existing version. `dotnet nuget push --skip-duplicate` swallows that silently, so the packages simply won't update — **check the number first**.
 
-`main` keeps `{height}` (`10.0.0-preview.{height}`): per-commit previews want a value that always moves on its own.
+`main` keeps `{height}` (`10.4.0-preview.{height}`): per-commit previews want a value that always moves on its own.
 
 ### Routine stable release (GitHub Packages only)
 

--- a/docs/branching-and-release.md
+++ b/docs/branching-and-release.md
@@ -12,6 +12,7 @@ A maturity ladder feeding the production line (amended [ADR-0004](adr/0004-calen
 |---|---|---|---|---|
 | `main` | **Integration trunk + sole prerelease lane (`-preview` channel).** Default branch. Both deliberate improvements / bug fixes **and** faster / AI-assisted work land here. Per-commit `…-preview` prereleases to GitHub Packages. **Never nuget.org.** Breaking work accumulates here gated behind `[Experimental("FALLOUT0xx")]` (or on a short-lived topic branch off `main`) for the yearly major. | Long-lived | Yes | **Preview only** (GitHub Packages, no nuget.org / no GH Release) |
 | `release/YYYY` | **Production line** for the calendar year (e.g. `release/2026`), **cut from `main` on demand at the first release of the year, not preemptively** ([ADR-0007](adr/0007-cut-release-branch-on-demand.md)). `-rc.N` → GA. Non-breaking minors/patches only after the cut. | Cut on demand; long-lived once cut | Yes | **Yes** — tags pushed here fire the full release pipeline (nuget.org opt-in) |
+| `release/vMAJOR.MINOR` | **Production line for a semver minor** (e.g. `release/v10.4`) — the shape in use while the line still ships `10.x`, before the CalVer major cut. Same rules and pipeline as `release/YYYY`; both are matched by `publicReleaseRefSpec` and by `validate-ref`. | Cut on demand; long-lived once cut | Yes | **Yes** — same pipeline |
 | `support/v10` (+ `hotfix/v10.1`, `hotfix/v10.2`) | **Legacy** semver `10.x` maintenance line — security/critical fixes only. (Renamed from `release/v10`.) | Long-lived | Yes | Yes — tags fire the pipeline (nuget.org opt-in) |
 | `support/YYYY` | **Retired** year production line (e.g. `support/2026` once 2027 supersedes it). Security/critical fixes only. | Long-lived | Yes | Yes — tags fire the pipeline (nuget.org opt-in) |
 | `release/v11` | **Retired and deleted** — nothing clean shipped; work re-homed onto `2026`. Branch removed per [ADR-0007](adr/0007-cut-release-branch-on-demand.md) §6 (no unique history; dead branches are deletable, tags are the durable markers). | Deleted | — | No |
@@ -23,15 +24,29 @@ This *is* gitflow with the project's vocabulary: `main` ≈ the integration trun
 
 ## Channel taxonomy
 
+### Lines live right now
+
+Keep this block current — the examples further down use these values.
+
+| Line | Branch | Ships | Latest |
+|---|---|---|---|
+| Preview | `main` | `10.0.0-preview.<height>.g<sha>` → GitHub Packages, per commit | rolling |
+| Production | `release/v10.4` | `10.4.0-rc.N` → GitHub Packages + GH Release; nuget.org opt-in | `v10.4.0-rc.4` |
+| Legacy | `support/v10` | `10.x` security/critical only | `10.3.47` |
+
+`main` is deliberately **not** in `publicReleaseRefSpec`, which is why its previews carry the `.g<sha>` suffix — they're non-public builds by design. Production lines are listed there, so their packages are clean (see [ADR-0004](adr/0004-calendar-versioning-and-dual-pace-channels.md) for the CalVer target; the current line is still `10.x`).
+
+### Channels
+
 Releases fire to multiple channels, each with its own GitHub Environment:
 
 **GitHub Packages = the test/preview channel; nuget.org = production.** The version ladder orders cleanly under SemVer: `…-preview.N` < `…-rc.N` < `…` (GA) — the `-alpha` rung was retired with the `experimental` branch ([ADR-0008](adr/0008-collapse-experimental-into-main.md)).
 
 | Channel | Built from | Cadence | Gating | Version shape |
 |---|---|---|---|---|
-| **preview** → `github-packages` env | `main` | Per-commit | None | `2026.1.0-preview.<height>.g<commit>` |
-| **stable** → `nuget-org` env | `release/YYYY` tags | Slow, deliberate | **Flag opt-in + approval-gated** | `2026.1.3` (CalVer) |
-| **stable/legacy** → `github-packages` env | `release/YYYY`, `support/*` tags | Every tag | None | CalVer / `10.x` |
+| **preview** → `github-packages` env | `main` | Per-commit | None | `10.0.0-preview.<height>.g<commit>` |
+| **stable** → `nuget-org` env | `release/*` tags | Slow, deliberate | **Flag opt-in + approval-gated** | `10.4.0-rc.N` today; `YYYY.M.P` after the CalVer cut |
+| **stable/legacy** → `github-packages` env | `release/*`, `support/*` tags | Every tag | None | Same as the tag |
 | **legacy** → `nuget-org` env | `support/v10`, `support/YYYY` tags | Security/critical only | **Flag opt-in + approval-gated** | `10.x` / `YYYY.x` |
 | `github-releases` env (bundled) | `release/*`, `support/*` tags | Same tag as the package publish | None | Same as the tag |
 | Docker local NuGet server | Per-PR / per-commit | None (local) | PR-derived | Available via `tests/integration/docker-compose.yml` |
@@ -51,24 +66,31 @@ On a release branch, `version.json`'s `version` pins the prerelease number liter
 
 ### Routine stable release (GitHub Packages only)
 
-The default path. Pushing a `v2026.1.X` tag to `release/2026` publishes to GitHub Packages + GitHub Releases. nuget.org is **not** touched. (Git tags keep the `v` prefix — `v2026.1.3` — so the `v*` tag-protection ruleset and `validate-ref` apply; the package version core is `2026.1.3`.)
+The default path. Pushing a tag to a production branch publishes to GitHub Packages + GitHub Releases. nuget.org is **not** touched. Git tags keep the `v` prefix — `v10.4.0-rc.4`, `v2026.1.3` — so the `v*` tag-protection ruleset and `validate-ref` apply; the package version core drops it (`10.4.0-rc.4`).
+
+Examples below use the live line, `release/v10.4`. A CalVer `release/YYYY` cut works identically — substitute the branch and tag.
 
 ```bash
-# 1. Make sure your local release/YYYY is up to date
+# 1. Make sure your local release branch is up to date
 git fetch
-git switch release/2026
+git switch release/v10.4
 git pull --ff-only
 
-# 2. (Optional) Verify what version NB.GV will compute
-dotnet nbgv get-version   # should report 2026.1.X clean, no -g<sha>
+# 2. Bump the rc number in version.json via a PR if you haven't (see above),
+#    then verify what NB.GV will compute. Note PublicRelease=1: a plain local
+#    run reports a .g<sha> suffix because your checked-out branch is only a
+#    public ref in CI's eyes.
+PublicRelease=1 dotnet nbgv get-version -v NuGetPackageVersion   # e.g. 10.4.0-rc.4
 
 # 3. Create the tag + GitHub Release in one step.
 #    --notes-start-tag is load-bearing: see "Release notes" below.
-gh release create v2026.1.X \
-    --target release/2026 \
-    --title "v2026.1.X" \
+#    Add --prerelease for an rc.
+gh release create v10.4.0-rc.4 \
+    --target release/v10.4 \
+    --title "v10.4.0-rc.4" \
+    --prerelease \
     --generate-notes \
-    --notes-start-tag <last-GA-tag>     # e.g. 10.3.47, NOT the previous rc
+    --notes-start-tag 10.3.47           # the last GA, NOT the previous rc
 ```
 
 ### Release notes
@@ -90,16 +112,19 @@ That tag push triggers `.github/workflows/publish-packages-release.yml`:
 
 ### Stabilised release (nuget.org publish)
 
-When a `release/2026` release is stabilised enough for nuget.org, or for cutting a `support/v10` legacy security patch, use `workflow_dispatch` with the opt-in flag:
+When a release is stabilised enough for nuget.org, or for cutting a `support/v10` legacy security patch, use `workflow_dispatch` with the opt-in flag:
 
 ```bash
 # Option A: via gh CLI
 gh workflow run publish-packages-release.yml \
-    -f tag=v2026.1.X \
+    --ref release/v10.4 \
+    -f tag=v10.4.0-rc.4 \
     -f publish-to-nugetorg=true
 
 # Option B: via Actions UI → publish-packages-release → "Run workflow" → set publish-to-nugetorg to true
 ```
+
+> **`--ref` is not optional.** `workflow_dispatch` takes the **workflow definition** from the ref you dispatch against, while `-f tag=` only controls which source gets checked out and packed. Dispatch against the default branch and you run `main`'s copy of the pipeline — which will differ from the release branch's whenever a pipeline fix hasn't been forward-ported yet, and will happily push the resulting packages to nuget.org. Always pass the production branch.
 
 The workflow:
 
@@ -111,16 +136,29 @@ The workflow:
 
 Two layers of safety on the nuget.org path: the flag opt-in + the env approval. You can also test the wiring without burning a release — set the flag, get the approval prompt, then cancel without approving.
 
+**A green run is not proof anything published.** Every publish job is conditional, so a misconfigured condition skips it while the run still reports success — this happened to all three jobs on the `workflow_dispatch` path until 2026-07-26. After any release, check the jobs actually ran and then confirm the packages resolve:
+
+```bash
+# Did the publish jobs run, or silently skip?
+gh api repos/Fallout-build/Fallout/actions/runs/<run-id>/jobs \
+    --jq '.jobs[] | "\(.name): \(.conclusion)"'
+
+# Is the version really on nuget.org? (expect the version listed)
+curl -s https://api.nuget.org/v3-flatcontainer/fallout.common/index.json | jq '.versions[-3:]'
+```
+
+Allow a minute or two for nuget.org to index — a package can be pushed successfully and not yet appear, especially a brand-new package ID.
+
 ### If a publish fails partway through
 
 Each `dotnet nuget push` uses `--skip-duplicate`. Re-running a publish job is idempotent on packages already pushed. For a transient failure mid-publish:
 
 ```bash
 # Routine re-run — leave publish-to-nugetorg false
-gh workflow run publish-packages-release.yml -f tag=v2026.1.X
+gh workflow run publish-packages-release.yml --ref release/v10.4 -f tag=v10.4.0-rc.4
 
 # Stabilised re-run — include the flag if you want to retry the nuget.org push
-gh workflow run publish-packages-release.yml -f tag=v2026.1.X -f publish-to-nugetorg=true
+gh workflow run publish-packages-release.yml --ref release/v10.4 -f tag=v10.4.0-rc.4 -f publish-to-nugetorg=true
 ```
 
 ## Promotion and hotfixing
@@ -137,17 +175,18 @@ A stabilised non-breaking change on `main` is promoted to the production line, t
 
 ```bash
 git fetch
-git switch -c promote-XXXX-to-2026 release/2026
+git switch -c promote-XXXX-to-v10.4 release/v10.4
 git cherry-pick <sha-on-main> [<sha> …]
 git push origin HEAD
-gh pr create --base release/2026 ...   # rigorous review tier
+gh pr create --base release/v10.4 ...   # rigorous review tier
 # once merged:
-gh release create v2026.1.X+1 --target release/2026 --generate-notes
+gh release create v10.4.0-rc.5 --target release/v10.4 --prerelease \
+    --generate-notes --notes-start-tag 10.3.47
 ```
 
 ### Forward-porting a stable-urgent fix
 
-If a fix must land on the production line first (prod-down), land it on `release/2026`, then **forward-port** to `main` so the trunk never regresses:
+If a fix must land on the production line first (prod-down), land it on `release/v10.4`, then **forward-port** to `main` so the trunk never regresses:
 
 ```bash
 git switch -c forward-port-XXXX main

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.0.0-preview.{height}",
+  "version": "10.4.0-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/release/\\d{4}$",
     "^refs/heads/release/v\\d+\\.\\d+$",


### PR DESCRIPTION
Brings the release runbook in line with what the project actually ships, and captures the release-branch protection config in the repo. Everything here came out of cutting `v10.4.0-rc.4`. Docs + one config file; no product code.

### 1. Release branches are protected by a ruleset

`release/v10.4` ran **unprotected** from its cut on 2026-07-21 until today — anything could be pushed straight to the branch that fires production releases. The on-demand cut ([ADR-0007](https://github.com/Fallout-build/Fallout/blob/main/docs/adr/0007-cut-release-branch-on-demand.md)) has no protection step attached, and the runbook's step 3 pointed at `scripts/release-branch-protection.json` — a file that never existed.

Now a pattern-based ruleset on `refs/heads/release/**` ([19766406](https://github.com/Fallout-build/Fallout/rules/19766406)), so every release line is protected the moment the branch exists — `release/v10.4` now, a `release/2027` cut later, with no per-branch step to forget. Mirrors `main`'s profile; repo admins bypass, matching the tag ruleset. Payload committed at **`.github/release-branch-ruleset.json`** (in `.github/`, not `scripts/` — it's GitHub config, not tooling) with the `PUT` command to re-apply after an edit.

### 2. The runbook described a line that doesn't exist

Every example named `release/2026` and `v2026.1.X`, while the line actually shipping is `release/v10.4` at `10.4.0-rc.N` — so no command was copy-pasteable. The channel table also claimed previews were `2026.1.0-preview.<height>` when `main`'s `version.json` says `10.0.0-preview.{height}`.

Documents `release/vMAJOR.MINOR` alongside `release/YYYY` (the pipeline matches both), adds a **"lines live right now"** block as the one place to keep current, and retargets the examples. ADR-0004/0007 CalVer intent is unchanged — a year cut substitutes branch and tag and works identically.

### 3. Two traps that cost time on rc.4

- **`--ref` on a `workflow_dispatch` selects the workflow *definition*,** not just the source to pack. Dispatching against the default branch runs `main`'s pipeline — which differs from the release branch's whenever a fix isn't forward-ported yet — and still pushes to nuget.org.
- **A green release run is not evidence packages shipped.** Every publish job is conditional, so a bad condition skips it while the run reports success. That was true of all three jobs on the dispatch path (fixed in [#567](https://github.com/Fallout-build/Fallout/pull/567)). Adds the commands to check what actually ran and whether the version resolves.

### 4. Prerelease numbers are a manual counter

The rc number is pinned literally in `version.json` rather than derived from `{height}`, which would have jumped `rc.3` → `rc.23`. That makes bumping manual, and forgetting means republishing an existing version — which `--skip-duplicate` swallows silently.

### 5. `main`'s preview lane moves onto the 10.4 core

`main` advertised `10.0.0-preview.{height}` while the line actually shipping is `10.4.0` — so the trunk published previews numbered *below* the branch cut from it. `10.0.0` was never a target anyone intends to release; it was left behind when the 10.4 line was cut. Now `10.4.0-preview.{height}`.

Two consequences, both verified:

- **The height resets**, so previews restart at `10.4.0-preview.1` rather than continuing from `10.0.0-preview.34`. Nothing regresses — `10.4.0` sorts above `10.0.0`, so the new previews still supersede every published one.
- **`10.4.0-preview.N` sorts below `10.4.0-rc.N`**, which is right while `main` is the trunk `10.4.0` stabilises from. Once `10.4.0` goes GA, `main` needs rolling to the next core (`10.5.0`, or the CalVer major) or its previews start reading as older than the released package despite carrying newer code — the same roll-forward the yearly-cut runbook already describes.

Ordering checked against SemVer 2.0 precedence: `10.0.0-preview.34` < `10.4.0-preview.1` < `10.4.0-rc.4` < `10.4.0`, and `10.3.47` < `10.4.0-preview.1`.

### Corrections to existing claims

Two things the protection docs asserted that aren't true:

- Stale approvals are **not** dismissed on new commits (`dismiss_stale_reviews: false`).
- Squash merge is **not** disabled by repo setting — only plain merge commits are (`allow_squash_merge: true`). So "rebase only" rests on convention, not enforcement. Worth closing separately if you want it enforced; squashing a promotion would collapse reviewed commits into one opaque commit.
