### PR TITLE
Label console lines with the full level name

### DIFF
--- a/src/Fallout.Build/Logging.cs
+++ b/src/Fallout.Build/Logging.cs
@@ -24,8 +24,12 @@ public static class Logging
         ? AnsiConsoleHostTheme.Default256AnsiColorTheme
         : SystemConsoleHostTheme.DefaultSystemColorTheme;
 
-    internal static string ErrorsAndWarningsOutputTemplate => "[{Level:u3}] {ExecutingTarget}: {Message:l}{NewLine}";
-    internal static string StandardOutputTemplate => "[{Level:u3}] {Message:l}{NewLine}{Exception}";
+    // Full level names, not the {Level:u3} codes. Abbreviating bought a fixed-width level column, but
+    // DBG/VRB/FTL are not self-explaining. Aligning the message column is #391's job — Spectre owns
+    // the frame there and can indent properly instead of truncating the words. The build.log
+    // templates below deliberately keep their compact single-letter column.
+    internal static string ErrorsAndWarningsOutputTemplate => "[{Level}] {ExecutingTarget}: {Message:l}{NewLine}";
+    internal static string StandardOutputTemplate => "[{Level}] {Message:l}{NewLine}{Exception}";
     internal static string TimestampOutputTemplate => $"{{Timestamp:HH:mm:ss}} {StandardOutputTemplate}";
 
     private const int TargetNameLength = 20;

--- a/tests/Fallout.Build.Specs/OutputTemplateLevelSpecs.cs
+++ b/tests/Fallout.Build.Specs/OutputTemplateLevelSpecs.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Linq;
+using Fallout.Common.Execution;
+using FluentAssertions;
+using Serilog.Events;
+using Serilog.Formatting.Display;
+using Serilog.Parsing;
+using Xunit;
+
+namespace Fallout.Common.Specs;
+
+/// <summary>
+/// Covers the level label in the console output templates. See #570. The templates used
+/// <c>{Level:u3}</c>, which renders three-letter codes (<c>DBG</c>, <c>INF</c>, <c>WRN</c>) rather
+/// than the level names.
+/// </summary>
+public class OutputTemplateLevelSpecs
+{
+    [Theory]
+    [InlineData(LogEventLevel.Verbose, "[Verbose]")]
+    [InlineData(LogEventLevel.Debug, "[Debug]")]
+    [InlineData(LogEventLevel.Information, "[Information]")]
+    [InlineData(LogEventLevel.Warning, "[Warning]")]
+    [InlineData(LogEventLevel.Error, "[Error]")]
+    [InlineData(LogEventLevel.Fatal, "[Fatal]")]
+    public void The_standard_template_labels_lines_with_the_level_name(LogEventLevel level, string expected)
+    {
+        Render(Logging.StandardOutputTemplate, level).Should().StartWith(expected);
+    }
+
+    [Theory]
+    [InlineData(LogEventLevel.Verbose, "[Verbose]")]
+    [InlineData(LogEventLevel.Debug, "[Debug]")]
+    [InlineData(LogEventLevel.Information, "[Information]")]
+    [InlineData(LogEventLevel.Warning, "[Warning]")]
+    [InlineData(LogEventLevel.Error, "[Error]")]
+    [InlineData(LogEventLevel.Fatal, "[Fatal]")]
+    public void The_errors_and_warnings_template_labels_lines_with_the_level_name(LogEventLevel level, string expected)
+    {
+        Render(Logging.ErrorsAndWarningsOutputTemplate, level).Should().StartWith(expected);
+    }
+
+    [Theory]
+    [InlineData("VRB")]
+    [InlineData("DBG")]
+    [InlineData("INF")]
+    [InlineData("WRN")]
+    [InlineData("ERR")]
+    [InlineData("FTL")]
+    public void No_console_template_renders_a_three_letter_code(string abbreviation)
+    {
+        var rendered = Enum.GetValues<LogEventLevel>()
+            .SelectMany(x => new[]
+            {
+                Render(Logging.StandardOutputTemplate, x),
+                Render(Logging.ErrorsAndWarningsOutputTemplate, x),
+                Render(Logging.TimestampOutputTemplate, x)
+            });
+
+        rendered.Should().NotContain(x => x.Contains($"[{abbreviation}]"));
+    }
+
+    [Fact]
+    public void The_timestamped_template_keeps_the_timestamp_ahead_of_the_level()
+    {
+        Render(Logging.TimestampOutputTemplate, LogEventLevel.Information)
+            .Should().MatchRegex(@"^\d{2}:\d{2}:\d{2} \[Information\] ");
+    }
+
+    [Fact]
+    public void The_message_still_follows_the_level()
+    {
+        Render(Logging.StandardOutputTemplate, LogEventLevel.Warning).Should().Contain("a warning line");
+    }
+
+    [Fact]
+    public void The_errors_and_warnings_template_still_names_the_executing_target()
+    {
+        Render(Logging.ErrorsAndWarningsOutputTemplate, LogEventLevel.Error).Should().Contain("Compile:");
+    }
+
+    /// <summary>Renders one event through an output template, the way the console sink does.</summary>
+    private static string Render(string outputTemplate, LogEventLevel level)
+    {
+        var formatter = new MessageTemplateTextFormatter(outputTemplate);
+        using var writer = new StringWriter();
+        formatter.Format(CreateLogEvent(level), writer);
+        return writer.ToString();
+    }
+
+    private static LogEvent CreateLogEvent(LogEventLevel level) =>
+        new(
+            timestamp: DateTimeOffset.UnixEpoch,
+            level: level,
+            exception: null,
+            messageTemplate: new MessageTemplateParser().Parse("a warning line"),
+            properties: new[]
+            {
+                new LogEventProperty("ExecutingTarget", new ScalarValue("Compile"))
+            });
+}


### PR DESCRIPTION
Replaces the three-letter level codes in console output with the level names. `VRB`, `DBG`, `INF`, `WRN`, `ERR` and `FTL` are not self-explaining.

### What changed
- `{Level:u3}` becomes `{Level}` in the two console output templates.
- Add `OutputTemplateLevelSpecs`, covering every level for both templates through the same formatter the console sink uses.

Before and after, same build:

```
22:49:44 [DBG] git version 2.50.1        01:43:13 [Debug] git version 2.50.1
22:49:44 [INF] > /usr/bin/git --version  01:43:13 [Information] > /usr/bin/git --version
22:49:44 [WRN] a warning line            01:43:13 [Warning] a warning line
22:49:44 [ERR] an error line             01:43:13 [Error] an error line
```

The errors-and-warnings summary block picks it up too, since it shares a template.

### Why
The codes existed to keep the level column a fixed width so the messages lined up. **That alignment is deliberately not preserved here.** Laying out a real column belongs to #391, where Spectre owns the frame and can indent properly rather than truncating the words. Padding the level to a fixed width is a one-token change (`{Level,-11}`) if a reviewer would rather have ragged-free columns in the meantime.

Two notes on scope:

- **The `build.log` file templates are unchanged.** They use a compact `{Level:u1}` single-letter column in a pipe-delimited, fixed-width layout. That format is for scanning and diffing a log file, not for reading along with a build.
- **Nothing depended on the abbreviations** — no Verify snapshots, no docs, no CI annotation path, no log parsing. Level colouring is applied to the `Level` token by the console sink regardless of format, so it is unaffected.

### Verification
`dotnet test` on `Fallout.Build.Specs` and `Fallout.Common.Specs`. 21 new specs pass, 19 of which failed before the change. Confirmed against a real build run, including the errors-and-warnings block.

Closes #570