### PR TITLE
Document the fallout-migrate step pattern for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,5 +79,6 @@ Full conventions + what-not-to-do list: [docs/agents/conventions.md](docs/agents
 
 - The `build/Build.*.cs` files are the canonical example of how to consume the framework — read these when reasoning about user-facing APIs.
 - `src/Fallout.Common/Tools/<Tool>/<Tool>.json` files are the source of truth for tool wrappers; the `.cs` next to them is generated.
+- `fallout-migrate` is a pipeline of `IMigrationStep`s (`src/Fallout.Migrate/Migration.cs`). A step is one operation over one set of files, and it owns the rewrite rules for those files. Add a new rename to the step that already covers that file type — do **not** add a step per rename. Recipe: [docs/agents/conventions.md](docs/agents/conventions.md#migration-step-recipe).
 - Source generators (`src/Fallout.SourceGenerators`) produce per-target code at compile time — if a symbol seems missing, check whether it's generated.
 - The Verify snapshots (`*.verified.txt`, `*.verified.cs`) under `tests/` are the contract for generator output; review carefully when they change.

--- a/docs/agents/conventions.md
+++ b/docs/agents/conventions.md
@@ -121,3 +121,32 @@ When asked to add or extend a tool wrapper:
 2. Copy its shape; cover a full command with all arguments.
 3. Run `./build.ps1 GenerateTools` to regenerate the `.cs` output.
 4. Commit the regenerated `.cs` output alongside the `.json` spec — `VerifyGeneratedTools` fails CI if they drift.
+
+## Migration step recipe
+
+`fallout-migrate` runs a fixed, ordered list of `IMigrationStep` implementations, built in
+`src/Fallout.Migrate/Migration.cs`. A **step is one operation over one set of files**, and it owns the
+rewrite rules for those files. `RewriteCsprojsStep` holds five rules for `*.csproj`;
+`RewriteCsFilesStep` holds the rules for `*.cs`.
+
+When asked to make `fallout-migrate` handle a new rename, removal, or rewrite:
+
+1. Find the step for that file type — `RewriteCsprojsStep` for `*.csproj`, `RewriteCsFilesStep` for
+   `*.cs`, `RewriteBootstrapScriptsStep` for the bootstrap scripts.
+2. Add a `private static readonly Regex` field to that step, with a comment saying what moved and why.
+3. Apply it as another statement in the step's `Rewrite` method, incrementing `edits` per replacement.
+4. Add cases to that step's spec class in `tests/Fallout.Migrate.Specs`.
+
+**Do not add a step per rename.** A new step means a second pass over the same files, so each file is
+written twice and the `Summary` edit count is inflated. Rule order also matters — a specific rule
+usually has to run before a general one — and inside one `Rewrite` method that order is plain
+statement order. Split across steps it becomes a hidden dependency between entries in
+`Migration.steps`.
+
+Add a **new step** only for a new set of files or a genuinely different operation, such as renaming a
+directory or prompting the user. That is one new class implementing `IMigrationStep` plus one line in
+`Migration.steps`. If the new step depends on an earlier one, say so in the comment on that list, the
+way `ResolveFalloutVersionStep` does.
+
+Keep `Steps/` free of helper classes. A rewriter that only serves one step belongs inside that step —
+see `aef6c073` (`CsprojRewriter`) and #528 (`CodeRewriter`) for the shape.


### PR DESCRIPTION
Writes down the `fallout-migrate` step convention, which currently exists only in commit history.

### What changed
- New "Migration step recipe" section in `docs/agents/conventions.md`, next to the existing tool wrapper recipe.
- A pointer bullet in `AGENTS.md`. That file links `conventions.md` rather than importing it, so the rule needs a line where an agent will actually see it.

### Why
`src/Fallout.Migrate/Steps/` teaches two contradictory patterns. Most files are steps implementing `IMigrationStep`. `ScriptRewriter` is a free-floating static class that only holds the rules for one step. #507 introduced that split, then `aef6c073` began retiring it by folding `CsprojRewriter` into `RewriteCsprojsStep` because it had a single caller.

The convention was never written down, so it came up in review on #528: a new rename rule went into a rewriter class instead of the step. The rule now has a home that does not require commit archaeology.

The recipe states the part that is easy to get backwards. A new rename goes into the step that already covers that file type. A new step is only for a new set of files or a different kind of operation. It also records why a step per rename is wrong: a second pass over the same files, each file written twice, inflated `Summary` edit counts, and rule ordering becoming a hidden dependency between entries in `Migration.steps` instead of plain statement order.

Docs only, no code change.

The remaining leftover is tracked in #573.