### PR TITLE
Set the release version to 10.4.0

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.4.0-rc.5",
+  "version": "10.4.0",
   "publicReleaseRefSpec": [
     "^refs/heads/release/\\d{4}$",
     "^refs/heads/release/v\\d+\\.\\d+$",


### PR DESCRIPTION
Drops the `-rc.5` prerelease tag from `version.json` so the branch stamps a GA core.

Verified with `PublicRelease=1 nbgv get-version` — computes `10.4.0` (the `-g<sha>` on this topic branch is expected; `release/v10.4` matches `publicReleaseRefSpec`, so it resolves clean there).

> [!IMPORTANT]
> **Merge this only when you are actually cutting GA.** Once it lands, every commit on `release/v10.4` reports `10.4.0`, and any `v10.4.0` tag push publishes GA. If another release candidate is needed first (e.g. after #614), bump to `-rc.6` instead and hold this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)