### PR TITLE
Fix the user facing migrate command description

### DIFF
--- a/src/Fallout.Migrate/MigrateCommand.cs
+++ b/src/Fallout.Migrate/MigrateCommand.cs
@@ -24,6 +24,7 @@ namespace Fallout.Migrate;
                - Rewrites `dotnet nuke` -> `dotnet fallout` and legacy NUKE_* env vars
                  in build.cmd / build.ps1 / build.sh
                - Renames .nuke/ to .fallout/
+               - Removes legacy NUKE_ENTERPRISE_TOKEN check from bootstrapper scripts, if exists
                - Prints a summary of files changed and warnings to address manually
              """)]
 [UsedImplicitly]


### PR DESCRIPTION
Fix wording in `fallout-migrate`'s user-facing `--help` description.

### What changed
- Corrects the `[Description]` text on `MigrateCommand` (`src/Fallout.Migrate/MigrateCommand.cs:16-29`) — the summary users see when running `fallout-migrate --help`.

### Why
The description is the first thing consumers of the migration tool read; it needs to accurately describe what the migration does.

### Verification
- ` dotnet run .\Fallout.Migrate.csproj -- --help` shows the fixed help text