### PR TITLE
Fix two regex patterns which behaves too greedy

### DIFF
--- a/src/Fallout.Migrate/Steps/RewriteCsprojsStep.cs
+++ b/src/Fallout.Migrate/Steps/RewriteCsprojsStep.cs
@@ -45,7 +45,7 @@ internal sealed class RewriteCsprojsStep : IMigrationStep
     // (ADR-0010), so a migrated project must not carry a dead <FalloutTelemetryVersion>.
     // Matches the whole element line (either legacy Nuke* or already-Fallout* spelling).
     private static readonly Regex telemetryVersionPropertyPattern = new(
-        @"^[ \t]*<(?<tag>(?:Nuke|Fallout)TelemetryVersion)>.*?</\k<tag>>\s*\r?\n?",
+        @"^[ \t]*<(?<tag>(?:Nuke|Fallout)TelemetryVersion)>.*?</\k<tag>>[ \t]*\r?\n?",
         RegexOptions.Compiled | RegexOptions.Multiline);
 
     // Strip explicit `System.Security.Cryptography.Xml` PackageReferences. NUKE-era projects
@@ -55,7 +55,7 @@ internal sealed class RewriteCsprojsStep : IMigrationStep
     // migrated project wants (#217). Matches a self-closing element with optional surrounding
     // indentation + trailing newline.
     private static readonly Regex cryptographyXmlPackageRefPattern = new(
-        @"^[ \t]*<PackageReference\s+Include=""System\.Security\.Cryptography\.Xml""[^/]*/>\s*\r?\n?",
+        @"^[ \t]*<PackageReference\s+Include=""System\.Security\.Cryptography\.Xml""[^/]*/>[ \t]*\r?\n?",
         RegexOptions.Compiled | RegexOptions.Multiline);
 
     /// <inheritdoc />

--- a/tests/Fallout.Migrate.Specs/RewriteCsprojsStepSpecs.cs
+++ b/tests/Fallout.Migrate.Specs/RewriteCsprojsStepSpecs.cs
@@ -104,6 +104,7 @@ public class RewriteCsprojsStepSpecs : IDisposable
                                </PropertyGroup>
                              </Project>
                              """;
+
         (tempDirectory / "build" / "_build.csproj").WriteAllText(input, eofLineBreak: false);
 
         await new RewriteCsprojsStep().ExecuteAsync(context, summary);
@@ -123,6 +124,7 @@ public class RewriteCsprojsStepSpecs : IDisposable
                                </PropertyGroup>
                              </Project>
                              """;
+
         (tempDirectory / "build" / "_build.csproj").WriteAllText(input, eofLineBreak: false);
 
         await new RewriteCsprojsStep().ExecuteAsync(context, summary);
@@ -232,6 +234,7 @@ public class RewriteCsprojsStepSpecs : IDisposable
                                </ItemGroup>
                              </Project>
                              """;
+
         (tempDirectory / "build" / "_build.csproj").WriteAllText(input, eofLineBreak: false);
 
         await new RewriteCsprojsStep().ExecuteAsync(context, summary);
@@ -239,5 +242,57 @@ public class RewriteCsprojsStepSpecs : IDisposable
         summary.EditCount.Should().Be(0);
         var buildCsproj = (tempDirectory / "build" / "_build.csproj").ReadAllText();
         buildCsproj.Should().Be(input);
+    }
+
+    [Fact]
+    public async Task Telemetry_remove_pattern_does_not_act_greedy()
+    {
+        const string input = """
+                             <Project Sdk="Microsoft.NET.Sdk">
+                                 <PropertyGroup>
+                                     <FalloutTelemetryVersion>1</FalloutTelemetryVersion>
+                                     <IsPackable>false</IsPackable>
+                                 </PropertyGroup>
+                             </Project>
+                             """;
+
+        (tempDirectory / "build" / "_build.csproj").WriteAllText(input, eofLineBreak: false);
+
+        await new RewriteCsprojsStep().ExecuteAsync(context, summary);
+
+        var buildCsproj = (tempDirectory / "build" / "_build.csproj").ReadAllText();
+        buildCsproj.Should().Be("""
+                                <Project Sdk="Microsoft.NET.Sdk">
+                                    <PropertyGroup>
+                                        <IsPackable>false</IsPackable>
+                                    </PropertyGroup>
+                                </Project>
+                                """);
+    }
+
+    [Fact]
+    public async Task Cryptography_package_pin_remove_pattern_does_not_act_greedy()
+    {
+        const string input = """
+                             <Project Sdk="Microsoft.NET.Sdk">
+                                 <ItemGroup>
+                                     <PackageReference Include="Fallout.Common" Version="10.3.49" />
+                                     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
+                                 </ItemGroup>
+                             </Project>
+                             """;
+
+        (tempDirectory / "build" / "_build.csproj").WriteAllText(input, eofLineBreak: false);
+
+        await new RewriteCsprojsStep().ExecuteAsync(context, summary);
+
+        var buildCsproj = (tempDirectory / "build" / "_build.csproj").ReadAllText();
+        buildCsproj.Should().Be("""
+                                <Project Sdk="Microsoft.NET.Sdk">
+                                    <ItemGroup>
+                                        <PackageReference Include="Fallout.Common" Version="10.3.49" />
+                                    </ItemGroup>
+                                </Project>
+                                """);
     }
 }


### PR DESCRIPTION
`RewriteCsprojStep`'s `telemetryVersionPropertyPattern` and `cryptographyXmlPackageRefPattern` acting too greedy.

### Why?
Leaving the `\s*` at the end of the pattern, it consumes _every_ whitespace (including `\r`, `\n`) until it finds a non-whitespace (meaning everthing until the next `<`). This leaves the csproj file wrong indented behind.

Fixes: #612 
