### PR TITLE
Point the tool manifest at the shipping package id

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,8 +2,8 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "fallout.cli": {
-      "version": "10.3.45",
+    "fallout.globaltool": {
+      "version": "10.4.0-rc.5",
       "commands": [
         "fallout"
       ]


### PR DESCRIPTION
Backport of the manifest half of #622 onto the release line.

`.config/dotnet-tools.json` pinned `fallout.cli` 10.3.45 — an unlisted version of a retired package id — on the branch about to cut 10.4.0 GA. Repointed at `Fallout.GlobalTool` 10.4.0-rc.5, verified with `dotnet tool restore`.

Last remaining acceptance criterion on #575 for this line.

> [!NOTE]
> The pin wants a follow-up bump to `10.4.0` after the GA tag — a tool manifest cannot float from a prerelease to a stable version on its own.

Refs #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)