### PR TITLE
Bump the release-branch prerelease counter to 10.4.0-rc.5

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.4.0-rc.4",
+  "version": "10.4.0-rc.5",
   "publicReleaseRefSpec": [
     "^refs/heads/release/\\d{4}$",
     "^refs/heads/release/v\\d+\\.\\d+$",


### PR DESCRIPTION
Bumps the release-branch prerelease counter from `10.4.0-rc.4` to `10.4.0-rc.5`, so the next tag off `release/v10.4` ships the two queued cherry-picks.

One-line change to `version.json`.

## Why

On a release branch the prerelease number is a **manual counter**, not `{height}` — see [branching-and-release.md → Prerelease numbers on a release branch are a manual counter](docs/branching-and-release.md). Tagging without bumping republishes an existing version, and `dotnet nuget push --skip-duplicate` swallows that silently, so the packages just don't update.

rc.5 is the first RC to carry:
- #590 — the `Fallout.Common.ProjectModel` transition shim (fixes the `CS0234`/`CS0246` break consumers hit upgrading 10.3.x → rc.4).
- #593 — reverting the CLI package id to `Fallout.GlobalTool`, so GA continues the id the install base has pinned.

## Verification

`dotnet pack src/Fallout.Cli` on this branch stamps **`10.4.0-rc.5`**. (Locally it also carries a `.g<commit>` suffix and the pre-#593 plural id, both only because this topic branch isn't a public release ref and doesn't include #593 — on `release/v10.4` with both cherry-picks in it stamps `Fallout.GlobalTool.10.4.0-rc.5`.)

## Merge order

Independent of #590 and #593 — no file overlap, so all three can merge in any order. The only ordering that matters is the **tag**: cut `v10.4.0-rc.5` only once all three are on `release/v10.4`, or the RC ships without the fixes it's numbered for.
