### PR TITLE
Pin the SDK to the 10.0.3xx feature band to stop unattended roll-forward

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
-    "rollForward": "latestMinor"
+    "version": "10.0.302",
+    "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
Restores CI. Pins the SDK to the `10.0.3xx` feature band so the runner image can no longer change our toolchain without us noticing.

### What changed
- `global.json`: `10.0.100` / `rollForward: latestMinor` → `10.0.302` / `rollForward: latestPatch`.

### Why we have to do this for now
`rollForward: latestMinor` meant CI used whatever SDK the GitHub runner image happened to ship. The image moved to **10.0.400**, which loads `NuGet.Frameworks 7.9.0.0` into MSBuild. That conflicts with our pinned `NuGet.Packaging 6.14.3`, which loads `NuGet.Frameworks 6.14.3` into the same build-host process. Every `./build.sh` run then fails at `Compile`.

No repository change caused this. The last green run used SDK **10.0.302**; the first failing run used **10.0.400**.

The real fix is bumping `NuGet.Packaging` to 7.x — that is #639. It cannot be merged now, because NuGet 7.x drops `netstandard2.0`, which makes it a breaking change held for the next major (`target/vNext`).

So this PR is the interim measure. It keeps CI green in the meantime and unblocks every other PR. `latestPatch` still accepts `10.0.3xx` security and bug-fix patches, but will not jump to `10.0.4xx`.

Once #639 lands, this pin should be revisited — the band can move forward, and roll-forward policy can be reconsidered deliberately rather than by accident.

### Verification
- With only 10.0.400 installed, `dotnet` in the repo now refuses to run rather than silently using the broken band. That is the intended behaviour.
- CI installs 10.0.302 automatically — `actions/setup-dotnet` is configured with `global-json-file: global.json` in both `build.yml` and the publish workflows.

### Note for contributors
You need a `10.0.3xx` SDK installed locally. If you only have 10.0.400, `dotnet` will report "A compatible .NET SDK was not found" until you install one.

Part of #638
