### PR TITLE
Point the nuget-org environment at the real nuget.org profile

### DIFF
--- a/.github/workflows/publish-packages-release.yml
+++ b/.github/workflows/publish-packages-release.yml
@@ -165,7 +165,7 @@ jobs:
       && (inputs.publish-to-nugetorg == true || inputs.publish-to-nugetorg == 'true')
     environment:
       name: nuget-org
-      url: https://www.nuget.org/profiles/Fallout
+      url: https://www.nuget.org/profiles/Fallout.build
     steps:
       - name: 'Setup: .NET SDK'
         uses: actions/setup-dotnet@v6


### PR DESCRIPTION
The `nuget-org` environment URL pointed at `https://www.nuget.org/profiles/Fallout`, which isn't the publishing account — the packages live under [`Fallout.build`](https://www.nuget.org/profiles/Fallout.build) (22 packages).

That URL is the link a maintainer clicks from the deployment entry after approving a nuget.org push, so it sent them somewhere unrelated. Confirmed on the `v10.4.0-rc.4` publish, which logged:

```
Evaluated environment url: https://www.nuget.org/profiles/Fallout
```

Display-only — the URL never affected which packages were pushed or where. The `v10.4.0-rc.4` publish itself was correct: all 19 `Fallout.*` packages are live on nuget.org.

Same fix is included for `main` in [#567](https://github.com/Fallout-build/Fallout/pull/567); this one lands it on the branch that actually publishes, so the link is right on the next approval rather than waiting for a promotion.
