### PR TITLE
Add an additional type converter for `System.Text.Json`

### DIFF
--- a/src/Fallout.Utilities/Converters/AbsolutePathJsonConverter.cs
+++ b/src/Fallout.Utilities/Converters/AbsolutePathJsonConverter.cs
@@ -1,0 +1,35 @@
+#if NET6_0_OR_GREATER
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Fallout.Common;
+using Fallout.Common.IO;
+using static Fallout.Common.IO.PathConstruction;
+
+namespace Fallout.Utilities.Converters;
+
+public sealed class AbsolutePathJsonConverter : JsonConverter<AbsolutePath>
+{
+    public override AbsolutePath Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (value != null)
+            return HasPathRoot(value)
+                ? AbsolutePath.Create(value)
+                : EnvironmentInfo.WorkingDirectory / value;
+
+        return null;
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        AbsolutePath value,
+        JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value);
+    }
+}
+#endif

--- a/src/Fallout.Utilities/Converters/TypeConverter.cs
+++ b/src/Fallout.Utilities/Converters/TypeConverter.cs
@@ -1,0 +1,31 @@
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using Fallout.Common;
+using Fallout.Common.IO;
+using static Fallout.Common.IO.PathConstruction;
+
+namespace Fallout.Utilities.Converters;
+
+public class TypeConverter : System.ComponentModel.TypeConverter
+{
+    public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+    {
+        return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+    }
+
+    public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+    {
+        if (value is string stringValue)
+        {
+            return HasPathRoot(stringValue)
+                ? (AbsolutePath)stringValue
+                : EnvironmentInfo.WorkingDirectory / stringValue;
+        }
+
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+        return value is null
+            ? null
+            : base.ConvertFrom(context, culture, value);
+    }
+}

--- a/src/Fallout.Utilities/IO/AbsolutePath.cs
+++ b/src/Fallout.Utilities/IO/AbsolutePath.cs
@@ -2,11 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
-using System.Linq;
+#if NET6_0_OR_GREATER
+using System.Text.Json.Serialization;
+using Fallout.Utilities.Converters;
+#endif
 using Fallout.Common.Utilities;
 using static Fallout.Common.IO.PathConstruction;
+using TypeConverter = Fallout.Utilities.Converters.TypeConverter;
 
 namespace Fallout.Common.IO;
 
@@ -14,6 +17,9 @@ namespace Fallout.Common.IO;
 /// Represents an absolute path without distinction between files and directories.
 /// </summary>
 [Serializable]
+#if NET6_0_OR_GREATER
+[JsonConverter(typeof(AbsolutePathJsonConverter))]
+#endif
 [TypeConverter(typeof(TypeConverter))]
 [DebuggerDisplay("{" + nameof(path) + "}")]
 public class AbsolutePath : IAbsolutePathHolder, IFormattable
@@ -23,29 +29,6 @@ public class AbsolutePath : IAbsolutePathHolder, IFormattable
     public const string SingleQuote = "s";
     public const string SingleQuoteIfNeeded = "sn";
     public const string NoQuotes = "nq";
-
-    public class TypeConverter : System.ComponentModel.TypeConverter
-    {
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-        {
-            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
-        }
-
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-        {
-            if (value is string stringValue)
-            {
-                return HasPathRoot(stringValue)
-                    ? (AbsolutePath) stringValue
-                    : EnvironmentInfo.WorkingDirectory / stringValue;
-            }
-
-            if (value is null)
-                return null;
-
-            return base.ConvertFrom(context, culture, value);
-        }
-    }
 
     public static AbsolutePath Create(string path)
     {
@@ -149,11 +132,14 @@ public class AbsolutePath : IAbsolutePathHolder, IFormattable
     {
         if (ReferenceEquals(objA: null, obj))
             return false;
+
         if (ReferenceEquals(this, obj))
             return true;
+
         if (obj.GetType() != GetType())
             return false;
-        return Equals((AbsolutePath) obj);
+
+        return Equals((AbsolutePath)obj);
     }
 
     public override int GetHashCode()

--- a/tests/Fallout.Utilities.Specs/IO/PathConstructionSpecs.cs
+++ b/tests/Fallout.Utilities.Specs/IO/PathConstructionSpecs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text.Json;
 using FluentAssertions;
 using Fallout.Common.IO;
 using Xunit;
@@ -217,6 +218,17 @@ public class PathConstructionSpecs
         ((string) ((UnixRelativePath) "foo/bar/foo" / ..)).Should().Be("foo/bar");
         ((string) ((WinRelativePath) "foo/bar/foo" / ..)).Should().Be("foo\\bar");
         ((string) ((RelativePath) "foo/bar" / ..)).Should().Be("foo");
+    }
+
+    [Fact]
+    public void TestSerialization()
+    {
+        AbsolutePath path = "/foo/bar";
+        string json = JsonSerializer.Serialize(path);
+        json.Should().Be("\"/foo/bar\"");
+
+        AbsolutePath deserialized = JsonSerializer.Deserialize<AbsolutePath>(json);
+        deserialized.Should().Be(path);
     }
 
     private static string ParseRelativePath(object[] parts)


### PR DESCRIPTION
Add a `System.Text.Json`-aware converter for `AbsolutePath` so `AddProperty`/`SetProperty` serialize it as a plain path string again.

### What changed
- Add a `JsonConverter<AbsolutePath>` (`AbsolutePath.STJTypeConverter`, `#if NET6_0_OR_GREATER`) that reads/writes the path as a JSON string.
- Keep the old `System.ComponentModel.TypeConverter` for pre-.NET 6 targets, since `System.Text.Json` never looks at it — that's the root cause.
- Minor whitespace cleanup in `Equals`.

### Why
`Options.Set` serializes property values with `System.Text.Json`, which ignores `[TypeConverter]`. Without a matching `JsonConverter`, it fell back to reflecting over `AbsolutePath`'s public properties (`Name`, `Parent`, ...), producing a JSON dump instead of the path — breaking anything downstream that expects a plain string (e.g. MSBuild's `/property:`).

Closes #588