### PR TITLE
Bump NuGet.Packaging to 7.9.0 to match the SDK's NuGet version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="NuGet.Packaging" Version="6.14.3" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.9.0" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />


### PR DESCRIPTION
> ⚠️ **Breaking change** — NuGet 7.x does not support `netstandard2.0`. Taking this bump means `Fallout.Tooling` and `Fallout.Tooling.Generator` stop supporting `netstandard2.0`, and .NET Framework support goes with it. Consumers on those targets must move to `net10.0`.

**Held for the next major.** This PR is labelled `target/vNext` and stays open until we cut that release. See the [direction comment on #638](https://github.com/Fallout-build/Fallout/issues/638#issuecomment-5307046010).

The .NET 10 SDK loads `NuGet.Frameworks 7.9.0.0` into MSBuild, but the pinned `NuGet.Packaging 6.14.3` loaded `NuGet.Frameworks 6.14.3` into the same build-host process, so every `./build.sh` run fails at `Compile` once CI moved from SDK 10.0.302 to 10.0.400.

### What changed
- `NuGet.Packaging` 6.14.3 → 7.9.0 in `Directory.Packages.props`. One line, no source changes.

### Why
[NuGet 7.0](https://learn.microsoft.com/en-us/nuget/release-notes/nuget-7.0) only removed APIs that were already marked obsolete. This repo uses `NuspecReader`, `PackageArchiveReader`, `PackageFolderReader`, `VersionRange`, `NuGetVersion` and `NuGetFramework`. None of them changed.

Nothing in the repository caused the break. `global.json` pins SDK `10.0.100` with `rollForward: latestMinor`, so CI takes whatever the runner image ships.

### Verification
- `./build.sh Compile` fails on `main` and succeeds on this branch, on SDK 10.0.400.
- `Fallout.Migrate.Analyzers.Specs`: 14/14 pass.
- `Fallout.Build.Specs`: 239/242 pass. The 3 `GitRepositoryWorktreeSpecs` failures are pre-existing and environment-specific — they assert on the git remote identity and fail identically at 6.14.3 in a fork checkout.

### Note on the netstandard2.0 targets
`Fallout.Tooling` (`net10.0;netstandard2.0`) and `Fallout.Tooling.Generator` (`netstandard2.0`) currently still declare those targets. With this bump they restore .NET Framework assets instead and emit NU1701 warnings. Actually removing the targets is separate work for the same major.

Part of #638
