### PR TITLE
Request the triage label by its real name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: 🐞 Bug Report
 description: "Report something that doesn't look alright."
-labels: ["bug", "triage"]
+labels: ["bug", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_idea.yml
+++ b/.github/ISSUE_TEMPLATE/feature_idea.yml
@@ -1,6 +1,6 @@
 name: 💡 Feature Idea
 description: "Suggest new features for the project."
-labels: ["enhancement", "triage"]
+labels: ["enhancement", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -1,6 +1,6 @@
 name: 📝 User Story
 description: "Describe a desired capability as a small, outcome-focused story."
-labels: ["enhancement", "triage"]
+labels: ["enhancement", "needs-triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
The issue forms ask for a `triage` label. The label is `needs-triage`. GitHub silently drops labels that don't exist, so every templated issue has arrived untriaged — `gh issue list --label triage --state all` returns nothing, ever.

### Changes
- `bug_report.yml`, `feature_idea.yml`, `user_story.yml` — `triage` → `needs-triage`.

### Notes
Found while aligning the extension repo's labels with the tidied set here — it had inherited the same typo from these forms, as had the org-wide defaults in `Fallout-build/.github`. Both are fixed.