### PR TITLE
[Backport / 10.4]: Fix description of `--no-logo` option

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -71,7 +71,7 @@
         },
         "NoLogo": {
           "type": "boolean",
-          "description": "Disables displaying the NUKE logo"
+          "description": "Disables displaying the Fallout logo"
         },
         "Partition": {
           "type": "string",

--- a/src/Fallout.Build/FalloutBuild.cs
+++ b/src/Fallout.Build/FalloutBuild.cs
@@ -135,9 +135,9 @@ public abstract partial class FalloutBuild : IFalloutBuild
     public bool Help { get; }
 
     /// <summary>
-    /// Gets a value whether to display the NUKE logo.
+    /// Gets a value whether to display the Fallout logo.
     /// </summary>
-    [Parameter("Disables displaying the NUKE logo.")]
+    [Parameter("Disables displaying the Fallout logo.")]
     public bool NoLogo { get; set; }
 
     /// <summary>

--- a/tests/Fallout.Build.Specs/BuiltInParameterTextSpecs.cs
+++ b/tests/Fallout.Build.Specs/BuiltInParameterTextSpecs.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Fallout.Common.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Fallout.Common.Specs;
+
+/// <summary>
+/// Guards the descriptions of the built-in <see cref="ParameterAttribute" /> parameters — the text
+/// <c>--help</c> prints and the generated <c>.fallout/build.schema.json</c> embeds. See #553, where
+/// <c>--no-logo</c> still described the NUKE logo after the rebrand.
+/// </summary>
+public class BuiltInParameterTextSpecs
+{
+    /// <summary>Every listed and unlisted built-in parameter, with its description.</summary>
+    public static TheoryData<string, string> BuiltInParameters
+    {
+        get
+        {
+            var data = new TheoryData<string, string>();
+            foreach (var (name, description) in GetBuiltInParameters())
+                data.Add(name, description);
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(BuiltInParameters))]
+    public void No_built_in_parameter_description_names_a_pre_rebrand_product(string name, string description)
+    {
+        // Deliberate NUKE references live in attribution text and the logo tagline, not in the
+        // parameter descriptions a consumer reads out of --help.
+        // NotMatchRegex fails on a null subject, and a missing description is
+        // Every_built_in_parameter_carries_a_description's concern, so normalise before asserting.
+        (description ?? string.Empty).Should().NotMatchRegex(
+            new Regex(@"\bnukes?\b", RegexOptions.IgnoreCase),
+            "the {0} parameter's description should not name NUKE", name);
+    }
+
+    [Fact]
+    public void The_no_logo_parameter_names_the_Fallout_logo()
+    {
+        GetDescription(nameof(FalloutBuild.NoLogo)).Should().Be("Disables displaying the Fallout logo.");
+    }
+
+    [Fact]
+    public void Every_built_in_parameter_carries_a_description()
+    {
+        GetBuiltInParameters().Should().NotContain(x => x.Description.IsNullOrWhiteSpace());
+    }
+
+    private static string GetDescription(string memberName) =>
+        GetBuiltInParameters().Single(x => x.Name == memberName).Description;
+
+    private static (string Name, string Description)[] GetBuiltInParameters() =>
+        typeof(FalloutBuild)
+            .GetMembers(ReflectionUtility.All)
+            .Select(x => (Member: x, Attribute: x.GetCustomAttribute<ParameterAttribute>()))
+            .Where(x => x.Attribute != null)
+            .Select(x => (x.Member.Name, x.Attribute.Description))
+            .Distinct()
+            .OrderBy(x => x.Name)
+            .ToArray();
+}

--- a/tests/Fallout.Build.Specs/CompletionUtilitySpecs.cs
+++ b/tests/Fallout.Build.Specs/CompletionUtilitySpecs.cs
@@ -55,7 +55,7 @@ public class CompletionUtilitySpecs
                       "properties": {
                         "NoLogo": {
                           "type": "boolean",
-                          "description": "Disables displaying the NUKE logo"
+                          "description": "Disables displaying the Fallout logo"
                         },
                         "Configuration": {
                           "type": "string",

--- a/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestCustomParameterAttribute.verified.json
+++ b/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestCustomParameterAttribute.verified.json
@@ -39,7 +39,7 @@
         },
         "NoLogo": {
           "type": "boolean",
-          "description": "Disables displaying the NUKE logo"
+          "description": "Disables displaying the Fallout logo"
         },
         "Partition": {
           "type": "string",

--- a/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestEmptyBuild.verified.json
+++ b/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestEmptyBuild.verified.json
@@ -39,7 +39,7 @@
         },
         "NoLogo": {
           "type": "boolean",
-          "description": "Disables displaying the NUKE logo"
+          "description": "Disables displaying the Fallout logo"
         },
         "Partition": {
           "type": "string",

--- a/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestGetBuildSchema.verified.json
+++ b/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestGetBuildSchema.verified.json
@@ -58,7 +58,7 @@
         },
         "NoLogo": {
           "type": "boolean",
-          "description": "Disables displaying the NUKE logo"
+          "description": "Disables displaying the Fallout logo"
         },
         "NullableBooleanParam": {
           "type": "boolean"

--- a/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestParameterBuild.verified.json
+++ b/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestParameterBuild.verified.json
@@ -84,7 +84,7 @@
         },
         "NoLogo": {
           "type": "boolean",
-          "description": "Disables displaying the NUKE logo"
+          "description": "Disables displaying the Fallout logo"
         },
         "Partition": {
           "type": "string",

--- a/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestTargetBuild.verified.json
+++ b/tests/Fallout.Build.Specs/SchemaUtilitySpecs.TestTargetBuild.verified.json
@@ -45,7 +45,7 @@
         },
         "NoLogo": {
           "type": "boolean",
-          "description": "Disables displaying the NUKE logo"
+          "description": "Disables displaying the Fallout logo"
         },
         "Partition": {
           "type": "string",


### PR DESCRIPTION
<!-- Keep it terse: one-line summary, then short "what changed" bullets. -->
<!-- Link the issue and summarize it — don't recite it. See docs/agents/issue-and-pr-style.md. -->
<!-- Or let Copilot draft one, then trim it. -->

Finally closes #553 for 10.4

<!-- This repo merges via rebase only (linear history). Curate your commits into a -->
<!-- clean sequence before final approval — see CONTRIBUTING.md → Merging. -->
