### PR TITLE
Add netstandard2.0 to Fallout.Core

### DIFF
--- a/src/Fallout.Core/Fallout.Core.csproj
+++ b/src/Fallout.Core/Fallout.Core.csproj
@@ -1,7 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net10.0</TargetFrameworks>
+    <!--
+      netstandard2.0 is only here so Core can be consumed by Fallout.SourceGenerators (Roslyn
+      requires it) and Fallout.MSBuildTasks (net472). Without it, anything those two need has
+      to be duplicated into a lower-floor project — see #584.
+
+      Keep new Core code netstandard2.0-clean, or guard it with #if NETSTANDARD2_1_OR_GREATER.
+      Drop this target once the generator and MSBuild tasks no longer need it.
+    -->
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net10.0</TargetFrameworks>
     <Description>The reactor core of Fallout — pure domain types and graph algorithms of the build execution pipeline. No I/O, no process, no console, no logging. References nothing else in the repo.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
Lets `Fallout.Core` hold shared values (#584). It could not while it was netstandard2.1 only — `Fallout.SourceGenerators` must be netstandard2.0 (Roslyn) and `Fallout.MSBuildTasks` runs under net472, so neither can load a 2.1 assembly.

Costs nothing today: Core references nothing and uses no 2.1-only API, so the 2.0 build is the same source. `netstandard2.1` stays so 2.1+ consumers keep the richer asset and future Core code can use 2.1 APIs behind an `#if`.

**Prep only — no constants moved yet.** The reason and the exit condition are in a comment on the csproj.

Verified: Core emits all three assets, `Fallout.Core.Specs` 7/7 (including architecture-fitness), `dotnet build fallout.slnx` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)