### PR TITLE
Ignore machine-local files by convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,14 @@ _dotTrace*
 # Tests
 *.received.txt
 
-# Claude Code — local-only files (shared settings.json IS committed)
-.claude/settings.local.json
+# Local-only, by convention: anything named *.local.* is this-machine state and never
+# committed. Covers CLAUDE.local.md (personal agent directives), .claude/settings.local.json,
+# and .*crunch*.local.xml above. The shared sibling — settings.json, AGENTS.md, CLAUDE.md —
+# IS committed.
+*.local.*
+
+# Claude Code — local state the pattern above doesn't catch. Credentials especially:
+# these must never reach a public repo.
 .claude/.credentials*
 .claude/scheduled_tasks.lock
 .claude/worktrees/


### PR DESCRIPTION
`CLAUDE.local.md` carries personal, per-checkout agent directives and is held back only by a local `.git/info/exclude` — which no other clone gets. One `git add -A` commits it.

### Changes
- `.gitignore` — ignore `*.local.*` as a pattern rather than each file. It subsumes `.claude/settings.local.json` and `.*crunch*.local.xml`, both removed here.

### Notes
The shared siblings stay tracked: `.claude/settings.json`, `AGENTS.md`, `CLAUDE.md`. Verified no currently-tracked file becomes ignored.