### PR TITLE
Add an llms.txt index for the documentation (#660)

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -43,7 +43,8 @@
         "Test",
         "UpdateContributors",
         "UpdateStargazers",
-        "VerifyGeneratedTools"
+        "VerifyGeneratedTools",
+        "VerifyLlmsTxt"
       ]
     },
     "Verbosity": {

--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -30,6 +30,7 @@
         "CreateGitHubRelease",
         "DeletePackages",
         "DownloadLicenses",
+        "GenerateLlmsTxt",
         "GeneratePublicApi",
         "GenerateTools",
         "Install",

--- a/.github/workflows/build-skip.yml
+++ b/.github/workflows/build-skip.yml
@@ -28,8 +28,13 @@ name: build
 # Mirrors build.yml. This job does real work now, so rapid pushes to a docs PR
 # would otherwise stack concurrent builds, which is the cost this file exists to
 # avoid in the first place.
+#
+# The group is a literal, NOT ${{ github.workflow }}: that expands to the workflow
+# `name:`, which is `build` in both this file and build.yml on purpose. A PR that
+# touches code AND a doc fires both workflows, and a shared group plus
+# cancel-in-progress would let whichever starts second cancel the other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: build-skip-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/build-skip.yml
+++ b/.github/workflows/build-skip.yml
@@ -25,6 +25,13 @@
 
 name: build
 
+# Mirrors build.yml. This job does real work now, so rapid pushes to a docs PR
+# would otherwise stack concurrent builds, which is the cost this file exists to
+# avoid in the first place.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/build-skip.yml
+++ b/.github/workflows/build-skip.yml
@@ -9,10 +9,15 @@
 #   - Without a substitute, docs-only PRs sit BLOCKED waiting for a check that
 #     never reports.
 #
-# This workflow fires on the inverse path set (docs-only changes), runs nothing
-# of substance, and reports success under the same `ubuntu-latest` status-check
-# context — satisfying the protection rule without spending CI minutes on a real
-# build.
+# This workflow fires on the inverse path set (docs-only changes) and reports
+# success under the same `ubuntu-latest` status-check context, satisfying the
+# protection rule without spending CI minutes on a full build/test/pack.
+#
+# It is not a no-op any more. docs/llms.txt is generated from docs/website by
+# `GenerateLlmsTxt`, so a docs-only PR is exactly the change that can leave it
+# stale — and it is exactly the change build.yml ignores. VerifyLlmsTxt therefore
+# runs here, which is the only workflow that sees these PRs. It builds the build
+# project and regenerates one file; it does not run the test or pack targets.
 #
 # Keep the job name `ubuntu-latest` aligned with build.yml so both files produce
 # a status check named `ubuntu-latest`; the workflow `name:` mirrors build.yml's
@@ -37,5 +42,23 @@ jobs:
     name: ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - name: 'Skip: docs-only PR, no build needed'
-        run: echo "Docs-only change — ubuntu-latest validation skipped via .github/workflows/build-skip.yml."
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.head_ref }}
+      - name: 'Cache: .fallout/temp, ~/.nuget/packages'
+        uses: actions/cache@v6
+        with:
+          path: |
+            .fallout/temp
+            ~/.nuget/packages
+          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
+      - name: 'Setup: .NET SDK'
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+      - name: 'Restore: dotnet tools'
+        run: dotnet tool restore
+      - name: 'Run: VerifyLlmsTxt'
+        run: dotnet fallout VerifyLlmsTxt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,5 +55,5 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyGeneratedTools, Test, Pack'
-        run: dotnet fallout VerifyGeneratedTools Test Pack
+      - name: 'Run: VerifyGeneratedTools, VerifyLlmsTxt, Test, Pack'
+        run: dotnet fallout VerifyGeneratedTools VerifyLlmsTxt Test Pack

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -44,7 +44,7 @@ using Fallout.Components;
     // long-lived and protected; all require the ubuntu-latest check.
     OnPullRequestBranches = new[] { DevelopBranch, MainBranch, ReleaseBranchPattern, SupportBranchPattern },
     OnPullRequestExcludePaths = new[] { "docs/**", ".assets/**", "**/*.md" },
-    InvokedTargets = new[] { nameof(VerifyGeneratedTools), nameof(ITest.Test), nameof(IPack.Pack) },
+    InvokedTargets = new[] { nameof(VerifyGeneratedTools), nameof(VerifyLlmsTxt), nameof(ITest.Test), nameof(IPack.Pack) },
     PublishArtifacts = false)]
 [GitHubActions(
     "build-cross-platform",

--- a/build/Build.Documentation.cs
+++ b/build/Build.Documentation.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Fallout.Common;
+using Fallout.Common.IO;
+using Fallout.Common.Utilities;
+using Fallout.Common.Utilities.Collections;
+using Serilog;
+
+partial class Build
+{
+    AbsolutePath DocsWebsiteDirectory => RootDirectory / "docs" / "website";
+
+    // The public site is built from docs/website by the separate Fallout-build/docs.fallout.build
+    // Docusaurus repository, which serves the pages under a /docs/ route prefix. Verified against
+    // https://docs.fallout.build/sitemap.xml, not against the README: the README's own links omit
+    // the prefix and 404 (see the follow-up on the PR). Hardcoded for the same reason as
+    // CanonicalRepositoryIdentifier: the generated file must be identical whichever fork
+    // regenerates it.
+    const string DocsBaseUrl = "https://docs.fallout.build/docs/";
+
+    // Docusaurus orders pages by a numeric prefix on the directory and file name, and strips that
+    // prefix from the served URL. So 01-getting-started/01-installation.md is served at
+    // /getting-started/installation, which is the URL the README already links.
+    static readonly Regex OrderPrefix = new(@"^(?<order>\d+)-", RegexOptions.Compiled);
+
+    static string StripOrderPrefix(string segment) => OrderPrefix.Replace(segment, string.Empty);
+
+    static int GetOrder(string segment)
+    {
+        var match = OrderPrefix.Match(segment);
+        return match.Success ? int.Parse(match.Groups["order"].Value) : int.MaxValue;
+    }
+
+    string ToPublicUrl(AbsolutePath page)
+    {
+        var relative = DocsWebsiteDirectory.GetUnixRelativePathTo(page).ToString();
+        var slug = relative[..^".md".Length]
+            .Split('/')
+            .Select(StripOrderPrefix)
+            .JoinSlash();
+
+        return DocsBaseUrl + slug;
+    }
+
+    // "01-getting-started" becomes "Getting Started". The directory slug is the only section name
+    // available: the docs tree has no per-directory metadata file.
+    static string ToSectionTitle(string directorySlug)
+    {
+        return StripOrderPrefix(directorySlug)
+            .Split('-')
+            .Select(x => char.ToUpperInvariant(x[0]) + x[1..])
+            .JoinSpace();
+    }
+
+    Target GenerateLlmsTxt => _ => _
+        .Executes(() =>
+        {
+            DocsWebsiteDirectory.GlobFiles("**/*.md")
+                .OrderBy(x => x.ToString())
+                .ForEach(x => Log.Information(
+                    "{Relative} -> {Url}",
+                    DocsWebsiteDirectory.GetUnixRelativePathTo(x),
+                    ToPublicUrl(x)));
+        });
+}

--- a/build/Build.Documentation.cs
+++ b/build/Build.Documentation.cs
@@ -8,12 +8,17 @@ using Fallout.Common;
 using Fallout.Common.IO;
 using Fallout.Common.Utilities;
 using Fallout.Common.Utilities.Collections;
+using Fallout.Utilities.Text.Yaml;
 using Serilog;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
 using static Fallout.Common.Tools.Git.GitTasks;
 
 partial class Build
 {
     AbsolutePath DocsWebsiteDirectory => RootDirectory / "docs" / "website";
+
+    AbsolutePath LlmsTxtFile => RootDirectory / "docs" / "llms.txt";
 
     // The public site is built from docs/website by the separate Fallout-build/docs.fallout.build
     // Docusaurus repository, which serves the pages under a /docs/ route prefix. Verified against
@@ -23,17 +28,138 @@ partial class Build
     // regenerates it.
     const string DocsBaseUrl = "https://docs.fallout.build/docs/";
 
+    const int MaxDescriptionLength = 200;
+
     // Docusaurus orders pages by a numeric prefix on the directory and file name, and strips that
     // prefix from the served URL. So 01-getting-started/01-installation.md is served at
     // /docs/getting-started/installation.
-    static readonly Regex OrderPrefix = new(@"^(?<order>\d+)-", RegexOptions.Compiled);
+    static readonly Regex orderPrefix = new(@"^(?<order>\d+)-", RegexOptions.Compiled);
 
-    static string StripOrderPrefix(string segment) => OrderPrefix.Replace(segment, string.Empty);
+    // Inline markdown links render as "[text](url)". Only the text belongs in a one-line summary.
+    static readonly Regex inlineLink = new(@"\[(?<text>[^\]]+)\]\([^)]+\)", RegexOptions.Compiled);
 
-    static int GetOrder(string segment)
+    // Deserialized rather than hand-parsed, so quoting, escaping and block scalars follow the YAML
+    // spec instead of a line regex. Underscored, not the repo-default camelCase builder, because
+    // Docusaurus spells its keys 'sidebar_position'.
+    static readonly DeserializerBuilder frontmatterDeserializer = new DeserializerBuilder()
+        .WithNamingConvention(UnderscoredNamingConvention.Instance)
+        .IgnoreUnmatchedProperties();
+
+    /// <param name="IsPrimary">
+    /// Whether the site places this page in its sidebar. Only meaningful for the pages at the root
+    /// of docs/website, which have no section to sort them: introduction.md declares a
+    /// 'sidebar_position' and badge.md does not, and that is exactly the split between a link that
+    /// belongs in the main body and one that belongs under "Optional".
+    /// </param>
+    sealed record DocPage(
+        string Title,
+        string Description,
+        string Url,
+        string Section,
+        int SectionOrder,
+        int Order,
+        bool IsPrimary);
+
+    // Only the three keys this index reads. Docusaurus accepts many more (tags, slug, keywords,
+    // hide_title...), so unmatched ones are ignored rather than failing a page that adds one.
+    sealed record Frontmatter
     {
-        var match = OrderPrefix.Match(segment);
-        return match.Success ? int.Parse(match.Groups["order"].Value) : int.MaxValue;
+        public string Title { get; init; }
+
+        public string Description { get; init; }
+
+        public int? SidebarPosition { get; init; }
+    }
+
+    Target GenerateLlmsTxt => _ => _
+        .Executes(() =>
+        {
+            var pages = ReadDocPages();
+            LlmsTxtFile.WriteAllText(RenderLlmsTxt(pages));
+
+            Log.Information("Wrote {File} with {Count} pages", RootDirectory.GetUnixRelativePathTo(LlmsTxtFile), pages.Count);
+        });
+
+    // CI gate, in the shape of VerifyGeneratedTools: GenerateLlmsTxt only runs when a contributor
+    // remembers to invoke it, so a page added under docs/website without regenerating would merge
+    // with docs/llms.txt silently missing it. `Requires` is asserted for the whole scheduled plan
+    // before any target runs, so the "start clean" check below still fires before GenerateLlmsTxt
+    // regenerates anything; the explicit re-check afterward catches drift with a message pointing
+    // at the fix.
+    //
+    // Wired into BOTH workflows on purpose. build.yml ignores docs/**, so on its own it would never
+    // fire on the change that actually invalidates the file; build-skip.yml is the workflow that
+    // handles those PRs, and it runs this target for exactly that reason.
+    Target VerifyLlmsTxt => _ => _
+        .Requires(() => GitHasCleanWorkingCopy())
+        .DependsOn(GenerateLlmsTxt)
+        .Executes(() =>
+        {
+            Assert.True(
+                GitHasCleanWorkingCopy(),
+                "docs/llms.txt is out of sync with docs/website. Run './build.ps1 GenerateLlmsTxt' "
+                + "locally and commit the result.");
+        });
+
+    // Docusaurus routes both .md and .mdx, and excludes anything whose file or directory name
+    // starts with an underscore (**/_*.md, **/_*/**). docs/website/_snippets/ exists for exactly
+    // that reason, so indexing it would emit URLs the site never serves.
+    IReadOnlyList<DocPage> ReadDocPages()
+    {
+        return DocsWebsiteDirectory.GlobFiles("**/*.md", "**/*.mdx")
+            .Where(x => !DocsWebsiteDirectory.GetUnixRelativePathTo(x).ToString()
+                .Split('/')
+                .Any(segment => segment.StartsWith('_')))
+            .Select(ReadPage)
+            .OrderBy(x => x.SectionOrder)
+            .ThenBy(x => x.Order)
+            // Ordinal, not the culture-sensitive default: docs/llms.txt is verified byte for byte,
+            // so a contributor on another culture must not regenerate a differently ordered file
+            // and trip VerifyLlmsTxt with no real drift.
+            .ThenBy(x => x.Title, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    DocPage ReadPage(AbsolutePath file)
+    {
+        var lines = file.ReadAllLines();
+        var frontmatterEnd = GetFrontmatterEnd(lines);
+        var frontmatter = ReadFrontmatter(lines, frontmatterEnd);
+
+        // Docusaurus falls back to the first H1 when a page declares no 'title', and docs/website
+        // has a page that relies on it: badge.md carries no frontmatter at all and is served as
+        // "Badge". Rejecting it would refuse a page the site renders correctly, so the fallback
+        // matches Docusaurus. A page with neither still fails, because that leaves no link text.
+        var title = frontmatter.Title.IsNullOrWhiteSpace()
+            ? GetFirstHeading(lines, frontmatterEnd)
+            : frontmatter.Title;
+        Assert.NotNullOrWhiteSpace(
+            title,
+            $"{DocsWebsiteDirectory.GetUnixRelativePathTo(file)} has neither a 'title' in its "
+            + "frontmatter nor a top-level heading. One of the two is needed: it is the link text "
+            + "in docs/llms.txt.");
+
+        var description = frontmatter.Description.IsNullOrWhiteSpace()
+            ? GetFirstProseParagraph(lines, frontmatterEnd)
+            : frontmatter.Description;
+
+        var relative = DocsWebsiteDirectory.GetUnixRelativePathTo(file).ToString();
+        var segments = relative.Split('/');
+        var isNested = segments.Length > 1;
+
+        return new DocPage(
+            Title: title,
+            Description: Summarize(description),
+            Url: ToPublicUrl(file),
+            // Root-level pages have no section, so they are rendered either above the first one or
+            // under "Optional", depending on IsPrimary.
+            Section: isNested ? ToSectionTitle(segments[0]) : null,
+            SectionOrder: isNested ? GetOrder(segments[0]) : int.MaxValue,
+            // Docusaurus lets a page's own 'sidebar_position' override the numeric filename prefix,
+            // and docs/website uses it: 07-ide has no prefixes, and rider.md declares position 1 to
+            // sort first. Reading only the prefix would order that section by title instead.
+            Order: frontmatter.SidebarPosition ?? GetOrder(segments[^1]),
+            IsPrimary: isNested || frontmatter.SidebarPosition.HasValue);
     }
 
     string ToPublicUrl(AbsolutePath page)
@@ -72,67 +198,28 @@ partial class Build
             .JoinSpace();
     }
 
-    /// <param name="IsPrimary">
-    /// Whether the site places this page in its sidebar. Only meaningful for the pages at the root
-    /// of docs/website, which have no section to sort them: introduction.md declares a
-    /// 'sidebar_position' and badge.md does not, and that is exactly the split between a link that
-    /// belongs in the main body and one that belongs under "Optional".
-    /// </param>
-    sealed record DocPage(
-        string Title,
-        string Description,
-        string Url,
-        string Section,
-        int SectionOrder,
-        int Order,
-        bool IsPrimary);
-
-    const int MaxDescriptionLength = 200;
-
-    // Inline markdown links render as "[text](url)". Only the text belongs in a one-line summary.
-    static readonly Regex InlineLink = new(@"\[(?<text>[^\]]+)\]\([^)]+\)", RegexOptions.Compiled);
-
-    static readonly Regex FrontmatterEntry = new(@"^(?<key>[a-zA-Z_]+):\s*(?<value>.*)$", RegexOptions.Compiled);
-
-    DocPage ReadPage(AbsolutePath file)
+    static int GetFrontmatterEnd(string[] lines)
     {
-        var lines = file.ReadAllLines();
-        var frontmatterEnd = GetFrontmatterEnd(lines);
-        var frontmatter = ReadFrontmatter(lines, frontmatterEnd);
+        if (lines.Length == 0 || lines[0].Trim() != "---")
+            return 0;
 
-        // Docusaurus falls back to the first H1 when a page declares no 'title', and docs/website
-        // has a page that relies on it: badge.md carries no frontmatter at all and is served as
-        // "Badge". Rejecting it would refuse a page the site renders correctly, so the fallback
-        // matches Docusaurus. A page with neither still fails, because that leaves no link text.
-        var title = frontmatter.GetValueOrDefault("title") ?? GetFirstHeading(lines, frontmatterEnd);
-        Assert.NotNullOrWhiteSpace(
-            title,
-            $"{DocsWebsiteDirectory.GetUnixRelativePathTo(file)} has neither a 'title' in its "
-            + "frontmatter nor a top-level heading. One of the two is needed: it is the link text "
-            + "in docs/llms.txt.");
+        var end = Array.FindIndex(lines, startIndex: 1, x => x.Trim() == "---");
+        // An opened but unclosed block is malformed. Returning 0 would hand the delimiter and the
+        // key/value lines to the prose reader and ship them as a description, so fail instead: a
+        // wrong entry in a generated index is worse than a build that says what is wrong.
+        Assert.True(end >= 0, "Frontmatter is opened with '---' but never closed.");
+        return end + 1;
+    }
 
-        var description = frontmatter.GetValueOrDefault("description")
-                          ?? GetFirstProseParagraph(lines, frontmatterEnd);
+    static Frontmatter ReadFrontmatter(string[] lines, int frontmatterEnd)
+    {
+        // frontmatterEnd is one past the closing '---', so the block itself is lines 1..end-2.
+        // 0 means the page opens with no frontmatter at all; badge.md is one such page.
+        if (frontmatterEnd == 0)
+            return new Frontmatter();
 
-        var relative = DocsWebsiteDirectory.GetUnixRelativePathTo(file).ToString();
-        var segments = relative.Split('/');
-        var isNested = segments.Length > 1;
-
-        return new DocPage(
-            Title: title,
-            Description: Summarize(description),
-            Url: ToPublicUrl(file),
-            // Root-level pages have no section, so they are rendered either above the first one or
-            // under "Optional", depending on IsPrimary.
-            Section: isNested ? ToSectionTitle(segments[0]) : null,
-            SectionOrder: isNested ? GetOrder(segments[0]) : int.MaxValue,
-            // Docusaurus lets a page's own 'sidebar_position' override the numeric filename prefix,
-            // and docs/website uses it: 07-ide has no prefixes, and rider.md declares position 1 to
-            // sort first. Reading only the prefix would order that section by title instead.
-            Order: frontmatter.TryGetValue("sidebar_position", out var position) && int.TryParse(position, out var parsed)
-                ? parsed
-                : GetOrder(segments[^1]),
-            IsPrimary: isNested || frontmatter.ContainsKey("sidebar_position"));
+        var yaml = lines[1..(frontmatterEnd - 1)].JoinNewLine();
+        return yaml.GetYaml<Frontmatter>(frontmatterDeserializer) ?? new Frontmatter();
     }
 
     // Starts after the frontmatter and ignores fenced code, because "# terminal-command" is used as
@@ -150,43 +237,6 @@ partial class Build
         }
 
         return null;
-    }
-
-    static int GetFrontmatterEnd(string[] lines)
-    {
-        if (lines.Length == 0 || lines[0].Trim() != "---")
-            return 0;
-
-        var end = Array.FindIndex(lines, startIndex: 1, x => x.Trim() == "---");
-        // An opened but unclosed block is malformed. Returning 0 would hand the delimiter and the
-        // key/value lines to the prose reader and ship them as a description, so fail instead: a
-        // wrong entry in a generated index is worse than a build that says what is wrong.
-        Assert.True(end >= 0, "Frontmatter is opened with '---' but never closed.");
-        return end + 1;
-    }
-
-    static Dictionary<string, string> ReadFrontmatter(string[] lines, int frontmatterEnd)
-    {
-        var entries = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        for (var i = 1; i < Math.Max(frontmatterEnd - 1, 1); i++)
-        {
-            var match = FrontmatterEntry.Match(lines[i]);
-            if (!match.Success)
-                continue;
-
-            var value = match.Groups["value"].Value.Trim().TrimMatchingDoubleQuotes().Trim('\'');
-
-            // ">" and "|" open a YAML block scalar whose text sits on the following lines. This
-            // parser is line-based, so it would store the indicator itself and render
-            // "- [Title](url): >". Treat the key as absent and let the prose fallback handle it.
-            if (value is ">" or "|" or ">-" or "|-")
-                continue;
-
-            if (!value.IsNullOrWhiteSpace())
-                entries[match.Groups["key"].Value] = value;
-        }
-
-        return entries;
     }
 
     // Only introduction.md declares a 'description', so for the other 36 pages the summary falls
@@ -218,7 +268,13 @@ partial class Build
                           !trimmed.StartsWith(":::") &&
                           !trimmed.StartsWith('#') &&
                           !trimmed.StartsWith('|') &&
-                          !trimmed.StartsWith('!');
+                          !trimmed.StartsWith('!') &&
+                          // A page opening with a list or a quote has no lead paragraph to take.
+                          // "- "/"* " and not '-'/'*', so a '---' rule or a '**bold**' lead-in
+                          // is still read as the prose it is.
+                          !trimmed.StartsWith("- ") &&
+                          !trimmed.StartsWith("* ") &&
+                          !trimmed.StartsWith('>');
 
             if (isProse)
                 paragraph.Add(trimmed);
@@ -234,7 +290,7 @@ partial class Build
         if (text.IsNullOrWhiteSpace())
             return null;
 
-        var flattened = InlineLink.Replace(text, "${text}").Trim();
+        var flattened = inlineLink.Replace(text, "${text}").Trim();
         if (flattened.Length <= MaxDescriptionLength)
             return flattened;
 
@@ -242,27 +298,6 @@ partial class Build
         var cut = flattened.LastIndexOf(' ', MaxDescriptionLength);
         return flattened[..(cut > 0 ? cut : MaxDescriptionLength)].TrimEnd(',', ';', ':', '.') + "...";
     }
-
-    // Docusaurus routes both .md and .mdx, and excludes anything whose file or directory name
-    // starts with an underscore (**/_*.md, **/_*/**). docs/website/_snippets/ exists for exactly
-    // that reason, so indexing it would emit URLs the site never serves.
-    IReadOnlyList<DocPage> ReadDocPages()
-    {
-        return DocsWebsiteDirectory.GlobFiles("**/*.md", "**/*.mdx")
-            .Where(x => !DocsWebsiteDirectory.GetUnixRelativePathTo(x).ToString()
-                .Split('/')
-                .Any(segment => segment.StartsWith('_')))
-            .Select(ReadPage)
-            .OrderBy(x => x.SectionOrder)
-            .ThenBy(x => x.Order)
-            // Ordinal, not the culture-sensitive default: docs/llms.txt is verified byte for byte,
-            // so a contributor on another culture must not regenerate a differently ordered file
-            // and trip VerifyLlmsTxt with no real drift.
-            .ThenBy(x => x.Title, StringComparer.Ordinal)
-            .ToList();
-    }
-
-    AbsolutePath LlmsTxtFile => RootDirectory / "docs" / "llms.txt";
 
     // https://llmstxt.org: an H1, an optional blockquote summary, then H2 sections of link lines.
     // A list may also sit between the blockquote and the first H2, which is where the pages that
@@ -322,32 +357,11 @@ partial class Build
             : $"- [{page.Title}]({page.Url}): {page.Description}";
     }
 
-    Target GenerateLlmsTxt => _ => _
-        .Executes(() =>
-        {
-            var pages = ReadDocPages();
-            LlmsTxtFile.WriteAllText(RenderLlmsTxt(pages));
+    static string StripOrderPrefix(string segment) => orderPrefix.Replace(segment, string.Empty);
 
-            Log.Information("Wrote {File} with {Count} pages", RootDirectory.GetUnixRelativePathTo(LlmsTxtFile), pages.Count);
-        });
-
-    // CI gate, in the shape of VerifyGeneratedTools: GenerateLlmsTxt only runs when a contributor
-    // remembers to invoke it, so a page added under docs/website without regenerating would merge
-    // with docs/llms.txt silently missing it. `Requires` is asserted for the whole scheduled plan
-    // before any target runs, so the "start clean" check below still fires before GenerateLlmsTxt
-    // regenerates anything; the explicit re-check afterward catches drift with a message pointing
-    // at the fix.
-    //
-    // Wired into BOTH workflows on purpose. build.yml ignores docs/**, so on its own it would never
-    // fire on the change that actually invalidates the file; build-skip.yml is the workflow that
-    // handles those PRs, and it runs this target for exactly that reason.
-    Target VerifyLlmsTxt => _ => _
-        .Requires(() => GitHasCleanWorkingCopy())
-        .DependsOn(GenerateLlmsTxt)
-        .Executes(() =>
-        {
-            Assert.True(
-                GitHasCleanWorkingCopy(),
-                "docs/llms.txt is out of sync with docs/website. Run './build.ps1 GenerateLlmsTxt' locally and commit the result.");
-        });
+    static int GetOrder(string segment)
+    {
+        var match = orderPrefix.Match(segment);
+        return match.Success ? int.Parse(match.Groups["order"].Value) : int.MaxValue;
+    }
 }

--- a/build/Build.Documentation.cs
+++ b/build/Build.Documentation.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using Fallout.Common;
 using Fallout.Common.IO;
@@ -65,14 +66,27 @@ partial class Build
             .JoinSpace();
     }
 
-    sealed record DocPage(string Title, string Description, string Url, string Section, int SectionOrder, int Order);
+    /// <param name="IsPrimary">
+    /// Whether the site places this page in its sidebar. Only meaningful for the pages at the root
+    /// of docs/website, which have no section to sort them: introduction.md declares a
+    /// 'sidebar_position' and badge.md does not, and that is exactly the split between a link that
+    /// belongs in the main body and one that belongs under "Optional".
+    /// </param>
+    sealed record DocPage(
+        string Title,
+        string Description,
+        string Url,
+        string Section,
+        int SectionOrder,
+        int Order,
+        bool IsPrimary);
 
     const int MaxDescriptionLength = 200;
 
     // Inline markdown links render as "[text](url)". Only the text belongs in a one-line summary.
     static readonly Regex InlineLink = new(@"\[(?<text>[^\]]+)\]\([^)]+\)", RegexOptions.Compiled);
 
-    static readonly Regex FrontmatterEntry = new(@"^(?<key>[a-zA-Z]+):\s*(?<value>.*)$", RegexOptions.Compiled);
+    static readonly Regex FrontmatterEntry = new(@"^(?<key>[a-zA-Z_]+):\s*(?<value>.*)$", RegexOptions.Compiled);
 
     DocPage ReadPage(AbsolutePath file)
     {
@@ -102,11 +116,12 @@ partial class Build
             Title: title,
             Description: Summarize(description),
             Url: ToPublicUrl(file),
-            // Root-level pages have no section. Task 3 collects them under "Optional", which is the
-            // part of the llmstxt.org format meant for lower-priority links.
+            // Root-level pages have no section, so they are rendered either above the first one or
+            // under "Optional", depending on IsPrimary.
             Section: isNested ? ToSectionTitle(segments[0]) : null,
             SectionOrder: isNested ? GetOrder(segments[0]) : int.MaxValue,
-            Order: GetOrder(segments[^1]));
+            Order: GetOrder(segments[^1]),
+            IsPrimary: isNested || frontmatter.ContainsKey("sidebar_position"));
     }
 
     static string GetFirstHeading(string[] lines)
@@ -207,14 +222,65 @@ partial class Build
             .ToList();
     }
 
+    AbsolutePath LlmsTxtFile => RootDirectory / "docs" / "llms.txt";
+
+    // https://llmstxt.org: an H1, an optional blockquote summary, then H2 sections of link lines.
+    // A list may also sit between the blockquote and the first H2, which is where the pages that
+    // live at the root of docs/website go when the site gives them a sidebar position.
+    string RenderLlmsTxt(IReadOnlyList<DocPage> pages)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# Fallout");
+        builder.AppendLine();
+
+        // Single source for the summary: introduction.md's own 'description', which is what the
+        // site serves as its meta description. Generating it from anywhere else would let the two
+        // drift apart.
+        var summary = pages.Single(x => x.Url == DocsBaseUrl + "introduction").Description;
+        builder.AppendLine($"> {summary}");
+        builder.AppendLine();
+        builder.AppendLine(
+            "Generated from the documentation sources by './build.ps1 GenerateLlmsTxt'. Do not edit by hand.");
+        builder.AppendLine();
+
+        foreach (var page in pages.Where(x => x.Section == null && x.IsPrimary))
+            builder.AppendLine(RenderEntry(page));
+
+        foreach (var section in pages.Where(x => x.Section != null).GroupBy(x => x.Section))
+        {
+            builder.AppendLine();
+            builder.AppendLine($"## {section.Key}");
+            builder.AppendLine();
+            section.ForEach(x => builder.AppendLine(RenderEntry(x)));
+        }
+
+        // llms.txt reserves "Optional" for links a consumer may skip when it needs a shorter
+        // context. Root pages the site does not place in the sidebar belong there.
+        var optional = pages.Where(x => x.Section == null && !x.IsPrimary).ToList();
+        if (optional.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("## Optional");
+            builder.AppendLine();
+            optional.ForEach(x => builder.AppendLine(RenderEntry(x)));
+        }
+
+        return builder.ToString();
+    }
+
+    static string RenderEntry(DocPage page)
+    {
+        return page.Description.IsNullOrWhiteSpace()
+            ? $"- [{page.Title}]({page.Url})"
+            : $"- [{page.Title}]({page.Url}): {page.Description}";
+    }
+
     Target GenerateLlmsTxt => _ => _
         .Executes(() =>
         {
-            ReadDocPages().ForEach(x => Log.Information(
-                "[{Section}] {Title} -> {Url} :: {Description}",
-                x.Section ?? "(root)",
-                x.Title,
-                x.Url,
-                x.Description ?? "(none)"));
+            var pages = ReadDocPages();
+            LlmsTxtFile.WriteAllText(RenderLlmsTxt(pages));
+
+            Log.Information("Wrote {File} with {Count} pages", RootDirectory.GetUnixRelativePathTo(LlmsTxtFile), pages.Count);
         });
 }

--- a/build/Build.Documentation.cs
+++ b/build/Build.Documentation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Fallout.Common;
@@ -21,7 +22,7 @@ partial class Build
 
     // Docusaurus orders pages by a numeric prefix on the directory and file name, and strips that
     // prefix from the served URL. So 01-getting-started/01-installation.md is served at
-    // /getting-started/installation, which is the URL the README already links.
+    // /docs/getting-started/installation.
     static readonly Regex OrderPrefix = new(@"^(?<order>\d+)-", RegexOptions.Compiled);
 
     static string StripOrderPrefix(string segment) => OrderPrefix.Replace(segment, string.Empty);
@@ -43,24 +44,177 @@ partial class Build
         return DocsBaseUrl + slug;
     }
 
-    // "01-getting-started" becomes "Getting Started". The directory slug is the only section name
-    // available: the docs tree has no per-directory metadata file.
-    static string ToSectionTitle(string directorySlug)
+    // Each section directory carries a Docusaurus _category_.json whose "label" is what the site's
+    // sidebar shows, so that is the authoritative section name. It matters: title-casing the slug
+    // instead would give "Cicd" and "Ide" where the site says "CI/CD Support" and "IDE Support",
+    // and "Common" where it says "Common Tasks". The slug is only a fallback for a directory that
+    // has no _category_.json.
+    string ToSectionTitle(string directorySlug)
     {
+        var category = DocsWebsiteDirectory / directorySlug / "_category_.json";
+        if (category.FileExists())
+        {
+            var label = category.ReadJsonObject().GetPropertyValue<string>("label");
+            if (!label.IsNullOrWhiteSpace())
+                return label;
+        }
+
         return StripOrderPrefix(directorySlug)
             .Split('-')
             .Select(x => char.ToUpperInvariant(x[0]) + x[1..])
             .JoinSpace();
     }
 
+    sealed record DocPage(string Title, string Description, string Url, string Section, int SectionOrder, int Order);
+
+    const int MaxDescriptionLength = 200;
+
+    // Inline markdown links render as "[text](url)". Only the text belongs in a one-line summary.
+    static readonly Regex InlineLink = new(@"\[(?<text>[^\]]+)\]\([^)]+\)", RegexOptions.Compiled);
+
+    static readonly Regex FrontmatterEntry = new(@"^(?<key>[a-zA-Z]+):\s*(?<value>.*)$", RegexOptions.Compiled);
+
+    DocPage ReadPage(AbsolutePath file)
+    {
+        var lines = file.ReadAllLines();
+        var frontmatterEnd = GetFrontmatterEnd(lines);
+        var frontmatter = ReadFrontmatter(lines, frontmatterEnd);
+
+        // Docusaurus falls back to the first H1 when a page declares no 'title', and docs/website
+        // has a page that relies on it: badge.md carries no frontmatter at all and is served as
+        // "Badge". Rejecting it would refuse a page the site renders correctly, so the fallback
+        // matches Docusaurus. A page with neither still fails, because that leaves no link text.
+        var title = frontmatter.GetValueOrDefault("title") ?? GetFirstHeading(lines);
+        Assert.NotNullOrWhiteSpace(
+            title,
+            $"{DocsWebsiteDirectory.GetUnixRelativePathTo(file)} has neither a 'title' in its "
+            + "frontmatter nor a top-level heading. One of the two is needed: it is the link text "
+            + "in docs/llms.txt.");
+
+        var description = frontmatter.GetValueOrDefault("description")
+                          ?? GetFirstProseParagraph(lines, frontmatterEnd);
+
+        var relative = DocsWebsiteDirectory.GetUnixRelativePathTo(file).ToString();
+        var segments = relative.Split('/');
+        var isNested = segments.Length > 1;
+
+        return new DocPage(
+            Title: title,
+            Description: Summarize(description),
+            Url: ToPublicUrl(file),
+            // Root-level pages have no section. Task 3 collects them under "Optional", which is the
+            // part of the llmstxt.org format meant for lower-priority links.
+            Section: isNested ? ToSectionTitle(segments[0]) : null,
+            SectionOrder: isNested ? GetOrder(segments[0]) : int.MaxValue,
+            Order: GetOrder(segments[^1]));
+    }
+
+    static string GetFirstHeading(string[] lines)
+    {
+        return lines
+            .Select(x => x.Trim())
+            .FirstOrDefault(x => x.StartsWith("# "))
+            ?[2..].Trim();
+    }
+
+    static int GetFrontmatterEnd(string[] lines)
+    {
+        if (lines.Length == 0 || lines[0].Trim() != "---")
+            return 0;
+
+        var end = Array.FindIndex(lines, startIndex: 1, x => x.Trim() == "---");
+        return end < 0 ? 0 : end + 1;
+    }
+
+    static Dictionary<string, string> ReadFrontmatter(string[] lines, int frontmatterEnd)
+    {
+        var entries = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 1; i < Math.Max(frontmatterEnd - 1, 1); i++)
+        {
+            var match = FrontmatterEntry.Match(lines[i]);
+            if (!match.Success)
+                continue;
+
+            var value = match.Groups["value"].Value.Trim().TrimMatchingDoubleQuotes().Trim('\'');
+            if (!value.IsNullOrWhiteSpace())
+                entries[match.Groups["key"].Value] = value;
+        }
+
+        return entries;
+    }
+
+    // Only introduction.md declares a 'description', so for the other 36 pages the summary falls
+    // back to the page's own opening paragraph. Several open with a Docusaurus import or an MDX
+    // component instead, and those are not prose, so they are skipped along with headings,
+    // admonitions, tables, images and code fences.
+    //
+    // The whole paragraph is collected, not just its first line: docs/website hard-wraps prose, so
+    // stopping at the first newline would cut a sentence mid-way ("... help other" on badge.md).
+    static string GetFirstProseParagraph(string[] lines, int frontmatterEnd)
+    {
+        var paragraph = new List<string>();
+        var insideFence = false;
+
+        foreach (var line in lines.Skip(frontmatterEnd))
+        {
+            var trimmed = line.Trim();
+
+            if (trimmed.StartsWith("```"))
+            {
+                insideFence = !insideFence;
+                continue;
+            }
+
+            var isProse = !insideFence &&
+                          !trimmed.IsNullOrWhiteSpace() &&
+                          !trimmed.StartsWith("import ") &&
+                          !trimmed.StartsWith('<') &&
+                          !trimmed.StartsWith(":::") &&
+                          !trimmed.StartsWith('#') &&
+                          !trimmed.StartsWith('|') &&
+                          !trimmed.StartsWith('!');
+
+            if (isProse)
+                paragraph.Add(trimmed);
+            else if (paragraph.Count > 0)
+                break;
+        }
+
+        return paragraph.Count > 0 ? paragraph.JoinSpace() : null;
+    }
+
+    static string Summarize(string text)
+    {
+        if (text.IsNullOrWhiteSpace())
+            return null;
+
+        var flattened = InlineLink.Replace(text, "${text}").Trim();
+        if (flattened.Length <= MaxDescriptionLength)
+            return flattened;
+
+        // Cut on a word boundary so the summary never ends mid-word.
+        var cut = flattened.LastIndexOf(' ', MaxDescriptionLength);
+        return flattened[..(cut > 0 ? cut : MaxDescriptionLength)].TrimEnd(',', ';', ':', '.') + "...";
+    }
+
+    IReadOnlyList<DocPage> ReadDocPages()
+    {
+        return DocsWebsiteDirectory.GlobFiles("**/*.md")
+            .Select(ReadPage)
+            .OrderBy(x => x.SectionOrder)
+            .ThenBy(x => x.Order)
+            .ThenBy(x => x.Title)
+            .ToList();
+    }
+
     Target GenerateLlmsTxt => _ => _
         .Executes(() =>
         {
-            DocsWebsiteDirectory.GlobFiles("**/*.md")
-                .OrderBy(x => x.ToString())
-                .ForEach(x => Log.Information(
-                    "{Relative} -> {Url}",
-                    DocsWebsiteDirectory.GetUnixRelativePathTo(x),
-                    ToPublicUrl(x)));
+            ReadDocPages().ForEach(x => Log.Information(
+                "[{Section}] {Title} -> {Url} :: {Description}",
+                x.Section ?? "(root)",
+                x.Title,
+                x.Url,
+                x.Description ?? "(none)"));
         });
 }

--- a/build/Build.Documentation.cs
+++ b/build/Build.Documentation.cs
@@ -8,6 +8,7 @@ using Fallout.Common.IO;
 using Fallout.Common.Utilities;
 using Fallout.Common.Utilities.Collections;
 using Serilog;
+using static Fallout.Common.Tools.Git.GitTasks;
 
 partial class Build
 {
@@ -282,5 +283,25 @@ partial class Build
             LlmsTxtFile.WriteAllText(RenderLlmsTxt(pages));
 
             Log.Information("Wrote {File} with {Count} pages", RootDirectory.GetUnixRelativePathTo(LlmsTxtFile), pages.Count);
+        });
+
+    // CI gate, in the shape of VerifyGeneratedTools: GenerateLlmsTxt only runs when a contributor
+    // remembers to invoke it, so a page added under docs/website without regenerating would merge
+    // with docs/llms.txt silently missing it. `Requires` is asserted for the whole scheduled plan
+    // before any target runs, so the "start clean" check below still fires before GenerateLlmsTxt
+    // regenerates anything; the explicit re-check afterward catches drift with a message pointing
+    // at the fix.
+    //
+    // Wired into BOTH workflows on purpose. build.yml ignores docs/**, so on its own it would never
+    // fire on the change that actually invalidates the file; build-skip.yml is the workflow that
+    // handles those PRs, and it runs this target for exactly that reason.
+    Target VerifyLlmsTxt => _ => _
+        .Requires(() => GitHasCleanWorkingCopy())
+        .DependsOn(GenerateLlmsTxt)
+        .Executes(() =>
+        {
+            Assert.True(
+                GitHasCleanWorkingCopy(),
+                "docs/llms.txt is out of sync with docs/website. Run './build.ps1 GenerateLlmsTxt' locally and commit the result.");
         });
 }

--- a/build/Build.Documentation.cs
+++ b/build/Build.Documentation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -38,7 +39,7 @@ partial class Build
     string ToPublicUrl(AbsolutePath page)
     {
         var relative = DocsWebsiteDirectory.GetUnixRelativePathTo(page).ToString();
-        var slug = relative[..^".md".Length]
+        var slug = relative[..^Path.GetExtension(relative).Length]
             .Split('/')
             .Select(StripOrderPrefix)
             .JoinSlash();
@@ -56,13 +57,17 @@ partial class Build
         var category = DocsWebsiteDirectory / directorySlug / "_category_.json";
         if (category.FileExists())
         {
-            var label = category.ReadJsonObject().GetPropertyValue<string>("label");
+            // OrNull, not GetPropertyValue: that one throws when the property is absent, which
+            // would make the fallback below unreachable. A _category_.json may legitimately carry
+            // only "position" or "collapsed".
+            var label = category.ReadJsonObject().GetPropertyValueOrNull<string>("label");
             if (!label.IsNullOrWhiteSpace())
                 return label;
         }
 
         return StripOrderPrefix(directorySlug)
             .Split('-')
+            .Where(x => x.Length > 0)
             .Select(x => char.ToUpperInvariant(x[0]) + x[1..])
             .JoinSpace();
     }
@@ -99,7 +104,7 @@ partial class Build
         // has a page that relies on it: badge.md carries no frontmatter at all and is served as
         // "Badge". Rejecting it would refuse a page the site renders correctly, so the fallback
         // matches Docusaurus. A page with neither still fails, because that leaves no link text.
-        var title = frontmatter.GetValueOrDefault("title") ?? GetFirstHeading(lines);
+        var title = frontmatter.GetValueOrDefault("title") ?? GetFirstHeading(lines, frontmatterEnd);
         Assert.NotNullOrWhiteSpace(
             title,
             $"{DocsWebsiteDirectory.GetUnixRelativePathTo(file)} has neither a 'title' in its "
@@ -121,16 +126,30 @@ partial class Build
             // under "Optional", depending on IsPrimary.
             Section: isNested ? ToSectionTitle(segments[0]) : null,
             SectionOrder: isNested ? GetOrder(segments[0]) : int.MaxValue,
-            Order: GetOrder(segments[^1]),
+            // Docusaurus lets a page's own 'sidebar_position' override the numeric filename prefix,
+            // and docs/website uses it: 07-ide has no prefixes, and rider.md declares position 1 to
+            // sort first. Reading only the prefix would order that section by title instead.
+            Order: frontmatter.TryGetValue("sidebar_position", out var position) && int.TryParse(position, out var parsed)
+                ? parsed
+                : GetOrder(segments[^1]),
             IsPrimary: isNested || frontmatter.ContainsKey("sidebar_position"));
     }
 
-    static string GetFirstHeading(string[] lines)
+    // Starts after the frontmatter and ignores fenced code, because "# terminal-command" is used as
+    // a marker throughout this doc set and would otherwise become a page's link text.
+    static string GetFirstHeading(string[] lines, int frontmatterEnd)
     {
-        return lines
-            .Select(x => x.Trim())
-            .FirstOrDefault(x => x.StartsWith("# "))
-            ?[2..].Trim();
+        var insideFence = false;
+        foreach (var line in lines.Skip(frontmatterEnd))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith("```"))
+                insideFence = !insideFence;
+            else if (!insideFence && trimmed.StartsWith("# "))
+                return trimmed[2..].Trim();
+        }
+
+        return null;
     }
 
     static int GetFrontmatterEnd(string[] lines)
@@ -139,7 +158,11 @@ partial class Build
             return 0;
 
         var end = Array.FindIndex(lines, startIndex: 1, x => x.Trim() == "---");
-        return end < 0 ? 0 : end + 1;
+        // An opened but unclosed block is malformed. Returning 0 would hand the delimiter and the
+        // key/value lines to the prose reader and ship them as a description, so fail instead: a
+        // wrong entry in a generated index is worse than a build that says what is wrong.
+        Assert.True(end >= 0, "Frontmatter is opened with '---' but never closed.");
+        return end + 1;
     }
 
     static Dictionary<string, string> ReadFrontmatter(string[] lines, int frontmatterEnd)
@@ -152,6 +175,13 @@ partial class Build
                 continue;
 
             var value = match.Groups["value"].Value.Trim().TrimMatchingDoubleQuotes().Trim('\'');
+
+            // ">" and "|" open a YAML block scalar whose text sits on the following lines. This
+            // parser is line-based, so it would store the indicator itself and render
+            // "- [Title](url): >". Treat the key as absent and let the prose fallback handle it.
+            if (value is ">" or "|" or ">-" or "|-")
+                continue;
+
             if (!value.IsNullOrWhiteSpace())
                 entries[match.Groups["key"].Value] = value;
         }
@@ -213,13 +243,22 @@ partial class Build
         return flattened[..(cut > 0 ? cut : MaxDescriptionLength)].TrimEnd(',', ';', ':', '.') + "...";
     }
 
+    // Docusaurus routes both .md and .mdx, and excludes anything whose file or directory name
+    // starts with an underscore (**/_*.md, **/_*/**). docs/website/_snippets/ exists for exactly
+    // that reason, so indexing it would emit URLs the site never serves.
     IReadOnlyList<DocPage> ReadDocPages()
     {
-        return DocsWebsiteDirectory.GlobFiles("**/*.md")
+        return DocsWebsiteDirectory.GlobFiles("**/*.md", "**/*.mdx")
+            .Where(x => !DocsWebsiteDirectory.GetUnixRelativePathTo(x).ToString()
+                .Split('/')
+                .Any(segment => segment.StartsWith('_')))
             .Select(ReadPage)
             .OrderBy(x => x.SectionOrder)
             .ThenBy(x => x.Order)
-            .ThenBy(x => x.Title)
+            // Ordinal, not the culture-sensitive default: docs/llms.txt is verified byte for byte,
+            // so a contributor on another culture must not regenerate a differently ordered file
+            // and trip VerifyLlmsTxt with no real drift.
+            .ThenBy(x => x.Title, StringComparer.Ordinal)
             .ToList();
     }
 
@@ -237,7 +276,14 @@ partial class Build
         // Single source for the summary: introduction.md's own 'description', which is what the
         // site serves as its meta description. Generating it from anywhere else would let the two
         // drift apart.
-        var summary = pages.Single(x => x.Url == DocsBaseUrl + "introduction").Description;
+        var introduction = pages.SingleOrDefault(x => x.Url == DocsBaseUrl + "introduction");
+        Assert.NotNull(
+            introduction,
+            "No page resolves to " + DocsBaseUrl + "introduction, which is where the llms.txt summary "
+            + "comes from. If introduction.md was renamed, moved into a section or given a 'slug', "
+            + "point this lookup at its new location.");
+
+        var summary = introduction.Description;
         builder.AppendLine($"> {summary}");
         builder.AppendLine();
         builder.AppendLine(

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,67 @@
+# Fallout
+
+> Fallout is a C#-first build automation framework for .NET — the hard-fork successor to NUKE. Write your CI/CD pipelines in plain C#, debug them locally, and share build steps across repositories.
+
+Generated from the documentation sources by './build.ps1 GenerateLlmsTxt'. Do not edit by hand.
+
+- [Introduction](https://docs.fallout.build/docs/introduction): Fallout is a C#-first build automation framework for .NET — the hard-fork successor to NUKE. Write your CI/CD pipelines in plain C#, debug them locally, and share build steps across repositories.
+
+## Getting Started
+
+- [Installation](https://docs.fallout.build/docs/getting-started/installation): Before you can set up a build project, you need to install Fallout's dedicated .NET global tool:
+- [Build Setup](https://docs.fallout.build/docs/getting-started/setup): After installing the Fallout global tool, you can call it from anywhere on your machine to set up a new build:
+- [Build Execution](https://docs.fallout.build/docs/getting-started/execution): After you've set up a build you can run it either through the global tool or one of the installed bootstrapping scripts:
+
+## Fundamentals
+
+- [Build Anatomy](https://docs.fallout.build/docs/fundamentals/builds): A build project is a regular .NET console application. However, unlike regular console applications, Fallout chooses to name the main class `Build` instead of `Program`. This establishes a convention...
+- [Target Definitions](https://docs.fallout.build/docs/fundamentals/targets): Inside a `Build` class, you can define your build steps as `Target` properties. The implementation for a build step is provided as a lambda function through the `Executes` method:
+- [Parameters](https://docs.fallout.build/docs/fundamentals/parameters): Another important aspect of build automation is the ability of passing input values to your build. These input values can be anything from generic texts, numeric and enum values, file and directory...
+- [Logging](https://docs.fallout.build/docs/fundamentals/logging): As with any other application, good logging greatly reduces the time to detect the source of errors and fix them quickly. Fallout integrates with Serilog and prepares a console and file logger for...
+- [Assertions](https://docs.fallout.build/docs/fundamentals/assertions): As in any other codebase, it is good practice to assert assumptions before continuing with more heavy procedures in your build automation. When an assertion is violated, it usually entails that the...
+
+## Common Tasks
+
+- [Constructing Paths](https://docs.fallout.build/docs/common/paths): Referencing files and directories seems like a trivial task. Nevertheless, developers often run into problems where relative paths no longer match the current working directory, or find themselves...
+- [Repository Insights](https://docs.fallout.build/docs/common/repository): Having knowledge about the current branch, applied tags, and the repository origin is eminently important in various scenarios. For instance, the deployment destination for an application is different...
+- [Data Serialization](https://docs.fallout.build/docs/common/serialization): Structured data plays an essential role in build automation. You may want to read a list of repositories to be checked out, write data that's consumed by another tool, or update version numbers of...
+- [Versioning Artifacts](https://docs.fallout.build/docs/common/versioning): Whenever a build produces artifacts, those should be identifiable with a unique version number. This avoids making wrong expectations about available features or fixed bugs, and allows for clear...
+- [Solution & Project Model](https://docs.fallout.build/docs/common/solution-project-model): Particularly when building .NET applications, your build may require information related to solution or project files. Such information is often duplicated with string literals and quickly becomes...
+- [Executing CLI Tools](https://docs.fallout.build/docs/common/cli-tools): Interacting with third-party command-line interface tools (CLIs) is an essential task in build automation. This includes a wide range of aspects, such as resolution of the tool path, construction of...
+- [Archive Compression](https://docs.fallout.build/docs/common/compression): In many situations you have to deal with compressed archives. Good examples are when you want to provide additional assets for your GitHub releases, or when you depend on other project's release...
+- [Chats & Social Media](https://docs.fallout.build/docs/common/chats): As a final step of your build automation process, you may want to report errors or announce a new version through different chats and social media channels. Fallout comes with basic support for the...
+
+## Build Sharing
+
+- [Global Builds](https://docs.fallout.build/docs/sharing/global-builds): Instead of adding and maintaining build projects in all your repositories, you can also build them by convention using a global build. Global builds are based on the concept of .NET global tools and...
+- [Build Components](https://docs.fallout.build/docs/sharing/build-components): With build components you can implement your build infrastructure once, and compose individual builds across different repositories. Central to the idea of build components are interface default...
+
+## CI/CD Support
+
+- [AppVeyor](https://docs.fallout.build/docs/cicd/appveyor): Running on AppVeyor will automatically enable custom theming for your build log output:
+- [Azure Pipelines](https://docs.fallout.build/docs/cicd/azure-pipelines): Running on Azure Pipelines will automatically enable custom theming for your build log output including collapsible sections for better structuring:
+- [Bitbucket](https://docs.fallout.build/docs/cicd/bitbucket): Running on Bitbucket will use the standard theming for your build log output.
+- [GitHub Actions](https://docs.fallout.build/docs/cicd/github-actions): Running on GitHub Actions will automatically enable custom theming for your build log output including collapsible groups for better structuring:
+- [GitLab](https://docs.fallout.build/docs/cicd/gitlab): Running on GitLab will automatically enable custom theming for your build log output including collapsible sections for better structuring:
+- [Jenkins](https://docs.fallout.build/docs/cicd/jenkins): Running on Jenkins will use the standard theming for your build log output.
+- [Space Automation](https://docs.fallout.build/docs/cicd/space-automation): Running on JetBrains Space will use the standard theming for your build log output:
+- [TeamCity](https://docs.fallout.build/docs/cicd/teamcity): Running on TeamCity will automatically enable custom theming for your build log output including collapsible blocks for better structuring:
+
+## Global Tool
+
+- [Shell Completion](https://docs.fallout.build/docs/global-tool/shell-completion): Typing long target names or parameters can be tedious and error-prone. The global tool helps you to invoke commands more quickly and without any typos, similar to tab completion for the .NET CLI.
+- [Adding NuGet Packages](https://docs.fallout.build/docs/global-tool/packages): In many cases, build automation relies on third-party tools. Fallout provides you with a great API for working with CLI tools, however, it is the responsibility of a build project to reference these...
+- [Managing Secrets](https://docs.fallout.build/docs/global-tool/secrets): Historically, secret values like passwords or auth-tokens are often saved as environment variables on local machines or CI/CD servers. This imposes both, security issues because other processes can...
+- [Navigation](https://docs.fallout.build/docs/global-tool/navigation): Over time, you might accumulate more and more projects that are built using Fallout. Some of these might even form a hierarchical structure, where one root directory contains several other root...
+- [Converting from Cake](https://docs.fallout.build/docs/global-tool/cake): Over the years, the .NET community has come up with a lot of great build automation tools, including FAKE, Cake, FlubuCore, and BullsEye. When coming from Cake Scripting, the time for converting build...
+
+## IDE Support
+
+- [JetBrains Rider](https://docs.fallout.build/docs/ide/rider): In JetBrains Rider you can install the _NUKE Support plugin_ to be more productive in writing, running, and debugging your builds.
+- [ReSharper](https://docs.fallout.build/docs/ide/resharper): In ReSharper you can install the _NUKE Support extension_ to be more productive in writing, running, and debugging your builds.
+- [Visual Studio](https://docs.fallout.build/docs/ide/visual-studio): In Visual Studio you can install the _NUKE Support extension_ to be more productive in writing, running, and debugging your builds.
+- [Visual Studio Code](https://docs.fallout.build/docs/ide/vscode): In Visual Studio Code you can install the _NUKE Support extension_ to be more productive in writing, running, and debugging your builds.
+
+## Optional
+
+- [Badge](https://docs.fallout.build/docs/badge): If you build with Fallout, link back with the badge. It is the quickest way to help other people find the project.


### PR DESCRIPTION
Implements #660.

Closes #660.

Generates `docs/llms.txt`, an [llmstxt.org](https://llmstxt.org/) index of the 37 pages under `docs/website/`, and fails the build when it goes stale.

`llms.txt` lets an LLM answer questions about Fallout from one fetch instead of crawling the site or falling back on stale NUKE knowledge. That fallback is the part that matters after the rebrand: a model trained before it will say `Nuke.*` and `nuke :setup`.

### What is here

| File | Change |
|---|---|
| `build/Build.Documentation.cs` *(new)* | `GenerateLlmsTxt` and `VerifyLlmsTxt` |
| `docs/llms.txt` *(new, generated)* | the index itself, committed |
| `build/Build.CI.GitHubActions.cs` | `VerifyLlmsTxt` added to the `build` workflow's targets |
| `.github/workflows/build.yml` | regenerated from the attribute above |
| `.github/workflows/build-skip.yml` | runs `VerifyLlmsTxt` instead of echoing |
| `.fallout/build.schema.json` | regenerated for the two new targets |

Not hand-maintained, by design. It follows the `GenerateTools` / `VerifyGeneratedTools` pattern already in this repo: generate, commit, and fail CI when a source edit lands without regenerating.

### Decisions worth reviewing

**The gate is wired into both workflows, and that is the point.** `build.yml` has `paths-ignore: docs/**`, so a PR editing a page under `docs/website/` never runs it. That is exactly the change that invalidates `llms.txt`. Wiring the gate only there would have produced a check that can never fire on the thing it guards. `build-skip.yml` is the workflow that handles those PRs, so it now runs `VerifyLlmsTxt` rather than an `echo`. It keeps the `ubuntu-latest` job name that branch protection keys on, and it builds the build project and regenerates one file rather than running test and pack.

**Metadata comes from what the site already declares, not from new fields.** Section names are read from each directory's Docusaurus `_category_.json` `label`, so they read "CI/CD Support" and "Common Tasks" exactly as the sidebar does. Title-casing the slug instead would have produced "Cicd" and "Ide". Titles fall back to the first H1 when a page declares no `title`, which is what Docusaurus does and what `badge.md` relies on. Descriptions fall back to the page's opening paragraph, since only `introduction.md` declares one.

**The base URL is `https://docs.fallout.build/docs/`,** verified against the live `sitemap.xml`. All 37 derived URLs match the 37 live pages exactly, set against set. The `/docs/` prefix is easy to miss: see the follow-up below.

### Test plan

- [x] All 37 derived URLs compared against `https://docs.fallout.build/sitemap.xml`. Identical in both directions, so no derived URL 404s and no live page is missing.
- [x] `./build.ps1 GenerateLlmsTxt` twice in a row leaves `git status` clean. The generator is deterministic, which is what keeps the gate from flapping.
- [x] `./build.ps1 VerifyLlmsTxt` on a clean tree exits 0.
- [x] Negative test: edited a page's `title:`, committed without regenerating, and the gate failed with `docs/llms.txt is out of sync with docs/website. Run './build.ps1 GenerateLlmsTxt' locally and commit the result.` Reverted afterwards.
- [x] Negative test: removed a page's `title:` and the target failed naming the offending file.
- [x] `./build.ps1 VerifyGeneratedTools VerifyLlmsTxt Test`, the same target set CI runs: 814 passed, 7 skipped, 0 failed, and the working tree stayed clean, so both verify gates passed.
- [x] `./build.ps1 Compile` exits 0. 8 warnings, all pre-existing `NU190x` advisories, none in the new file.
- [x] Generated file checked by hand: one H1, one blockquote, 8 `##` sections, 37 link lines.

### Review round

A high-effort review raised 12 findings. Ten are fixed in `7383c59e`; none changes the generated file today, and each closes a way it could go wrong on a page the docs do not have yet. The two that mattered most:

- `_category_.json` without a `label` **crashed** the target. `GetPropertyValue` throws when the property is absent, so the guard and the slug fallback under it were dead code.
- Underscore-prefixed files were indexed. Docusaurus excludes them from routing and `docs/website/_snippets/` already exists, so a `.md` dropped there would have emitted a URL the site never serves.

Also fixed: `.mdx` pages are indexed, `sidebar_position` orders pages inside a section as it does on the site, titles are read outside code fences, unclosed frontmatter fails instead of shipping garbage, and titles sort with `StringComparer.Ordinal` so a different culture cannot fail the byte-for-byte gate with no real drift.

Verified empirically rather than by reading: added `_snippets/partial.md`, a `.mdx` page with `sidebar_position: 1`, and a label-less `_category_.json`, regenerated, and confirmed the snippet was skipped, the MDX page indexed and sorted first, and the label-less category fell back to its slug instead of throwing. Reverted afterwards; `docs/llms.txt` is byte-identical.

**One finding dismissed.** The review flagged that `docs/llms.txt` sits outside `docs/website/` and might never be published. That path is the deliberate cross-repo contract, not an oversight: it is an artifact *of* the website sources rather than a page *in* them, and [Fallout-build/docs.fallout.build#14](https://github.com/Fallout-build/docs.fallout.build/issues/14) names the exact path to copy. Worth confirming with whoever owns the site build.

### Serving half is a separate repo

`docs.fallout.build` is built from [`Fallout-build/docs.fallout.build`](https://github.com/Fallout-build/docs.fallout.build). This PR generates the file; that repo has to copy it to `static/llms.txt`. Filed as [Fallout-build/docs.fallout.build#14](https://github.com/Fallout-build/docs.fallout.build/issues/14).

**Neither half is user-visible alone.** `https://docs.fallout.build/llms.txt` stays 404 until both land. That is expected, not an oversight.

### Plan

- [x] Task 1: Walk the docs and derive URLs
- [x] Task 2: Parse frontmatter into title and description
- [x] Task 3: Render and write docs/llms.txt
- [x] Task 4: Gate the generated file in CI
- [x] Task 5: Hand off the serving half

## Follow-ups

Not fixed here, to keep this PR to its issue.

- **`README.md:59` links to `https://docs.fallout.build/getting-started/installation`, which 404s.** It is missing the `/docs/` prefix. Found while verifying the URL derivation: the issue cited this link as proof of the mapping, and it turned out to be the stale one. It is the only such link in the repo.
- **`llms-full.txt`** (the corpus inlined rather than linked). Cheap now that the walk exists, but a different file with a different size budget.
- **`build-skip.yml` now has a real build step**, which makes it the natural home for other docs-only validation, such as link checking. Nothing is broken; it is just no longer true that docs PRs run nothing.
